### PR TITLE
fix: add missing ana check to camp guards

### DIFF
--- a/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
+++ b/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
@@ -172,6 +172,16 @@ npc_say("You don't belong in here!");
 mes("More guards come to arrest you.");
 ~npc_retaliate(0);
 p_delay(2);
+if(inv_total(inv, thanainabarrel) > 0) {
+    npc_say("Hey, what's in this barrel?");
+    p_delay(1);
+    npc_say("Right... we'll take that off your hands.");
+    inv_del(inv, thanainabarrel, 1); // not changeslot
+    inv_add(inv, thminebarrel_empty, 1);
+    p_delay(1);
+    mes("The guards drag Ana off into the distance.");
+    p_delay(1);
+}
 mes("You're outnumbered by all the guards.");
 p_delay(2);
 mes("They manhandle you into a cell.");

--- a/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
+++ b/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
@@ -186,7 +186,8 @@ mes("You're outnumbered by all the guards.");
 p_delay(2);
 mes("They manhandle you into a cell.");
 p_delay(2);
-p_teleport(^desertrescue_prison_coord);
+if(inzone(0_51_147_0_0, 0_51_147_63_63, coord) = true) p_teleport(^desertrescue_underground_prison_coord);
+else p_teleport(^desertrescue_prison_coord);
 
 [oploc2,loc_2683] // RSC, this is completely different in osrs/post 2006
 ~mesbox("You search the window.");


### PR DESCRIPTION
currently missing check when caught with a weapon on 