### PR TITLE
fix: remove complete tutorial code in login.rs2

### DIFF
--- a/scripts/login_logout/login.rs2
+++ b/scripts/login_logout/login.rs2
@@ -49,16 +49,9 @@ if(inzone(movecoord(^grandtree_jail_coord, 0, 0, -2), movecoord(^grandtree_jail_
     ~grandtree_spawn_charlie;
 }
 
-if (%tutorial_progress < ^tutorial_complete) {
-     if (~in_tutorial_island(coord) = false & %tutorial_progress < ^tutorial_complete) {
-        // Checking if you're off tutorial island but it's not complete
-        ~update_bas;
-        @tutorial_complete;
-    } else {
-        // Starting tutorial regularly
-        ~update_bas;
-        @start_tutorial;
-    }
+if (%tutorial_progress < ^tutorial_complete & ~in_tutorial_island(coord) = true) {
+    ~update_bas;
+    @start_tutorial;
 }
 ~initalltabs;
 ~update_all(inv_getobj(worn, ^wearpos_rhand));


### PR DESCRIPTION
Code before this would teleport you to lumbridge if you relog outside of tutorial island (if you didnt complete it somehow). Anecdotal evidence suggests this didnt exist, relogging just reset the tabs and tutorial island hud