### PR TITLE
fix: change pvp with an empty shortbow to set action_delay 

### DIFF
--- a/scripts/skill_combat/scripts/pvp/pvp_melee.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_melee.rs2
@@ -2,18 +2,24 @@
 if (~duel_arena_melee_check = false) {
     return;
 }
+if (.%death = ^true) {
+    p_stopaction;
+    return;
+}
 if (%action_delay > map_clock) {
     p_opplayer(2); // it is guaranteed here that we are already within op distance
     return;
 }
 
-if (.%death = ^true) {
-    p_stopaction;
-    return;
-}
-
 p_opplayer(2);
 ~set_pk_vars;
+
+def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
+if ($weapon = null) {
+    %action_delay = add(map_clock, 4);
+} else {
+    %action_delay = add(map_clock, oc_param($weapon, attackrate));
+}
 
 def_int $damage = 0;
 // not sure if xp multipler exists for us or not?!
@@ -39,13 +45,7 @@ sound_synth(%com_attacksound, 0, 0);
 // .sound_synth(.%com_defendsound, 0, 20);
 // sound_synth(.%com_defendsound, 0, 20);
 
-def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
-if ($weapon = null) {
-    %action_delay = add(map_clock, 4);
-} else {
-    %action_delay = add(map_clock, oc_param($weapon, attackrate));
-    def_int $poison_severity = oc_param($weapon, poison_severity);
-    if ($damage > 0 & $poison_severity > 0 & random(4) = 0) { // 1/4 chance to poison
-        .queue(poison_player, 0, $poison_severity);
-    }
+def_int $poison_severity = oc_param($weapon, poison_severity);
+if ($damage > 0 & $poison_severity > 0 & random(4) = 0) { // 1/4 chance to poison
+    .queue(poison_player, 0, $poison_severity);
 }

--- a/scripts/skill_combat/scripts/pvp/pvp_melee.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_melee.rs2
@@ -14,11 +14,13 @@ if (%action_delay > map_clock) {
 p_opplayer(2);
 ~set_pk_vars;
 
-def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
-if ($weapon = null) {
+def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
+def_int $poison_severity = 0;
+if ($rhand = null) {
     %action_delay = add(map_clock, 4);
 } else {
-    %action_delay = add(map_clock, oc_param($weapon, attackrate));
+    %action_delay = add(map_clock, oc_param($rhand, attackrate));
+    $poison_severity = oc_param($rhand, poison_severity);
 }
 
 def_int $damage = 0;
@@ -45,7 +47,6 @@ sound_synth(%com_attacksound, 0, 0);
 // .sound_synth(.%com_defendsound, 0, 20);
 // sound_synth(.%com_defendsound, 0, 20);
 
-def_int $poison_severity = oc_param($weapon, poison_severity);
 if ($damage > 0 & $poison_severity > 0 & random(4) = 0) { // 1/4 chance to poison
     .queue(poison_player, 0, $poison_severity);
 }

--- a/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -12,10 +12,12 @@ if (%action_delay > map_clock) {
 }
 // this can be either the quiver or rhand.
 def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
+def_int $poison_severity = 0;
 if ($rhand = null) {
     %action_delay = add(map_clock, 4);
 } else {
     %action_delay = add(map_clock, oc_param($rhand, attackrate));
+    $poison_severity = oc_param($weapon, poison_severity);
 }
 if (%damagestyle = ^style_ranged_rapid) {
     %action_delay = sub(%action_delay, 1);
@@ -43,7 +45,6 @@ if (~pvp_hit_roll(%damagetype) = true) {
     both_heropoints($damage);
 }
 
-def_int $poison_severity = oc_param($ammo, poison_severity);
 if ($damage > 0 & $poison_severity > 0 & random(4) = 0) { // 1/4 chance to poison
     .queue(poison_player, 0, $poison_severity);
 }

--- a/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -17,7 +17,7 @@ if ($rhand = null) {
     %action_delay = add(map_clock, 4);
 } else {
     %action_delay = add(map_clock, oc_param($rhand, attackrate));
-    $poison_severity = oc_param($weapon, poison_severity);
+    $poison_severity = oc_param($rhand, poison_severity);
 }
 if (%damagestyle = ^style_ranged_rapid) {
     %action_delay = sub(%action_delay, 1);

--- a/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -12,6 +12,14 @@ if (%action_delay > map_clock) {
 }
 // this can be either the quiver or rhand.
 def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
+if ($rhand = null) {
+    %action_delay = add(map_clock, 4);
+} else {
+    %action_delay = add(map_clock, oc_param($rhand, attackrate));
+}
+if (%damagestyle = ^style_ranged_rapid) {
+    %action_delay = sub(%action_delay, 1);
+}
 def_obj $ammo = ~player_ranged_check_ammo($rhand);
 if ($ammo = null) {
     p_stopaction;
@@ -34,6 +42,12 @@ if (~pvp_hit_roll(%damagetype) = true) {
     ~give_combat_experience_pvp(%damagestyle, $damage, ~pvp_xp_multiplier(~.player_combat_level));
     both_heropoints($damage);
 }
+
+def_int $poison_severity = oc_param($ammo, poison_severity);
+if ($damage > 0 & $poison_severity > 0 & random(4) = 0) { // 1/4 chance to poison
+    .queue(poison_player, 0, $poison_severity);
+}
+
 def_int $delay = ~pvp_ranged_use_weapon($rhand, $ammo);
 anim(%com_attackanim, 0);
 sound_synth(%com_attacksound, 0, 0);
@@ -45,19 +59,6 @@ sound_synth(%com_attacksound, 0, 0);
 .anim(.%com_defendanim, $delay);
 // .sound_synth(.%com_defendsound, 0, 20);
 // sound_synth(.%com_defendsound, 0, 20);
-
-if ($rhand = null) {
-    %action_delay = add(map_clock, 4);
-} else {
-    %action_delay = add(map_clock, oc_param($rhand, attackrate));
-    def_int $poison_severity = oc_param($ammo, poison_severity);
-    if ($damage > 0 & $poison_severity > 0 & random(4) = 0) { // 1/4 chance to poison
-        .queue(poison_player, 0, $poison_severity);
-    }
-}
-if (%damagestyle = ^style_ranged_rapid) {
-    %action_delay = sub(%action_delay, 1);
-}
 
 ~ranged_dropammo_pvp($ammo, 5, sub(divide($delay, 30), 2));
 

--- a/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -12,12 +12,10 @@ if (%action_delay > map_clock) {
 }
 // this can be either the quiver or rhand.
 def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
-def_int $poison_severity = 0;
 if ($rhand = null) {
     %action_delay = add(map_clock, 4);
 } else {
     %action_delay = add(map_clock, oc_param($rhand, attackrate));
-    $poison_severity = oc_param($rhand, poison_severity);
 }
 if (%damagestyle = ^style_ranged_rapid) {
     %action_delay = sub(%action_delay, 1);
@@ -44,7 +42,7 @@ if (~pvp_hit_roll(%damagetype) = true) {
     ~give_combat_experience_pvp(%damagestyle, $damage, ~pvp_xp_multiplier(~.player_combat_level));
     both_heropoints($damage);
 }
-
+def_int $poison_severity = oc_param($ammo, poison_severity); // ammo will never be null
 if ($damage > 0 & $poison_severity > 0 & random(4) = 0) { // 1/4 chance to poison
     .queue(poison_player, 0, $poison_severity);
 }


### PR DESCRIPTION
Attacking with an empty shortbow normally sets the action_delay still. With our current code, this wasn't happening in pvp