### PR TITLE
fix: some fishing anims playing 1t late

### DIFF
--- a/scripts/macro events/scripts/fishing/macro_event_whirlpool.rs2
+++ b/scripts/macro events/scripts/fishing/macro_event_whirlpool.rs2
@@ -13,8 +13,7 @@ if (p_finduid(uid) = true) {
         return;
     }
     %macro_whirlpool_counter = 0;
-    if_close;
-    p_stopaction;
     sound_synth(watersplash, 0, 0);
     inv_del(inv, $fishing_equipment, 1);
+    anim(null, 0); // https://youtu.be/ji4qvtcLKpI?list=PLn23LiLYLb1am4weMQzkWn5m9b3m9fXv9&t=112
 }

--- a/scripts/macro events/scripts/fishing/macro_event_whirlpool.rs2
+++ b/scripts/macro events/scripts/fishing/macro_event_whirlpool.rs2
@@ -5,7 +5,8 @@
 // moves instantly back to respawn, then moves back again
 sound_synth(whirlpool, 0, 0);
 npc_changetype(npc_param(whirlpool), 60);
-
+// doesnt continue to fish https://youtu.be/ji4qvtcLKpI?list=PLn23LiLYLb1am4weMQzkWn5m9b3m9fXv9&t=112
+// anim plays out... people dont seem to lose their equipment at the whirlpool unless they *reclick* on it
 [proc,macro_whirlpool_attempt_take_equipment](namedobj $fishing_equipment)
 if (p_finduid(uid) = true) {
     %macro_whirlpool_counter = calc(%macro_whirlpool_counter + 1);
@@ -15,5 +16,4 @@ if (p_finduid(uid) = true) {
     %macro_whirlpool_counter = 0;
     sound_synth(watersplash, 0, 0);
     inv_del(inv, $fishing_equipment, 1);
-    anim(null, 0); // https://youtu.be/ji4qvtcLKpI?list=PLn23LiLYLb1am4weMQzkWn5m9b3m9fXv9&t=112
 }

--- a/scripts/skill_fishing/scripts/fishing_spots/freshfish.rs2
+++ b/scripts/skill_fishing/scripts/fishing_spots/freshfish.rs2
@@ -140,11 +140,11 @@ if (inv_freespace(inv) = 0 & inv_total(inv, fishing_bait) > 1) {
 if (%action_delay < map_clock) {
     %action_delay = calc(map_clock + 4);
 } else if (%action_delay = map_clock) {
+    anim(human_fish_onspot, 0);
     ~fish_roll(raw_pike, null, fishing_rod, fishing_bait);
     if (random(5) = 0) { // 1/5 chance to recast https://x.com/JagexAsh/status/1585958606364868608
         p_opnpc(3);
         return;
     }
-    anim(human_fish_onspot, 0);
 }
 p_opnpc(5);

--- a/scripts/skill_fishing/scripts/fishing_spots/memberfish.rs2
+++ b/scripts/skill_fishing/scripts/fishing_spots/memberfish.rs2
@@ -33,8 +33,8 @@ if (%action_delay = calc(map_clock + 4)) {
     sound_synth(fishing_cast, 0, 0);
     p_opnpc(5);
 } else if (%action_delay = map_clock) { 
-    ~fish_roll(raw_shark, null, harpoon, null);
     anim(human_harpoon, 0);
+    ~fish_roll(raw_shark, null, harpoon, null);
 }
 
 if (afk_event = ^true & npc_param(is_whirlpool) = ^false) {

--- a/scripts/skill_fishing/scripts/fishing_spots/rarefish.rs2
+++ b/scripts/skill_fishing/scripts/fishing_spots/rarefish.rs2
@@ -47,8 +47,8 @@ if (%action_delay < map_clock) {
     mes("You attempt to catch a Lobster.");
     p_opnpc(4);
 } else if (%action_delay = map_clock) { 
-    ~fish_roll(raw_lobster, null, lobster_pot, null);
     anim(human_lobster, 0);
+    ~fish_roll(raw_lobster, null, lobster_pot, null);
 }
 if (afk_event = ^true & npc_param(is_whirlpool) = ^false) {
     @macro_event_fishing(lobster_pot);
@@ -75,8 +75,8 @@ if (inv_freespace(inv) < 1) {
 if (%action_delay < map_clock) {
     %action_delay = calc(map_clock + 5);
 } else if (%action_delay = map_clock) {
-    ~fish_roll(raw_lobster, null, lobster_pot, null);
     anim(human_lobster, 0);
+    ~fish_roll(raw_lobster, null, lobster_pot, null);
 }
 p_opnpc(4);
 
@@ -108,12 +108,12 @@ if (%action_delay < map_clock) {
     sound_synth(fishing_cast, 0, 0);
     p_opnpc(5);
 } else if (%action_delay = map_clock) { 
+    anim(human_harpoon, 0);
     if (stat(fishing) >= 50) {
         ~fish_roll(raw_swordfish, raw_tuna, harpoon, null);
     } else {
         ~fish_roll(raw_tuna, null, harpoon, null);
     }
-    anim(human_harpoon, 0);
 }
 if (afk_event = ^true & npc_param(is_whirlpool) = ^false) {
     @macro_event_fishing(harpoon);
@@ -139,11 +139,11 @@ if (inv_freespace(inv) < 1) {
 if (%action_delay < map_clock) {
     %action_delay = calc(map_clock + 5);
 } else if (%action_delay = map_clock) {
+    anim(human_harpoon, 0);
     if (stat(fishing) >= 50) {
         ~fish_roll(raw_swordfish, raw_tuna, harpoon, null);
     } else {
         ~fish_roll(raw_tuna, null, harpoon, null);
     }
-    anim(human_harpoon, 0);
 }
 p_opnpc(5);

--- a/scripts/skill_fishing/scripts/fishing_spots/saltfish.rs2
+++ b/scripts/skill_fishing/scripts/fishing_spots/saltfish.rs2
@@ -44,13 +44,13 @@ if (%action_delay = calc(map_clock + 3)) {
     anim(human_smallnet, 0);
     sound_synth(net, 0, 0);
     p_opnpc(4);
-} else if (%action_delay = map_clock) { 
+} else if (%action_delay = map_clock) {
+    // doesnt play anim here
     if (stat(fishing) >= 15) {
         ~fish_roll(raw_shrimp, raw_anchovies, net, null);
     } else {
         ~fish_roll(raw_shrimp, null, net, null);
     }
-    anim(human_smallnet, 0);
 }
 
 if (afk_event = ^true & npc_param(is_whirlpool) = ^false) {
@@ -71,12 +71,12 @@ if (inv_freespace(inv) < 1) {
 if (%action_delay < map_clock) {
     %action_delay = calc(map_clock + 5);
 } else if (%action_delay = map_clock) {
+    anim(human_smallnet, 0);
     if (stat(fishing) >= 15) {
         ~fish_roll(raw_shrimp, raw_anchovies, net, null);
     } else {
         ~fish_roll(raw_shrimp, null, net, null);
     }
-    anim(human_smallnet, 0);
 }
 p_opnpc(4);
 
@@ -113,6 +113,7 @@ if (%action_delay = calc(map_clock + 4)) {
     sound_synth(fishing_cast, 0, 0);
     p_opnpc(5);
 } else if (%action_delay = map_clock) {
+    anim(human_fish_onspot, 0);
     if (stat(fishing) >= 10) {
         ~fish_roll(raw_sardine, raw_herring, fishing_rod, fishing_bait);
     } else {
@@ -143,8 +144,8 @@ if (inv_freespace(inv) < 1 & inv_total(inv, fishing_bait) > 1) {
 }
 if (%action_delay < map_clock) {
     %action_delay = calc(map_clock + 4);
-    anim(human_fish_onspot, 0);
 } else if (%action_delay = map_clock) {
+    anim(human_fish_onspot, 0);
     if (stat(fishing) >= 10) {
         ~fish_roll(raw_sardine, raw_herring, fishing_rod, fishing_bait);
     } else {

--- a/scripts/skill_fishing/scripts/fishing_spots/waterfall.rs2
+++ b/scripts/skill_fishing/scripts/fishing_spots/waterfall.rs2
@@ -48,13 +48,12 @@ if (inv_freespace(inv) = 0 & inv_total(inv, feather) > 1) {
 if (%action_delay < map_clock) {
     %action_delay = calc(map_clock + 4);
 } else if (%action_delay = map_clock) {
+    anim(human_fish_onspot, 0);
     if (stat(fishing) >= 30) {
         ~fish_roll_loc(raw_trout, raw_salmon, feather);
     } else {
         ~fish_roll_loc(raw_trout, null, feather);
     }
-    anim(human_fish_onspot, 0);
-    p_oploc(3);
 }
 p_oploc(3);
 


### PR DESCRIPTION
- removes redundant if_close and p_stopaction from whirlpool
- play anim before fishing roll... this is very minor but im pretty sure they do this. Pike is a good indicator of this. Plays the human_fish_onspot anim before p_opnpc(3) (recasting)
![image](https://github.com/user-attachments/assets/dbedb31c-5875-4bd1-b961-f3dfc6a8d268)
- fishing is similar to woodcutting, where the anim plays when you get the roll. Most of our fishing spots already did this... except for our sardine/herring fishing. I fixed this in this pr.
- small net fishing spots in osrs dont play the anim when you get the roll in the op1. I think this is the only fishing spot to do this!
- One final little piece of information: whirlpools dont continue your interaction when they spawn (because it changes type), the only way to actually *lose* equipment at it is to click on the whirlpool. [Video](https://youtu.be/ji4qvtcLKpI?list=PLn23LiLYLb1am4weMQzkWn5m9b3m9fXv9&t=112) shows people who get a whirlpool, will stop fishing (anim still plays till its finished), after a bit they continue fishing as normal (no equipment is lost!)