### PR TITLE
fix: %lastcombat to null instead of %aggressive_npc in ~npc_death

### DIFF
--- a/scripts/skill_combat/scripts/npc/npc_death.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_death.rs2
@@ -17,7 +17,7 @@ if (finduid(%npc_aggressive_player) = true) {
     if (npc_param(death_sound) ! null) {
         ~sound_within_distance(npc_param(death_sound), 0, npc_coord, 12); // osrs
     }
-    %aggressive_npc = null;
+    %lastcombat = null; // allows other npcs to hunt you immediately
 }
 npc_anim(npc_param(death_anim), 0);
 npc_delay(1); // osrs has an extra tick of delay here. I think this delay can vary from npc to npc


### PR DESCRIPTION
When put out of combat from ~npc_death, hunts from the engine would still think the player was in combat.

https://github.com/user-attachments/assets/93a12fcf-00ff-4efd-960c-9698451aebae

This is easily fixed by setting %lastcombat to null in ~npc_death.


https://github.com/user-attachments/assets/b955af05-8278-469d-80db-eb0820d21afa

This change impacts thieving & other checks to %lastcombat. Fortunately, these all match now!! For example, thieving stalls & pickpocketing will immediately let you thieve after killing an npc:

https://github.com/user-attachments/assets/f9ad908b-6a9e-48c7-b958-441ecc55970d

https://github.com/user-attachments/assets/556d3134-0991-415a-85fd-18de5006fc0f


