### PR TITLE
fix: remove inv_clear for duel & trade offers

### DIFF
--- a/scripts/interface_trade/scripts/trade.rs2
+++ b/scripts/interface_trade/scripts/trade.rs2
@@ -52,14 +52,12 @@ if (.%tradepartner = uid & %tradestatus = ^tradestatus_received) {
     }
     if_settext(trademain:status, "");
     if_settext(trademain:otherplayer, "Trading With: <.displayname>");
-    inv_clear(tradeoffer);
     inv_transmit(tradeoffer, trademain:inv);
     invother_transmit(.uid, tradeoffer, trademain:otherinv);
     inv_transmit(inv, tradeside:inv);
 
     .if_settext(trademain:status, "");
     .if_settext(trademain:otherplayer, "Trading With: <displayname>");
-    .inv_clear(tradeoffer);
     .inv_transmit(tradeoffer, trademain:inv);
     .invother_transmit(uid, tradeoffer, trademain:otherinv);
     .inv_transmit(inv, tradeside:inv);

--- a/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
+++ b/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
@@ -29,14 +29,12 @@ if (.%duelpartner = uid & %duelstatus = ^duelstatus_received) {
     %duel_settings = 0;
     if_settext(duel_select_type:status, "");
     if_settext(duel_select_type:otherplayer, "Dueling with: <.displayname>");
-    inv_clear(dueloffer);
     inv_transmit(dueloffer, duel_select_type:inv);
     invother_transmit(.uid, dueloffer, duel_select_type:otherinv);
     inv_transmit(inv, duel_side:inv);
 
     .if_settext(duel_select_type:status, "");
     .if_settext(duel_select_type:otherplayer, "Dueling with: <displayname>");
-    .inv_clear(dueloffer);
     .inv_transmit(dueloffer, duel_select_type:inv);
     .invother_transmit(uid, dueloffer, duel_select_type:otherinv);
     .inv_transmit(inv, duel_side:inv);


### PR DESCRIPTION
For all revs

from [video](https://youtu.be/ZJ1w9N4HNYU?si=JsSwcBYMVSrby7dC):

- First they put up a glory into the dueloffer and start the duel

https://github.com/user-attachments/assets/087f93b6-d8e6-404b-a4a8-c146d591e3a8

- Next they get force teleported out of the duel (without clearing dueloffer)

https://github.com/user-attachments/assets/cfea9b89-79c0-4c11-8ea3-3289c9f99ec4

- Finally they send another duel offer, with the glory from before staying in the dueloffer

https://github.com/user-attachments/assets/2a3b1ae6-ee84-4b83-899d-06ceb1b62b9f

