### PR TITLE
fix: members checks for enchanted jewelry

### DIFF
--- a/scripts/drop tables/scripts/shared_droptables.rs2
+++ b/scripts/drop tables/scripts/shared_droptables.rs2
@@ -37,7 +37,7 @@ if ($random < 32) {
 [proc,randomjewel]()(namedobj, int)
 def_int $random = 0;
 
-if (inv_total(worn, ring_of_wealth) > 0) {
+if (inv_total(worn, ring_of_wealth) > 0 & map_members = ^true) {
     $random = random(65);
 } else {
     $random = random(128);

--- a/scripts/general/scripts/enchanted_jewellry/ring_of_life.rs2
+++ b/scripts/general/scripts/enchanted_jewellry/ring_of_life.rs2
@@ -1,6 +1,6 @@
 [proc,ring_of_life_check]
 if (p_finduid(uid) = true) {
-    if (inv_getobj(worn, ^wearpos_ring) ! ring_of_life | ~wilderness_level(coord) > 30 | ~pre_tele_checks(coord) = false) {
+    if (inv_getobj(worn, ^wearpos_ring) ! ring_of_life | map_members = ^false | ~wilderness_level(coord) > 30 | ~pre_tele_checks(coord) = false) {
         return;
     }
     if (stat(hitpoints) <= scale(10, 100, stat_base(hitpoints))) {

--- a/scripts/player/scripts/damage.rs2
+++ b/scripts/player/scripts/damage.rs2
@@ -16,7 +16,7 @@ if ($amount > 0) {
 
 if (stat(hitpoints) = 0){
     ~player_die;
-    // no early return, ring of life still processes on death. https://youtu.be/LSpyUVXa4LE?t=202
+    return;
 }
 
 ~ring_of_life_check;

--- a/scripts/skill_agility/scripts/agility.rs2
+++ b/scripts/skill_agility/scripts/agility.rs2
@@ -115,7 +115,7 @@ mes($message);
 p_delay(0);
 if (stat(hitpoints) = 0){
     ~player_die;
-    // no early return, ring of life still processes on death. https://youtu.be/LSpyUVXa4LE?t=202
+    return;
 }
 ~ring_of_life_check;
 

--- a/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -295,7 +295,7 @@ error("style of <tostring($style)> not defined in switch for npc_combat_defenceb
 
 //  this should be strong queued. Some damage is queued, some isnt
 [queue,combat_damage_player](int $damage)
-if (inv_getobj(worn, ^wearpos_ring) = ring_of_recoil & npc_finduid(%aggressive_npc) = true & %npc_attacking_uid = uid & $damage > 0 & stat(hitpoints) > 0) {
+if (inv_getobj(worn, ^wearpos_ring) = ring_of_recoil & map_members = ^true & npc_finduid(%aggressive_npc) = true & %npc_attacking_uid = uid & $damage > 0 & stat(hitpoints) > 0) {
     // https://oldschool.runescape.wiki/w/Update:Clue_Scroll_Step_Counter
     // - "Recoil damage will now always target the entity that caused the initial damage, rather than the most recent entity to deal damage."
     def_int $recoil_damage = add(scale(10, 100, $damage), 1);

--- a/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
@@ -166,7 +166,7 @@ if ($damage < 0) {
 
 // needs to be a queue
 [queue,pvp_damage](int $damage)
-if (inv_getobj(worn, ^wearpos_ring) = ring_of_recoil & .finduid(%pk_predator1) = true & $damage > 0 & stat(hitpoints) > 0) {
+if (inv_getobj(worn, ^wearpos_ring) = ring_of_recoil & map_members = ^true & .finduid(%pk_predator1) = true & $damage > 0 & stat(hitpoints) > 0) {
     // https://oldschool.runescape.wiki/w/Update:Clue_Scroll_Step_Counter
     // - "Recoil damage will now always target the entity that caused the initial damage, rather than the most recent entity to deal damage."
     // Having it here instead of the opplayer2 trigger will allow this bug to occur

--- a/scripts/skill_mining/scripts/mining.rs2
+++ b/scripts/skill_mining/scripts/mining.rs2
@@ -111,7 +111,7 @@ if ($data = null) {
 // roll for gem
 def_int $chance = 256;
 def_obj $neck = inv_getobj(worn, ^wearpos_front);
-if ($neck ! null & oc_category($neck) = category_557) {
+if ($neck ! null & oc_category($neck) = category_557 & map_members = ^true) {
     $chance = 86;
 }
 if (random($chance) = ^true) {
@@ -156,8 +156,8 @@ if ($data = null) {
 // roll for gem
 def_int $chance = 256;
 def_obj $neck = inv_getobj(worn, ^wearpos_front);
-if ($neck ! null & oc_category($neck) = category_557) {
-    $chance = 64;
+if ($neck ! null & oc_category($neck) = category_557 & map_members = ^true) {
+    $chance = 86;
 }
 if (random($chance) = ^true) {
     def_namedobj $gem = ~mining_gem_table;
@@ -206,7 +206,7 @@ def_int $low;
 def_int $high;
 $low, $high = db_getfield($data, mining_table:rock_successchance, 0);
 def_obj $neck = inv_getobj(worn, ^wearpos_front);
-if ($neck ! null & oc_category($neck) = category_557) {
+if ($neck ! null & oc_category($neck) = category_557 & map_members = ^true) {
     $low = multiply($low, 3);
     $high = multiply($high, 3);
 }

--- a/scripts/skill_smithing/scripts/smelting/smelting.rs2
+++ b/scripts/skill_smithing/scripts/smelting/smelting.rs2
@@ -68,7 +68,7 @@ if (struct_param($struct, ingredient_secondary) ! null) {
 
 if ($bar = iron_bar) {
     // if player is wearing ring of forging
-    if (inv_total(worn, ring_of_forging) > 0) {
+    if (inv_total(worn, ring_of_forging) > 0 & map_members = ^true) {
         ~lose_charge_ring_of_forging;
     } else if (randominc(1) = 1) { // else assume 50% chance of success
         mes("The ore is too impure and you fail to refine it.");


### PR DESCRIPTION
Forgot a bunch of members checks when I originally implemented.

Also, videos such as: https://youtu.be/LSpyUVXa4LE?t=202, https://youtu.be/9Rs1sgmS2oA?t=75 were used as evidence to show that ring of life would run when damaged to 0 hp. This is incorrect, as the second video shows this happening on a f2p world, and the first video's victim death drops varrock tele runes!

Whats actually happening in these videos is that the p_delay, xp & tele anim still runs but theres a check in `~p_telejump_safe()` that returns early if you're at 0 hp. Funny we actually have this lil quirk implemented already!


https://github.com/user-attachments/assets/7e250854-2610-44c2-8390-c56818e7da1b

