### PR TITLE
fix(bank): free space check should be based on players' membership status instead of world type

### DIFF
--- a/scripts/_test/scripts/debug/debug_others.rs2
+++ b/scripts/_test/scripts/debug/debug_others.rs2
@@ -15,4 +15,4 @@ if (p_finduid(uid) = true) {
 }
 
 [debugproc,members]
-mes("Your membership status is: <tostring(player_members)>");
+mes("Your membership status is: <tostring(playermember)>");

--- a/scripts/_test/scripts/debug/debug_others.rs2
+++ b/scripts/_test/scripts/debug/debug_others.rs2
@@ -13,3 +13,6 @@ midi_jingle(^sailing_journey_jingle, ^sailing_journey_jingle_millis);
 if (p_finduid(uid) = true) {
     ~objbox($obj, "You've found <~add_article(oc_name($obj))>!", 250, ^objbox_width, 0);
 }
+
+[debugproc,members]
+mes("Your membership status is: <tostring(player_members)>");

--- a/scripts/engine.rs2
+++ b/scripts/engine.rs2
@@ -489,6 +489,8 @@
 [command,wealth_event](int $eventType, string $name, int $count, int $value)
 // info: Toggle the player's run-mode
 [command,p_run](int $state)
+// info: Check player's membership status
+[command,player_members]()(int)
 
 // Npc ops (2500-2999)
 // info: Get access to the npc if they are in the world

--- a/scripts/engine.rs2
+++ b/scripts/engine.rs2
@@ -490,7 +490,7 @@
 // info: Toggle the player's run-mode
 [command,p_run](int $state)
 // info: Check player's membership status
-[command,player_members]()(int)
+[command,playermember]()(int)
 
 // Npc ops (2500-2999)
 // info: Get access to the npc if they are in the world

--- a/scripts/interface_bank/scripts/bank.rs2
+++ b/scripts/interface_bank/scripts/bank.rs2
@@ -99,7 +99,7 @@ if (~bank_find_obj_unbankable($obj) = true) {
     return(true);
 }
 
-if (player_members = ^false) {
+if (playermember = ^false) {
     // check for f2p bank limits, use the player's membership status rather than world type
     if ((inv_total(bank, oc_uncert($obj)) = 0) & (sub(inv_size(bank), inv_freespace(bank)) >= ^bank_free_slots)) {
         // https://youtu.be/yv-H5-IoRLs?t=9 (2006)

--- a/scripts/interface_bank/scripts/bank.rs2
+++ b/scripts/interface_bank/scripts/bank.rs2
@@ -99,8 +99,8 @@ if (~bank_find_obj_unbankable($obj) = true) {
     return(true);
 }
 
-if (map_members = ^false) {
-    // check for f2p bank limits.
+if (player_members = ^false) {
+    // check for f2p bank limits, use the player's membership status rather than world type
     if ((inv_total(bank, oc_uncert($obj)) = 0) & (sub(inv_size(bank), inv_freespace(bank)) >= ^bank_free_slots)) {
         // https://youtu.be/yv-H5-IoRLs?t=9 (2006)
         // https://web.archive.org/web/20041126073829/http://img39.imageshack.us/img39/3412/firemaking.jpg (2004)


### PR DESCRIPTION
This changes the free space check for the bank to check the player's membership status instead of world type. This allows members who are logged into f2p worlds to use all of their bank slots.

Greetz to @AmVoidGuy for the source: https://www.neoseeker.com/forums/2410/t581056-members-question/#m9338051

Requires https://github.com/LostCityRS/Engine-TS/pull/12 engine-side to function.

Old behavior (member=1 player logged into NODE_MEMBERS=false world):
![image](https://github.com/user-attachments/assets/372739c5-0fc3-441c-96d4-8a97648de024)

New behavior:
![image](https://github.com/user-attachments/assets/0b2036a1-eed6-4a6d-aa9a-d0bb2238b6b3)




