### PR TITLE
refactor: organize ranged ammo logic into procs

### DIFF
--- a/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -136,7 +136,9 @@ inv_del(worn, $ammo, $count);
 
 [proc,ranged_dropammo_npc](obj $ammo, int $chance, int $delay)
 if (random($chance) ! 0 | $chance = ^true) {
-    world_delay($delay);
+    if ($delay >= 0) {
+        world_delay($delay);
+    }
     if (map_blocked(npc_coord) = false) {
         obj_add(npc_coord, enum(obj, namedobj, ranged_ammo, $ammo), 1, ^lootdrop_duration);
     }

--- a/scripts/skill_combat/scripts/player/player_ranged.rs2
+++ b/scripts/skill_combat/scripts/player/player_ranged.rs2
@@ -117,18 +117,22 @@ switch_category(oc_category($rhand)) {
 [proc,ranged_shoot_npc](obj $ammo)(int)
 if($ammo = ogre_arrow) spotanim_pl(oc_param($ammo, proj_launch), 50, 0);
 else spotanim_pl(oc_param($ammo, proj_launch), 96, 0);
-inv_del(worn, $ammo, 1);
+~ranged_delammo_npc($ammo, 1);
 return(~npc_projectile(coord, npc_uid, oc_param($ammo, proj_travel), 40, 36, 41, 15, 5, 11, 5));
 
 [proc,ranged_throw_npc](obj $ammo)(int)
 spotanim_pl(oc_param($ammo, proj_launch), 96, 0);
-inv_del(worn, $ammo, 1);
+~ranged_delammo_npc($ammo, 1);
 if (inv_total(worn, $ammo) = 0) {
     mes("That was your last one!");
     p_stopaction;
     ~update_all(inv_getobj(worn, ^wearpos_rhand));
 }
 return(~npc_projectile(coord, npc_uid, oc_param($ammo, proj_travel), 40, 36, 32, 15, 0, 11, 5));
+
+// centralizes logic for the future just incase
+[proc,ranged_delammo_npc](obj $ammo, int $count)
+inv_del(worn, $ammo, $count);
 
 [proc,ranged_dropammo_npc](obj $ammo, int $chance, int $delay)
 if (random($chance) ! 0 | $chance = ^true) {

--- a/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -80,9 +80,9 @@ return($delay);
 
 [proc,ranged_delammo_pvp](obj $ammo, int $count)
 if (~in_duel_arena(coord) = true) {
-    inv_moveitem(worn, duelarrows, $ammo, 1); // give rangers their arrows back from duels
+    inv_moveitem(worn, duelarrows, $ammo, $count); // give rangers their arrows back from duels
 } else {
-    inv_del(worn, $ammo, 1);
+    inv_del(worn, $ammo, $count);
 }
 
 [proc,ranged_dropammo_pvp](obj $ammo, int $chance, int $delay)

--- a/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -93,7 +93,9 @@ if (~in_duel_arena(coord) = true) {
     return;
 }
 if (random($chance) ! 0) {
-    world_delay($delay);
+    if ($delay >= 0) {
+        world_delay($delay);
+    }
     if (map_blocked(.coord) = false) {
         obj_add(.coord, enum(obj, namedobj, ranged_ammo, $ammo), 1, ^lootdrop_duration);
     }

--- a/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_ranged.rs2
@@ -64,11 +64,7 @@ if (%damagestyle = ^style_ranged_rapid) {
 
 [proc,pvp_ranged_use_weapon](obj $rhand, obj $ammo)(int)
 spotanim_pl(oc_param($ammo, proj_launch), 96, 0);
-if (~in_duel_arena(coord) = true) {
-    inv_moveitem(worn, duelarrows, $ammo, 1); // give rangers their arrows back from duels
-} else {
-    inv_del(worn, $ammo, 1);
-}
+~ranged_delammo_pvp($ammo, 1);
 def_int $delay = 30;
 switch_category(oc_category($rhand)) {
     case weapon_bow, weapon_crossbow :
@@ -81,6 +77,13 @@ switch_category(oc_category($rhand)) {
         $delay = ~player_projectile(coord, .coord, .uid, oc_param($ammo, proj_travel), 40, 36, 32, 15, 0, 11, 5);
 }
 return($delay);
+
+[proc,ranged_delammo_pvp](obj $ammo, int $count)
+if (~in_duel_arena(coord) = true) {
+    inv_moveitem(worn, duelarrows, $ammo, 1); // give rangers their arrows back from duels
+} else {
+    inv_del(worn, $ammo, 1);
+}
 
 [proc,ranged_dropammo_pvp](obj $ammo, int $chance, int $delay)
 if (~in_duel_arena(coord) = true) {


### PR DESCRIPTION
for 225 and 244. Organizes some logic and adds an extra check for the world_delay in ranged_dropammo procs

Range specs in 244 are a bit different than our ranged_use_weapon procs, so they'll need some custom logic. This pr organizes some of the ammo logic into procs (and centralizes logic like duel arena check, and later on clan wars check)