### PR TITLE
fix: kebabs, poison chalice, and ugthanki kebabs

### DIFF
--- a/scripts/player/scripts/consumption/consume.rs2
+++ b/scripts/player/scripts/consumption/consume.rs2
@@ -13,7 +13,7 @@ mes("You cant eat it whole; maybe you should cut it up.");
 
 // Kebabs
 [opheld1,kebab] @player_consume_item(consume_effect_kebab, 2, 3);
-[opheld1,ugthanki_kebab_bad] @player_consume_item(consume_effect_stat, 2, 3);
+[opheld1,ugthanki_kebab_bad] @player_consume_item(consume_effect_ugthanki_kebab_bad, 2, 3);
 [opheld1,ugthanki_kebab] @player_consume_item(consume_effect_stat_say, 2, 3);
 
 // stews

--- a/scripts/player/scripts/consumption/effects/scripts/kebab.rs2
+++ b/scripts/player/scripts/consumption/effects/scripts/kebab.rs2
@@ -3,81 +3,38 @@ mes("You eat the kebab.");
 sound_synth(eat, 0, 0);
 anim(human_eat, 0);
 inv_delslot(inv, last_slot);
-def_int $hitpoints = stat(hitpoints);
 // wiki data from 17229 kebabs
-def_int $random = random(128);
-if ($random < 80) { // 80/128 chance
-    // heal 7% + 3
-    stat_heal(hitpoints, 3, 7);
-    if ($hitpoints < stat(hitpoints)) {
-        mes("It heals some health.");
-    }
-    return;
-}
-if ($random < 112) { // 32/128 chance
-    mes("That was a good kebab. You feel a lot better.");
-    // heal 14% + 6
-    stat_heal(hitpoints, 6, 14);
-    return;
-}
-if ($random < 116) { // 4/128 chance
-    // increases melee stats by 2, regardless of level
+// todo: figure out the order these go in. This is important because theres hp checks in some of these
+def_int $random = random(32);
+if ($random < 1) { // 1/32
     mes("Wow, that was an amazing kebab! You feel really invigorated.");
     stat_boost(attack, 2, 0);
     stat_boost(strength, 2, 0);
     stat_boost(defence, 2, 0);
-    // heal 24% + 7
     stat_heal(hitpoints, 7, 24);
-    return;
-}
-if ($random < 120) { // 4/128 chance
+} else if ($random < 9) { // 8/32
+    mes("That was a good kebab. You feel a lot better.");
+    stat_heal(hitpoints, 6, 14);
+} else if ($random < 29) { // 20/32
+    if (stat(hitpoints) < stat_base(hitpoints)) {
+        mes("It heals some health.");
+        stat_heal(hitpoints, 3, 7);
+    }
+} else if ($random < 30) { // 1/32
     mes("That tasted very dodgy. You feel very ill.");
-    // reduces melees by 3, and reduces a random stat 4
-    stat_sub(attack, 3, 0);
-    stat_sub(strength, 3, 0);
-    stat_sub(defence, 3, 0);
-    def_stat $random_stat = ~random_stat;
-    // has a weird check for stats close to 1. Minimum it can reduce to is 2
-    // it always reduces by 4 unless stats are low, if stat is low it reduces it to level 2
-    // never reduces to level 1 or lower. Doesnt show 2nd message if stat is 1 or 2
-    def_int $debuff = 4;
-    if (stat($random_stat) < 5) {
-        $debuff = calc(stat($random_stat) - 2);
+    stat_drain(attack, 3, 0);
+    stat_drain(strength, 3, 0);
+    stat_drain(defence, 3, 0);
+    if (stat(hitpoints) > 2) {
+        ~damage_self(min(sub(stat(hitpoints), 2), 4));
     }
-    if (stat($random_stat) > 2){
-        if ($random_stat = hitpoints) {
-            ~damage_self($debuff);
-        } else {
-            stat_sub($random_stat, $debuff, 0);
-        }
-        mes("Eating the kebab has done damage to some of your stats.");
-    }
-    return;
+} else if ($random < 31 & stat(hitpoints) > 4) { // 1/32
+    // in osrs you cant get this if the stat it picks is below 5
+    mes("That tasted a bit dodgy. You feel a bit ill.");
+    ~damage_self(3);
+} else { // 1/32
+    mes("The kebab didn't seem to do a lot.");
 }
-if ($random < 124) { // 4/128 chance
-    mes("That kebab didn't seem to do a lot.");
-    return;
-}
-
-mes("That tasted a bit dodgy. You feel a bit ill.");
-// reduces random stat by 3
-def_stat $random_stat = ~random_stat;
-def_int $debuff;
-if (stat($random_stat) > 4) {
-    $debuff = 3;
-    mes("Eating the kebab has damaged your <enum(stat, string, stat_names, $random_stat)> stat.");
-} else if (stat($random_stat) > 2){
-    $debuff = calc(stat($random_stat) - 2);
-    mes("Eating the kebab has damaged your <enum(stat, string, stat_names, $random_stat)> stat.");
-}
-// not sure if this can damage the player.
-// they removed the damage feature in like 2006/2007
-if ($random_stat = hitpoints) {
-    ~damage_self($debuff);
-} else {
-    stat_sub($random_stat, $debuff, 0);
-}
-
 
 [debugproc,godbab]
 mes("Wow, that was an amazing kebab! You feel really invigorated.");

--- a/scripts/player/scripts/consumption/effects/scripts/poison_chalice.rs2
+++ b/scripts/player/scripts/consumption/effects/scripts/poison_chalice.rs2
@@ -6,7 +6,7 @@ mes("You drink the strange green liquid.");
 def_int $hitpoints = stat(hitpoints);
 def_int $random = random(128);
 if ($random < 40 & $hitpoints < stat_base(hitpoints)) { // 40/128 chance, doesnt activate if health is full
-    mes("It heals some health");
+    mes("It heals some health.");
     stat_heal(hitpoints, 6, 0);
 } else if ($random < 72) { // 32/128 chance
     mes("You feel a little strange.");

--- a/scripts/player/scripts/consumption/effects/scripts/poison_chalice.rs2
+++ b/scripts/player/scripts/consumption/effects/scripts/poison_chalice.rs2
@@ -5,7 +5,7 @@ inv_setslot(inv, last_slot, cocktail_glass_empty, 1);
 mes("You drink the strange green liquid.");
 def_int $hitpoints = stat(hitpoints);
 def_int $random = random(128);
-if ($random < 40 & $hitpoints >= stat_base(hitpoints)) { // 40/128 chance, doesnt activate if health is full
+if ($random < 40 & $hitpoints < stat_base(hitpoints)) { // 40/128 chance, doesnt activate if health is full
     mes("It heals some health");
     stat_heal(hitpoints, 6, 0);
 } else if ($random < 72) { // 32/128 chance

--- a/scripts/player/scripts/consumption/effects/scripts/poison_chalice.rs2
+++ b/scripts/player/scripts/consumption/effects/scripts/poison_chalice.rs2
@@ -11,37 +11,50 @@ if ($random < 40 & $hitpoints < stat_base(hitpoints)) { // 40/128 chance, doesnt
 } else if ($random < 72) { // 32/128 chance
     mes("You feel a little strange.");
     // Attack, Strength, Defence go down by 1, Crafting goes up by 1
-    stat_sub(attack, 1, 0);
-    stat_sub(strength, 1, 0);
-    stat_sub(defence, 1, 0);
+    stat_drain(attack, 1, 0);
+    stat_drain(strength, 1, 0);
+    stat_drain(defence, 1, 0);
     stat_boost(crafting, 1, 0);
 } else if ($random < 80) { // 8/128 chance
     mes("That tasted a bit dodgy.  You feel a bit ill."); // extra space, not a typo
-    if ($hitpoints < 5 & $hitpoints > 2) {
-        ~damage_self(sub($hitpoints, 2));
-    } else {
+    if ($hitpoints > 4) {
         ~damage_self(4);
+    } else if ($hitpoints > 2) {
+        ~damage_self(sub($hitpoints, 2));
     }
 } else if ($random < 84) { // 4/128 chance
     mes("That tasted very dodgy. You feel very ill.");
-    def_int $damage;
-    // deal up to 49 damage
-    if ($hitpoints > 10) {
-        $damage = divide(sub($hitpoints, 1), 10);
-        $damage = min(sub(multiply($damage, 10), 1), 49);
-        $damage = min(sub($hitpoints, 2), $damage);
-    }  else if ($hitpoints < 10) {
-        $damage = 4;
-    } else {
-        $damage = 6;
+    // 1-2 hp: nothing
+    // 3 hp: 1 damage
+    // 4 hp: 2 damage
+    // 5 hp: 3 damage
+    // 6-9 hp: 4 damage
+    // 10 hp: 6 damage
+    // 11-20 hp: 9 damage
+    // 21-30 hp: 19 damage
+    // 31-40 hp: 29 damage
+    // 41-50 hp: 39 damage
+    // 51-99 hp: 49 damage
+    if ($hitpoints > 50) {
+        ~damage_self(49);
+    } else if ($hitpoints > 40) {
+        ~damage_self(39);
+    } else if ($hitpoints > 30) {
+        ~damage_self(29);
+    } else if ($hitpoints > 20) {
+        ~damage_self(19);
+    } else if ($hitpoints > 10) {
+        ~damage_self(9);
+    } else if ($hitpoints > 9) {
+        ~damage_self(6);
+    } else if ($hitpoints > 5) {
+        ~damage_self(4);
+    } else if ($hitpoints > 2) {
+        ~damage_self(sub(stat(hitpoints), 2));
     }
-    if ($damage = 0) {
-        return;
-    }
-    ~damage_self($damage);
-    stat_sub(attack, min(calc(1 + scale(5, 100, stat(attack))), 3), 0);
-    stat_sub(strength, min(calc(1 + scale(5, 100, stat(strength))), 3), 0);
-    stat_sub(defence, min(calc(1 + scale(5, 100, stat(defence))), 3), 0);
+    stat_drain(attack, 1, 3);
+    stat_drain(strength, 1, 3);
+    stat_drain(defence, 1, 3);
 } else if ($random < 120) {
     mes("You feel a lot better."); // 36/128 chance
     // heal by 14% + 6

--- a/scripts/player/scripts/consumption/effects/scripts/ugthanki_kebab_bad.rs2
+++ b/scripts/player/scripts/consumption/effects/scripts/ugthanki_kebab_bad.rs2
@@ -1,0 +1,10 @@
+[label,consume_effect_ugthanki_kebab_bad]
+mes("You eat the ugthanki kebab.");
+sound_synth(eat, 0, 0);
+anim(human_eat, 0);
+inv_delslot(inv, last_slot);
+// 1/32 chance to do nothing
+if (random(32) > 1 & stat(hitpoints) < stat_base(hitpoints)) {
+    mes("It heals some health.");
+    stat_heal(hitpoints, 9, 0);
+}


### PR DESCRIPTION
Kebabs:
- When all stats are under 5, `That tasted a bit dodgy. You feel a bit ill.` kebabs DO NOT OCCUR. It seems like it chooses the stat before the $random check, and skips if the chosen stat is under 5. Whenever I had just agility & prayer over 5, these were the only ones to get lowered (still incredibly rarer than it should be!)
-  The odds of `That tasted very dodgy. You feel very ill.` is unaffected, however it wont lower the chosen stat if its less than 3 (doesnt even display the second mes when it does this!)
- It seems increasingly likely that kebabs worked closer to they did in RSC. In RSC they only lowered hp when you fealt ill.
    - From July 2007 [blog post](https://oldschool.runescape.wiki/w/Update:Game_Improvements_(July_2007)): `kebabs can no longer reduce your Hitpoints and will affect a different skill instead`.... Not exactly sure if this wording suggests it only reduces Hitpoints.
    - Trying to find more evidence of this!

Poison chalices:
- Our damaging logic for poison chalice was kinda weird, so I refactored it so it makes more sense.
- The attack/strength/defence stat drain was kinda just wrong. It subtracted from the base level instead of current level. From a boosted strength level, I was able to get it to drain 4 levels!
- The `It heals some health` was missing a period, but it also didn't check for hp properly
- Our poison chalice code could theoretically kill you when it shouldnt!!