### PR TITLE
fix: additional %duelstatus check before losing duel after duel death

### DIFF
--- a/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -6,7 +6,7 @@ if (~in_duel_arena(coord) = true) {
 clearqueue(duel_finish);
 queue(duel_finish, 0);
 
-if (.finduid(%duelpartner) = true) {
+if (%duelstatus = ^duelstatus_lost & .finduid(%duelpartner) = true) {
     session_log(^log_moderator, "Lost a duel against <.name>");
     .if_close;
     .%duelstatus = ^duelstatus_victory;


### PR DESCRIPTION
from https://github.com/tannerdino/Content/commit/8e3fc03970bcc4d1358bba225effde16e302b1a4 I moved `both_moveinv(dueloffer, duelwinnings);` to the duel death queue, this was to recreate an early osrs bug where you could overflow your duelwinnings inventory to force drop items in the duel arena after winning.


Inauthentic bug that this pr fixes:
The way double deaths at the duel arena are currently handled is who ever is the last person to 'lose' is the winner.  `both_moveinv(dueloffer, duelwinnings);` was missing a check to see if your %duelstatus varp changed during the death animation... So essentially both players would send their dueloffer to the other persons duelwinnings. duelwinnings is only accessible through winning a duel, so the winner would just receive the losers dueloffer, and the loser would receive the winners duel offer (though inaccessible until duel win).