### PR TITLE
fix: remove mage arena 2 dialogue from kolodion

### DIFF
--- a/scripts/areas/area_mage_arena/scripts/kolodion.rs2
+++ b/scripts/areas/area_mage_arena/scripts/kolodion.rs2
@@ -26,7 +26,7 @@ if (~mage_arena_in_progress = true) {
 ~chatplayer("<p,neutral>Hello, Kolodion.");
 ~chatnpc("<p,shifty>Hey there, how are you? Are you enjoying the|bloodshed?");
 ~chatplayer("<p,neutral>It's not bad; I've seen worse.");
-def_int $choice = ~p_choice3("I think I've had enough for now.", 1, "How can I use my new spells outside of the arena?", 2, "Are there any more challenges available?", 3);
+def_int $choice = ~p_choice3("I think I've had enough for now.", 1, "How can I use my new spells outside of the arena?", 2);
 if ($choice = 1) {
     ~chatplayer("<p,bored>I think I've had enough for now.");
     ~chatnpc("<p,neutral>A shame. You're a good battle mage. I hope to see you|soon.");
@@ -53,12 +53,6 @@ if ($choice = 1) {
     } else {
         ~chatnpc("<p,happy>You're experienced enough to use the flame spell|anywhere.");
     }
-    return;
-} else if ($choice = 3) {
-    ~chatplayer("<p,quiz>Are there any more challenges available?");
-    // check if the player has learned the god spells
-    ~chatnpc("<p,sad>You still need to learn how to cast all god spells outside|of the arena.");
-    ~chatnpc("<p,neutral>I've made a note of the spells you still need to learn in|your journal.");
     return;
 }
 

--- a/scripts/areas/area_mage_arena/scripts/kolodion.rs2
+++ b/scripts/areas/area_mage_arena/scripts/kolodion.rs2
@@ -26,7 +26,7 @@ if (~mage_arena_in_progress = true) {
 ~chatplayer("<p,neutral>Hello, Kolodion.");
 ~chatnpc("<p,shifty>Hey there, how are you? Are you enjoying the|bloodshed?");
 ~chatplayer("<p,neutral>It's not bad; I've seen worse.");
-def_int $choice = ~p_choice3("I think I've had enough for now.", 1, "How can I use my new spells outside of the arena?", 2);
+def_int $choice = ~p_choice2("I think I've had enough for now.", 1, "How can I use my new spells outside of the arena?", 2);
 if ($choice = 1) {
     ~chatplayer("<p,bored>I think I've had enough for now.");
     ~chatnpc("<p,neutral>A shame. You're a good battle mage. I hope to see you|soon.");


### PR DESCRIPTION
This is the starting dialogue to mage arena 2!! released in 2017