### PR TITLE
feat: pvp & pvm special attacks

### DIFF
--- a/pack/interface.pack
+++ b/pack/interface.pack
@@ -7814,8 +7814,8 @@
 7813=duel_confirm:com_164
 7814=duel_confirm:com_165
 7815=duel_select_type:com_144
-7816=duel_select_type:com_161
-7817=duel_select_type:com_162
+7816=duel_select_type:no_specs
+7817=duel_select_type:no_specs_text
 7818=friends:com_228
 7819=friends:com_229
 7820=friends:com_230

--- a/scripts/_unpack/244.varp
+++ b/scripts/_unpack/244.varp
@@ -14,4 +14,5 @@ scope=perm
 transmit=yes
 
 [sa_enabled]
+protect=no
 transmit=yes

--- a/scripts/login_logout/login.rs2
+++ b/scripts/login_logout/login.rs2
@@ -44,7 +44,7 @@ queue(macro_event_login, 0);
 ~thieving_stall_timers_login;
 ~stat_boost_login; // f2p boost reset
 ~wilderness_warning_login; // remove wildy warning if logged in at wildy border https://youtu.be/hiUfg8MsKMo
-~upsert_sa_regen_timer;
+~sa_login; // start timer if low sa energy
 
 if(inzone(movecoord(^grandtree_jail_coord, 0, 0, -2), movecoord(^grandtree_jail_coord, 3, 0, 2), coord) = true) {
     ~grandtree_spawn_charlie;

--- a/scripts/minigames/game_duelarena/configs/duelarena.constant
+++ b/scripts/minigames/game_duelarena/configs/duelarena.constant
@@ -11,6 +11,7 @@
 ^obstacles = 10
 ^no_jewelry = 11
 ^flower_power = 12
+^no_specs = 13
 
 
 ^north_camera = 0

--- a/scripts/minigames/game_duelarena/interfaces/duel_select_type.if
+++ b/scripts/minigames/game_duelarena/interfaces/duel_select_type.if
@@ -1444,7 +1444,7 @@ script1=eq,1
 graphic=miscgraphics,10
 activegraphic=miscgraphics,11
 
-[com_161]
+[no_specs]
 type=graphic
 x=162
 y=250
@@ -1456,7 +1456,7 @@ script1=eq,1
 graphic=miscgraphics,10
 activegraphic=miscgraphics,11
 
-[com_162]
+[no_specs_text]
 type=text
 x=188
 y=250

--- a/scripts/minigames/game_duelarena/scripts/duel_arena_settings.rs2
+++ b/scripts/minigames/game_duelarena/scripts/duel_arena_settings.rs2
@@ -80,6 +80,9 @@ if (~duel_arena_flower_power_check = true) {
 [if_button,duel_select_type:obstacles]
 ~toggle_duel_setting(^obstacles);
 
+[if_button,duel_select_type:no_specs]
+~toggle_duel_setting(^no_specs);
+
 
 [proc,toggle_duel_setting](int $setting)
 %duel_settings = togglebit(%duel_settings, $setting);
@@ -257,6 +260,17 @@ if (testbit(%duel_settings, ^no_magic) = ^true) {
 if (testbit(%duel_settings, ^flower_power) = ^true) {
     mes("This is a 'flower power' duel. You can only use flowers."); // guess based off of 2006 vid
     // 2006: "This is a 'fun weapon' duel. You can only use flowers or a rubber|chicken."
+    return(false);
+}
+return(true);
+
+[proc,duel_arena_spec_check]()(boolean)
+if (~in_duel_arena(coord) = false) {
+    return(true);
+}
+if (testbit(%duel_settings, ^no_specs) = ^true) {
+    mes("Use of special attacks has been turned off for this duel."); // https://youtu.be/YkJQDvB14-U?t=327
+    %sa_enabled = ^false;
     return(false);
 }
 return(true);

--- a/scripts/skill_combat/configs/combat.constant
+++ b/scripts/skill_combat/configs/combat.constant
@@ -1,2 +1,3 @@
 ^sa_max_energy = 1000
+^sa_regen_amount = 100
 ^sa_regen_interval = 50

--- a/scripts/skill_combat/configs/combat.param
+++ b/scripts/skill_combat/configs/combat.param
@@ -170,3 +170,8 @@ default=null
 [specwep]
 type=int
 default=0
+
+// just some arbitrary default lol
+[sa_energy]
+type=int
+default=500

--- a/scripts/skill_combat/configs/combat.param
+++ b/scripts/skill_combat/configs/combat.param
@@ -174,4 +174,4 @@ default=0
 // just some arbitrary default lol
 [sa_energy]
 type=int
-default=500
+default=1000

--- a/scripts/skill_combat/configs/melee/daggers.obj
+++ b/scripts/skill_combat/configs/melee/daggers.obj
@@ -248,6 +248,7 @@ param=weapon_poisoned,dragon_dagger_p
 param=weapon_poisoned_message,You poison the dagger.
 // osrs defend anim seq_378
 param=specwep,^true
+param=sa_energy,250
 
 [black_dagger]
 model=model_2672_obj
@@ -544,6 +545,7 @@ param=slash_sound,stabsword_slash
 // osrs defend anim seq_378
 param=poison_severity,20
 param=specwep,^true
+param=sa_energy,250
 
 [black_dagger_p]
 members=yes

--- a/scripts/skill_combat/configs/melee/longswords.obj
+++ b/scripts/skill_combat/configs/melee/longswords.obj
@@ -250,3 +250,4 @@ param=defend_anim,human_sword_def
 param=slash_sound,hacksword_slash
 param=stab_sound,hacksword_stab
 param=specwep,^true
+param=sa_energy,250

--- a/scripts/skill_combat/configs/melee/maces.obj
+++ b/scripts/skill_combat/configs/melee/maces.obj
@@ -229,3 +229,4 @@ param=defend_anim,human_blunt_block
 param=crush_sound,mace_crush
 param=stab_sound,mace_stab
 param=specwep,^true
+param=sa_energy,250

--- a/scripts/skill_combat/configs/melee/spears.obj
+++ b/scripts/skill_combat/configs/melee/spears.obj
@@ -284,6 +284,7 @@ param=crush_sound,staff_hit
 param=weapon_poisoned,dragon_spear_p
 param=weapon_poisoned_message,You poison a spear.
 param=specwep,^true
+param=sa_energy,250
 
 [bronze_spear_p]
 members=yes
@@ -563,3 +564,4 @@ param=slash_sound,staff_hit
 param=crush_sound,staff_hit
 param=poison_severity,20
 param=specwep,^true
+param=sa_energy,250

--- a/scripts/skill_combat/configs/ranged/bows.obj
+++ b/scripts/skill_combat/configs/ranged/bows.obj
@@ -311,6 +311,7 @@ param=defend_anim,human_unarmedblock
 param=rangeattack_sound,longbow
 param=damagetype,^ranged_style
 param=specwep,^true
+param=sa_energy,350
 
 [magic_shortbow]
 members=yes
@@ -340,6 +341,7 @@ param=defend_anim,human_unarmedblock
 param=rangeattack_sound,arrowlaunch2
 param=damagetype,^ranged_style
 param=specwep,^true
+param=sa_energy,350
 
 [ogre_bow]
 name=Ogre bow

--- a/scripts/skill_combat/configs/ranged/thrownaxes.obj
+++ b/scripts/skill_combat/configs/ranged/thrownaxes.obj
@@ -194,3 +194,4 @@ param=rangeattack_sound,throwingaxe
 param=proj_launch,rune_taxe_launch
 param=proj_travel,rune_taxe_travel
 param=specwep,^true
+param=sa_energy,100

--- a/scripts/skill_combat/scripts/player/player_combat.rs2
+++ b/scripts/skill_combat/scripts/player/player_combat.rs2
@@ -13,6 +13,9 @@ if (($attackrange <= 1 & ~player_in_combat_check = false) | npc_range(coord) > $
 if (~player_in_combat_check = false) {
     return;
 }
+if (~sa_enabled = true) {
+    @player_special_attack;
+}
 if (%damagetype = ^ranged_style) {
     @player_ranged_attack;
 }

--- a/scripts/skill_combat/scripts/player/player_special_attack.rs2
+++ b/scripts/skill_combat/scripts/player/player_special_attack.rs2
@@ -13,6 +13,12 @@ if (npc_stat(hitpoints) = 0) {
 if (~sa_enough_energy = false) {
     return;
 }
-switch_obj(inv_getobj(worn, ^wearpos_rhand)) {
+def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
+~set_sa_vars(oc_param($weapon, sa_energy));
+p_opnpc(2);
+%action_delay = add(map_clock, oc_param($weapon, attackrate));
+switch_obj($weapon) {
     case dragon_dagger, dragon_dagger_p : @pvm_dragon_dagger_sa;
+    case dragon_longsword : @pvm_dragon_longsword_sa;
+    case dragon_mace : @pvm_dragon_mace_sa;
 }

--- a/scripts/skill_combat/scripts/player/player_special_attack.rs2
+++ b/scripts/skill_combat/scripts/player/player_special_attack.rs2
@@ -1,0 +1,18 @@
+[label,player_special_attack]
+if (~npc_is_attackable() = false) {
+    return;
+}
+if (%action_delay > map_clock) {
+    p_opnpc(2); // it is guaranteed here that we are already within op distance
+    return;
+}
+if (npc_stat(hitpoints) = 0) {
+    p_stopaction;
+    return; // this means the npc is not avail to fight i.e dead
+}
+if (~sa_enough_energy = false) {
+    return;
+}
+switch_obj(inv_getobj(worn, ^wearpos_rhand)) {
+    case dragon_dagger, dragon_dagger_p : @pvm_dragon_dagger_sa;
+}

--- a/scripts/skill_combat/scripts/player/specs/scripts/pvm_dragon_dagger_sa.rs2
+++ b/scripts/skill_combat/scripts/player/specs/scripts/pvm_dragon_dagger_sa.rs2
@@ -1,11 +1,4 @@
 [label,pvm_dragon_dagger_sa]
-def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
-~set_sa_vars(oc_param($weapon, sa_energy));
-
-p_opnpc(2);
-
-%action_delay = add(map_clock, oc_param($weapon, attackrate));
-
 spotanim_pl(spotanim_252, 96, 0);
 anim(seq_1062, 0);
 sound_synth(puncture, 0, 0);

--- a/scripts/skill_combat/scripts/player/specs/scripts/pvm_dragon_dagger_sa.rs2
+++ b/scripts/skill_combat/scripts/player/specs/scripts/pvm_dragon_dagger_sa.rs2
@@ -1,0 +1,42 @@
+[label,pvm_dragon_dagger_sa]
+def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
+~set_sa_vars(oc_param($weapon, sa_energy));
+
+p_opnpc(2);
+
+%action_delay = add(map_clock, oc_param($weapon, attackrate));
+
+spotanim_pl(spotanim_252, 96, 0);
+anim(seq_1062, 0);
+sound_synth(puncture, 0, 0);
+npc_anim(npc_param(defend_anim), 20); 
+
+~pvm_dragon_dagger_spec_hit;
+p_delay(0);
+~pvm_dragon_dagger_spec_hit;
+
+[proc,pvm_dragon_dagger_spec_hit]
+if (npc_stat(hitpoints) = 0) {
+    return;
+}
+def_int $damage = 0;
+def_int $maxhit = scale(115, 100, %com_maxhit); // 15% bonus damage
+def_int $attackroll = scale(115, 100, ~player_attack_roll_specific(%damagetype)); // 15% bonus accuracy
+def_int $defenceroll = ~npc_defence_roll_specific(^slash_style);
+if (~player_npc_hit_roll(%damagetype) = true) {
+    if (npc_type = count_draynor & inv_total(inv, garlic) > 0) {
+        $maxhit = add($maxhit, 1);
+    }
+    $damage = randominc(min($maxhit, npc_param(max_dealt)));
+    def_int $damage_capped = min($damage, npc_stat(hitpoints));
+    ~give_combat_experience(%damagestyle, $damage_capped, %npc_combat_xp_multiplier);
+    npc_heropoints($damage_capped);
+}
+
+def_int $poison_severity = oc_param(inv_getobj(worn, ^wearpos_rhand), poison_severity);
+if ($damage > 0 & $poison_severity > 0 & random(4) = 0) { // 1/4 chance to poison
+    // poison npc
+    ~npc_poison_start($poison_severity);
+}
+~npc_retaliate(0);
+npc_queue(2, $damage, 0);

--- a/scripts/skill_combat/scripts/player/specs/scripts/pvm_dragon_longsword.sa.rs2
+++ b/scripts/skill_combat/scripts/player/specs/scripts/pvm_dragon_longsword.sa.rs2
@@ -1,0 +1,25 @@
+[label,pvm_dragon_longsword_sa]
+def_int $damage = 0;
+def_int $maxhit = scale(125, 100, %com_maxhit);
+def_int $damage_capped = 0;
+// https://archive.ph/QQRNa, rolled against npc slash def, but uses current damage type
+def_int $attack_roll = ~player_attack_roll_specific(%damagetype);
+def_int $defence_roll = ~npc_defence_roll_specific(^slash_style);
+if (randominc($attack_roll) > randominc($defence_roll)) {
+    if (npc_type = count_draynor & inv_total(inv, garlic) > 0) {
+        $maxhit = add($maxhit, 1);
+    }
+    $damage = randominc(min($maxhit, npc_param(max_dealt)));
+    $damage_capped = min($damage, npc_stat(hitpoints));
+    ~give_combat_experience(%damagestyle, $damage_capped, %npc_combat_xp_multiplier);
+    npc_heropoints($damage_capped);
+}
+anim(seq_1058, 0);
+sound_synth(cleave, 0, 0);
+spotanim_pl(spotanim_248, 96, 0);
+~npc_retaliate(0);
+npc_queue(2, $damage, 0);
+npc_anim(npc_param(defend_anim), 20); 
+if (npc_param(defend_sound) ! null) {
+    sound_synth(npc_param(defend_sound), 0, 20); // delay npc this tick
+}

--- a/scripts/skill_combat/scripts/player/specs/scripts/pvm_dragon_mace.rs2
+++ b/scripts/skill_combat/scripts/player/specs/scripts/pvm_dragon_mace.rs2
@@ -1,0 +1,24 @@
+[label,pvm_dragon_mace_sa]
+def_int $damage = 0;
+def_int $maxhit = scale(150, 100, %com_maxhit);
+def_int $damage_capped = 0;
+def_int $attack_roll = scale(125, 100, ~player_attack_roll_specific(%damagetype)); // 25% bonus accuracy
+def_int $defence_roll = ~npc_defence_roll_specific(^crush_style);
+if (randominc($attack_roll) > randominc($defence_roll)) {
+    if (npc_type = count_draynor & inv_total(inv, garlic) > 0) {
+        $maxhit = add($maxhit, 1);
+    }
+    $damage = randominc(min($maxhit, npc_param(max_dealt)));
+    $damage_capped = min($damage, npc_stat(hitpoints));
+    ~give_combat_experience(%damagestyle, $damage_capped, %npc_combat_xp_multiplier);
+    npc_heropoints($damage_capped);
+}
+anim(seq_1060, 0);
+sound_synth(shatter, 0, 0);
+spotanim_pl(spotanim_251, 96, 0);
+~npc_retaliate(0);
+npc_queue(2, $damage, 0);
+npc_anim(npc_param(defend_anim), 20); 
+if (npc_param(defend_sound) ! null) {
+    sound_synth(npc_param(defend_sound), 0, 20); // delay npc this tick
+}

--- a/scripts/skill_combat/scripts/player/specwep.rs2
+++ b/scripts/skill_combat/scripts/player/specwep.rs2
@@ -1,28 +1,47 @@
-[queue,sa_setenergy](int $energy)
-%sa_energy = min(max($energy, 0), ^sa_max_energy);
-~upsert_sa_regen_timer;
+[proc,sa_enabled]()(boolean)
+if (%sa_enabled = ^true & oc_param(inv_getobj(worn, ^wearpos_rhand), specwep) = ^true & map_members = ^true) {
+    return(true);
+}
+return(false);
 
-[proc,upsert_sa_regen_timer]
-// If we're below max sa_energy, start the regen timer
+[proc,sa_enough_energy]()(boolean)
+if (%sa_energy < oc_param(inv_getobj(worn, ^wearpos_rhand), sa_energy)) {
+    mes("You don't have enough power left.");
+    %sa_enabled = ^false;
+    // If players attempt to use a special attack with insufficient energy then they'll find that instead 
+    // of a special attack failing and no attack occurring, a regular attack will instead be performed.
+    // - https://oldschool.runescape.wiki/w/Update:PvM_QoL_updates_%26_Wilderness_Rejuvenation_improvements
+    p_stopaction; // based on the way ive implemented specs, this is necessary to produce the behavior above.
+    return(false);
+}
+return(true);
+
+[proc,set_sa_vars](int $energy_used)
+if (%sa_energy = ^sa_max_energy) {
+    settimer(sa_regen, ^sa_regen_interval);
+}
+%sa_energy = max(sub(%sa_energy, $energy_used), 0);
+%sa_enabled = ^false;
+
+[proc,sa_reset]
+%sa_energy = ^sa_max_energy;
+cleartimer(sa_regen);
+
+[proc,sa_login]
 if (%sa_energy < ^sa_max_energy) {
-    if (gettimer(sa_regen) = -1) {
-        settimer(sa_regen, ^sa_regen_interval);
-    }
-} else {
-    if (gettimer(sa_regen) > 0) {
-        cleartimer(sa_regen);
-    }
+    settimer(sa_regen, ^sa_regen_interval);
 }
 
-[proc,sa_subenergy](int $amount)
-queue(sa_setenergy, 0, calc(%sa_energy - $amount));
-
-[proc,sa_healenergy](int $amount)
-queue(sa_setenergy, 0, calc(%sa_energy + $amount));
-
+// Special attack energy now restores while interfaces such as the bank are open.
+// - https://oldschool.runescape.wiki/w/Update:Easter_%26_Slayer_Updates
 [timer,sa_regen]
-~sa_healenergy(100);
+%sa_energy = min(add(%sa_energy, ^sa_regen_amount), ^sa_max_energy);
+if (%sa_energy = ^sa_max_energy) {
+    cleartimer(sa_regen);
+}
 
+
+// todo: queue if cannot access? or should sa_enabled be unprotected?
 [label,toggle_sa]
 if (%sa_enabled = ^false) {
     %sa_enabled = ^true;
@@ -30,63 +49,20 @@ if (%sa_enabled = ^false) {
     %sa_enabled = ^false;
 }
 
-[if_button,combat_blunt:specbar]
-// todo: queue if cannot access? or should sa_enabled be unprotected?
-if (p_finduid(uid) = true) {
-    @toggle_sa;
-}
-
+[if_button,combat_blunt:specbar] @toggle_sa;
 [if_button,combat_axe:specbar]
-if (p_finduid(uid) = true) {
-    @toggle_sa;
+// order is guessed
+if (~sa_enough_energy = false) {
+    return;
 }
-
-[if_button,combat_crossbow:specbar]
-if (p_finduid(uid) = true) {
-    @toggle_sa;
-}
-
-[if_button,combat_bow:specbar]
-if (p_finduid(uid) = true) {
-    @toggle_sa;
-}
-
-[if_button,combat_stabsword:specbar]
-if (p_finduid(uid) = true) {
-    @toggle_sa;
-}
-
-[if_button,combat_hacksword:specbar]
-if (p_finduid(uid) = true) {
-    @toggle_sa;
-}
-
-[if_button,combat_spiked:specbar]
-if (p_finduid(uid) = true) {
-    @toggle_sa;
-}
-
-[if_button,combat_thrown:specbar]
-if (p_finduid(uid) = true) {
-    @toggle_sa;
-}
-
-[if_button,combat_spear:specbar]
-if (p_finduid(uid) = true) {
-    @toggle_sa;
-}
-
-[if_button,combat_heavysword:specbar]
-if (p_finduid(uid) = true) {
-    @toggle_sa;
-}
-
-[if_button,combat_pickaxe:specbar]
-if (p_finduid(uid) = true) {
-    @toggle_sa;
-}
-
-[if_button,combat_unarmed:specbar]
-if (p_finduid(uid) = true) {
-    @toggle_sa;
-}
+@toggle_sa;
+[if_button,combat_crossbow:specbar] @toggle_sa;
+[if_button,combat_bow:specbar] @toggle_sa;
+[if_button,combat_stabsword:specbar] @toggle_sa;
+[if_button,combat_hacksword:specbar] @toggle_sa;
+[if_button,combat_spiked:specbar] @toggle_sa;
+[if_button,combat_thrown:specbar] @toggle_sa;
+[if_button,combat_spear:specbar] @toggle_sa;
+[if_button,combat_heavysword:specbar] @toggle_sa;
+[if_button,combat_pickaxe:specbar] @toggle_sa;
+[if_button,combat_unarmed:specbar] @toggle_sa;

--- a/scripts/skill_combat/scripts/player/specwep.rs2
+++ b/scripts/skill_combat/scripts/player/specwep.rs2
@@ -51,18 +51,59 @@ if (%sa_enabled = ^false) {
 
 [if_button,combat_blunt:specbar] @toggle_sa;
 [if_button,combat_axe:specbar]
-// order is guessed
-if (~sa_enough_energy = false) {
-    return;
-}
+// order is guessed (based off OSRS)
 if (~duel_arena_spec_check = false) {
     return;
 }
+if (~sa_enough_energy = false) {
+    return;
+}
+if(inv_getobj(worn, ^wearpos_rhand) = dragon_battleaxe) {
+    if(p_finduid(uid) = true) { // strongqueued in osrs, assuming its like settings stuff and doesnt queue
+        %sa_energy = sub(%sa_energy, 1000);
+        say("Raarrrrrgggggghhhhhhh!");
+        anim(seq_1056, 0);
+        spotanim_pl(spotanim_246, 0, 0);
+        def_int $drained_attack = calc(stat(attack) / 10);
+        def_int $drained_defence = calc(stat(defence) / 10);
+        def_int $drained_ranged = calc(stat(ranged) / 10);
+        def_int $drained_magic = calc(stat(magic) / 10);
+        def_int $sum = calc($drained_attack + $drained_defence + $drained_ranged + $drained_magic);
+        sound_synth(rampage, 0, 0);
+        stat_drain(attack, $drained_attack, 0);
+        stat_drain(defence, $drained_defence, 0);
+        stat_drain(ranged, $drained_ranged, 0);
+        stat_drain(magic, $drained_magic, 0);
+        stat_boost(strength, calc(10 + ($sum / 4)), 0);
+    }
+    return;
+}
 @toggle_sa;
+
 [if_button,combat_crossbow:specbar] @toggle_sa;
 [if_button,combat_bow:specbar] @toggle_sa;
 [if_button,combat_stabsword:specbar] @toggle_sa;
-[if_button,combat_hacksword:specbar] @toggle_sa;
+
+[if_button,combat_hacksword:specbar] 
+if (~duel_arena_spec_check = false) {
+    return;
+}
+if (~sa_enough_energy = false) {
+    return;
+}
+if(inv_getobj(worn, ^wearpos_rhand) = excalibur) {
+    if(p_finduid(uid) = true) { // strongqueued in osrs, assuming its like settings stuff and doesnt queue
+        %sa_energy = sub(%sa_energy, 1000);
+        say("For Camelot!");
+        anim(seq_1057, 0);
+        spotanim_pl(spotanim_247, 0, 0);
+        sound_synth(sanctuary, 0, 0);
+        stat_boost(defence, 8, 0);
+    }
+    return;
+}
+@toggle_sa;
+
 [if_button,combat_spiked:specbar] @toggle_sa;
 [if_button,combat_thrown:specbar] @toggle_sa;
 [if_button,combat_spear:specbar] @toggle_sa;

--- a/scripts/skill_combat/scripts/player/specwep.rs2
+++ b/scripts/skill_combat/scripts/player/specwep.rs2
@@ -55,6 +55,9 @@ if (%sa_enabled = ^false) {
 if (~sa_enough_energy = false) {
     return;
 }
+if (~duel_arena_spec_check = false) {
+    return;
+}
 @toggle_sa;
 [if_button,combat_crossbow:specbar] @toggle_sa;
 [if_button,combat_bow:specbar] @toggle_sa;

--- a/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
@@ -17,6 +17,9 @@ if ($attackrange <= 1 | $distance > $attackrange) {
 @pvp_combat_start;
 
 [label,pvp_combat_start]
+if (~sa_enabled = true) {
+    @pvp_special_attack;
+}
 if (%damagetype = ^ranged_style) {
     @pvp_ranged_attack;
 }

--- a/scripts/skill_combat/scripts/pvp/pvp_special_attack.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_special_attack.rs2
@@ -1,0 +1,20 @@
+[label,pvp_special_attack]
+if (%action_delay > map_clock) {
+    p_opplayer(2);
+    return;
+}
+if (stat(hitpoints) = 0) {
+    return;
+}
+if (.%death = ^true) {
+    p_stopaction;
+    return;
+}
+if (~sa_enough_energy = false) {
+    return;
+}
+if (~duel_arena_spec_check = false) {
+    return;
+}
+switch_obj(inv_getobj(worn, ^wearpos_rhand)) {
+}

--- a/scripts/skill_combat/scripts/pvp/pvp_special_attack.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_special_attack.rs2
@@ -16,6 +16,18 @@ if (~sa_enough_energy = false) {
 if (~duel_arena_spec_check = false) {
     return;
 }
+if (~duel_arena_melee_check = false) {
+    return;
+}
+def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
+~set_sa_vars(oc_param($weapon, sa_energy));
+
+p_opplayer(2);
+~set_pk_vars;
+
+%action_delay = add(map_clock, oc_param($weapon, attackrate));
 switch_obj(inv_getobj(worn, ^wearpos_rhand)) {
     case dragon_dagger, dragon_dagger_p : @pvp_dragon_dagger_sa;
+    case dragon_longsword : @pvp_dragon_longsword_sa;
+    case dragon_mace : @pvp_dragon_mace_sa;
 }

--- a/scripts/skill_combat/scripts/pvp/pvp_special_attack.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_special_attack.rs2
@@ -17,4 +17,5 @@ if (~duel_arena_spec_check = false) {
     return;
 }
 switch_obj(inv_getobj(worn, ^wearpos_rhand)) {
+    case dragon_dagger, dragon_dagger_p : @pvp_dragon_dagger_sa;
 }

--- a/scripts/skill_combat/scripts/pvp/specs/scripts/pvp_dragon_dagger_sa.rs2
+++ b/scripts/skill_combat/scripts/pvp/specs/scripts/pvp_dragon_dagger_sa.rs2
@@ -1,16 +1,4 @@
 [label,pvp_dragon_dagger_sa]
-if (~duel_arena_melee_check = false) {
-    return;
-}
-
-def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
-~set_sa_vars(oc_param($weapon, sa_energy));
-
-p_opplayer(2);
-~set_pk_vars;
-
-%action_delay = add(map_clock, oc_param($weapon, attackrate));
-
 spotanim_pl(spotanim_252, 96, 0);
 anim(seq_1062, 0);
 sound_synth(puncture, 0, 0);

--- a/scripts/skill_combat/scripts/pvp/specs/scripts/pvp_dragon_dagger_sa.rs2
+++ b/scripts/skill_combat/scripts/pvp/specs/scripts/pvp_dragon_dagger_sa.rs2
@@ -1,0 +1,47 @@
+[label,pvp_dragon_dagger_sa]
+if (~duel_arena_melee_check = false) {
+    return;
+}
+
+def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
+~set_sa_vars(oc_param($weapon, sa_energy));
+
+p_opplayer(2);
+~set_pk_vars;
+
+%action_delay = add(map_clock, oc_param($weapon, attackrate));
+
+spotanim_pl(spotanim_252, 96, 0);
+anim(seq_1062, 0);
+sound_synth(puncture, 0, 0);
+.anim(.%com_defendanim, 20);
+.sound_synth(puncture, 0, 0);
+
+~pvp_dragon_dagger_spec_hit;
+p_delay(0); // p_delays before 2006 or so
+~pvp_dragon_dagger_spec_hit;
+
+[proc,pvp_dragon_dagger_spec_hit]
+// If you're dead, 2nd hitsplat doesnt go through
+// https://youtu.be/b4KCZ3ySHwc?t=131
+if (stat(hitpoints) = 0) {
+    return;
+}
+def_int $damage = 0;
+def_int $maxhit = scale(115, 100, %com_maxhit); // 15% bonus damage
+def_int $attack_roll = scale(115, 100, ~player_attack_roll_specific(%damagetype)); // 15% bonus accuracy
+def_int $defence_roll = ~.player_defence_roll_specific(^slash_style); // puncture spec always rolls against their slash
+if (randominc($attack_roll) > randominc($defence_roll)) {
+    if (~.check_protect_prayer(^melee_style) = true) {
+        $maxhit = scale(6, 10, $maxhit); // reduction of 40%
+    }
+    $damage = min(randominc($maxhit), .stat(hitpoints)); // tick eating existed! https://oldschool.runescape.wiki/w/Update:The_Wintertodt
+    ~give_combat_experience_pvp(%damagestyle, $damage, ~pvp_xp_multiplier(~.player_combat_level));
+    both_heropoints($damage);
+}
+.queue(pvp_retaliate, 0, uid);
+~.pvp_damage(0, $damage);
+def_int $poison_severity = oc_param(inv_getobj(worn, ^wearpos_rhand), poison_severity);
+if ($damage > 0 & $poison_severity > 0 & random(4) = 0) { // 1/4 chance to poison
+    .queue(poison_player, 0, $poison_severity);
+}

--- a/scripts/skill_combat/scripts/pvp/specs/scripts/pvp_dragon_longsword.rs2
+++ b/scripts/skill_combat/scripts/pvp/specs/scripts/pvp_dragon_longsword.rs2
@@ -1,0 +1,20 @@
+[label,pvp_dragon_longsword_sa]
+def_int $damage = 0;
+def_int $maxhit = scale(125, 100, %com_maxhit);
+def_int $attack_roll = ~player_attack_roll_specific(%damagetype); 
+def_int $defence_roll = ~.player_defence_roll_specific(^slash_style); // rolls against slash def 
+if (randominc($attack_roll) > randominc($defence_roll)) {
+    if (~.check_protect_prayer(^melee_style) = true) {
+        $maxhit = scale(6, 10, $maxhit); // reduction of 40%
+    }
+    $damage = min(randominc($maxhit), .stat(hitpoints)); // tick eating existed! https://oldschool.runescape.wiki/w/Update:The_Wintertodt
+    ~give_combat_experience_pvp(%damagestyle, $damage, ~pvp_xp_multiplier(~.player_combat_level));
+    both_heropoints($damage);
+}
+anim(seq_1058, 0);
+sound_synth(cleave, 0, 0);
+spotanim_pl(spotanim_248, 96, 0);
+.anim(.%com_defendanim, 20);
+.sound_synth(cleave, 0, 0);
+.queue(pvp_retaliate, 0, uid);
+~.pvp_damage(0, $damage);

--- a/scripts/skill_combat/scripts/pvp/specs/scripts/pvp_dragon_mace.rs2
+++ b/scripts/skill_combat/scripts/pvp/specs/scripts/pvp_dragon_mace.rs2
@@ -1,0 +1,20 @@
+[label,pvp_dragon_mace_sa]
+def_int $damage = 0;
+def_int $maxhit = scale(150, 100, %com_maxhit); // 50% bonus damage
+def_int $attack_roll = scale(125, 100, ~player_attack_roll_specific(%damagetype)); // 25% bonus accuracy
+def_int $defence_roll = ~.player_defence_roll_specific(^crush_style); // rolls against crush def 
+if (randominc($attack_roll) > randominc($defence_roll)) {
+    if (~.check_protect_prayer(^melee_style) = true) {
+        $maxhit = scale(6, 10, $maxhit); // reduction of 40%
+    }
+    $damage = min(randominc($maxhit), .stat(hitpoints)); // tick eating existed! https://oldschool.runescape.wiki/w/Update:The_Wintertodt
+    ~give_combat_experience_pvp(%damagestyle, $damage, ~pvp_xp_multiplier(~.player_combat_level));
+    both_heropoints($damage);
+}
+anim(seq_1060, 0);
+sound_synth(shatter, 0, 0);
+spotanim_pl(spotanim_251, 96, 0);
+.anim(.%com_defendanim, 20);
+.sound_synth(shatter, 0, 0);
+.queue(pvp_retaliate, 0, uid);
+~.pvp_damage(0, $damage);


### PR DESCRIPTION
Implemented so far:
- base logic for special attacks
- pvm & pvp dragon dagger spec
- duel arena no spec setting

Implementation needed:
- other wep specs


some edge cases and research:
- duel arena only checks for spec weapon when you attack: [video](https://youtu.be/YkJQDvB14-U?t=327). This will 'consume' your attack
- Your attack will also be consumed if you dont have enough spec energy: [osrs blogpost](https://oldschool.runescape.wiki/w/Update:PvM_QoL_updates_%26_Wilderness_Rejuvenation_improvements)
- spec regen is just a regular timer: [osrs blogpost](https://oldschool.runescape.wiki/w/Update:Easter_%26_Slayer_Updates)
- spec still regens in f2p worlds in osrs (needs 2004 confirmation)
- spec doesnt require protected access to activate (needs 2004 confirmation)
- `The special attack of the rune throwing axe will no longer "steal" other people's random event monsters from combat, causing them to attack you.` - [2006 blogpost](https://oldschool.runescape.wiki/w/Update:Enlightened_Journey)
- dragon scimitar change: [2005 blogpost](https://oldschool.runescape.wiki/w/Update:Dragon_Scimitar_Change)
- magic short bow change: [2005 blogpost](https://oldschool.runescape.wiki/w/Update:Wilderness_Capes,_and_Changes)
- dragon dagger and magic shortbow delayed the attacker by 1 tick between hit splats: [msb video](https://youtu.be/uSO-ilQk5XY&t=207),  [dragon dagger video](https://youtu.be/b4KCZ3ySHwc?t=131)
- guy dragon dagger specs whilst at 1 hp, to a player with a ring of recoil. The 2nd hit splat doesnt go off, meaning theres an hp check between each hit: [video](https://youtu.be/b4KCZ3ySHwc?t=131)
- count draynor garlic effect applies with specs in 2025 osrs
- dspear worked on big npcs, but it just didnt push them only stunned: [rslegends](https://web.archive.org/web/20041228204209/http://trillionareguild.com/runescape/specialattacks.php), [runehq](https://web.archive.org/web/20040816032037/http://runehq.com/viewskills.php?id=00367)