### PR TITLE
fix: Change Falador wall shortcut to act similarly to the barbarian course wall 

### DIFF
--- a/scripts/skill_agility/scripts/barbarian_course.rs2
+++ b/scripts/skill_agility/scripts/barbarian_course.rs2
@@ -94,7 +94,9 @@ p_delay(0);
 stat_advance(agility, 200);
 ~update_barbarian_varp(4);
 
-[oploc1,barbarian_crumblingwall] 
+[oploc1,barbarian_crumblingwall] @climb_barbarian_crumblingwall;
+
+[label,climb_barbarian_crumblingwall]
 if(coordx(coord) > coordx(loc_coord)) {
     mes("You cannot climb that from this side.");
     return;

--- a/scripts/skill_agility/scripts/shortcuts.rs2
+++ b/scripts/skill_agility/scripts/shortcuts.rs2
@@ -1,26 +1,13 @@
-[oploc1,loc_1947]
+[oploc1,loc_1947] 
 if (map_members = ^false) {
     mes(^mes_members_feature);
-    return;
-}
-if(loc_coord ! 0_45_52_55_27) {
-    // these walls are reused in the barb course for some reason (not the wall you climb)
-    // todo: figure out what would happen if you interact with those ones
     return;
 }
 if(stat(agility) < 5) {
     mes("You need an Agility level of 5 to climb this.");
     return;
 }
-def_int $dir = ^exact_east; 
-def_coord $end = movecoord(loc_coord, 1, 0, 0);
-if(coordx(coord) > coordx(loc_coord)) {
-    $dir = ^exact_west;
-    $end = movecoord(loc_coord, -1, 0, 0);
-}
-p_delay(0);
-~agility_exactmove(human_walk_crumbledwall, 30, 2, coord, $end, 30, 100, $dir, true);
-stat_advance(agility, 5);
+@climb_barbarian_crumblingwall;
 
 [oploc1,loc_2298]
 if(stat(agility) < 5) {

--- a/scripts/skill_agility/scripts/shortcuts.rs2
+++ b/scripts/skill_agility/scripts/shortcuts.rs2
@@ -1,4 +1,4 @@
-[oploc1,loc_1947] 
+[oploc1,loc_1947]
 if (map_members = ^false) {
     mes(^mes_members_feature);
     return;


### PR DESCRIPTION
https://oldschool.runescape.wiki/w/Update:New_shortcuts_and_prayers (Two Falador shortcuts: the one to the west is now two-way, and a new one to the south.)

Before this update this loc was also in the barbarian outpost course, old guides generally say it gave 25 or 12.5 xp and worked from outside -> inside, in this case it's probably safe to assume it functioned identically to the barbarian outpost wall (although it retains the agility req and map_members check)
