### PR TITLE
fix: fix operation order with ice queen dung rocks

### DIFF
--- a/scripts/areas/area_white_wolf_mountain/scripts/white_wolf_mountain.rs2
+++ b/scripts/areas/area_white_wolf_mountain/scripts/white_wolf_mountain.rs2
@@ -31,10 +31,10 @@ p_delay(1);
 loc_change(loc_474, 3);
 p_delay(1);
 // Temp note: dur updated
-loc_add($loc_coord, loc_475, loc_angle, loc_shape, 4); // replace rockslide with 2x2 invisible barrier
 loc_add(movecoord($loc_coord, 0, 0, 1), loc_475, loc_angle, loc_shape, 4);
 loc_add(movecoord($loc_coord, 1, 0, 1), loc_475, loc_angle, loc_shape, 4);
 loc_add(movecoord($loc_coord, 1, 0, 0), loc_475, loc_angle, loc_shape, 4);
+loc_add($loc_coord, loc_475, loc_angle, loc_shape, 4); // replace rockslide with 2x2 invisible barrier
 if (coordx(coord) > coordx($loc_coord)) {
   ~forcemove(movecoord(coord, -2, 0, 0));
   ~forcemove(movecoord(coord, -1, 0, 1));


### PR DESCRIPTION
current implementation will remove blocking, allowing players to path through (same issue as gnome gate)