### PR TITLE
fix: special attack fixes

### DIFF
--- a/scripts/skill_combat/scripts/player/specwep.rs2
+++ b/scripts/skill_combat/scripts/player/specwep.rs2
@@ -54,9 +54,10 @@ if (~duel_arena_spec_check = false) {
 if (~sa_enough_energy = false) {
     return;
 }
-if(inv_getobj(worn, ^wearpos_rhand) = dragon_battleaxe) {
+def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
+if($weapon = dragon_battleaxe) {
     if(p_finduid(uid) = true) { // strongqueued in osrs, assuming its like settings stuff and doesnt queue
-        %sa_energy = sub(%sa_energy, 1000);
+        ~set_sa_vars(oc_param($weapon, sa_energy));
         say("Raarrrrrgggggghhhhhhh!");
         anim(rampage, 0);
         spotanim_pl(sp_attackglow_red, 0, 0);
@@ -87,9 +88,10 @@ if (~duel_arena_spec_check = false) {
 if (~sa_enough_energy = false) {
     return;
 }
-if(inv_getobj(worn, ^wearpos_rhand) = excalibur) {
+def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
+if($weapon = excalibur) {
     if(p_finduid(uid) = true) { // strongqueued in osrs, assuming its like settings stuff and doesnt queue
-        %sa_energy = sub(%sa_energy, 1000);
+        ~set_sa_vars(oc_param($weapon, sa_energy));
         say("For Camelot!");
         anim(sanctuary, 0);
         spotanim_pl(sp_attackglow_blue, 0, 0);

--- a/scripts/skill_combat/scripts/player/specwep.rs2
+++ b/scripts/skill_combat/scripts/player/specwep.rs2
@@ -8,10 +8,6 @@ return(false);
 if (%sa_energy < oc_param(inv_getobj(worn, ^wearpos_rhand), sa_energy)) {
     mes("You don't have enough power left.");
     %sa_attack = ^false;
-    // If players attempt to use a special attack with insufficient energy then they'll find that instead 
-    // of a special attack failing and no attack occurring, a regular attack will instead be performed.
-    // - https://oldschool.runescape.wiki/w/Update:PvM_QoL_updates_%26_Wilderness_Rejuvenation_improvements
-    p_stopaction; // based on the way ive implemented specs, this is necessary to produce the behavior above.
     return(false);
 }
 return(true);

--- a/scripts/skill_combat/scripts/pvp/pvp_special_attack.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_special_attack.rs2
@@ -11,6 +11,10 @@ if (%action_delay > map_clock) {
     return;
 }
 if (~sa_enough_energy = false) {
+    // If players attempt to use a special attack with insufficient energy then they'll find that instead 
+    // of a special attack failing and no attack occurring, a regular attack will instead be performed.
+    // - https://oldschool.runescape.wiki/w/Update:PvM_QoL_updates_%26_Wilderness_Rejuvenation_improvements
+    // p_stopaction; // based on the way ive implemented specs, this is necessary to produce the behavior above.
     return;
 }
 if (~duel_arena_spec_check = false) {

--- a/scripts/skill_combat/scripts/pvp/specs/scripts/pvp_dragon_mace.rs2
+++ b/scripts/skill_combat/scripts/pvp/specs/scripts/pvp_dragon_mace.rs2
@@ -13,7 +13,7 @@ if (randominc($attack_roll) > randominc($defence_roll)) {
     ~give_combat_experience_pvp(%damagestyle, $damage, ~pvp_xp_multiplier(~.player_combat_level));
     both_heropoints($damage);
 }
-anim(sp_attack_shatter_spotanim, 0);
+anim(shatter, 0);
 sound_synth(shatter, 0, 0);
 spotanim_pl(sp_attack_shatter_spotanim, 96, 0);
 .anim(.%com_defendanim, 20);


### PR DESCRIPTION
- dragon mace spec used the wrong anim
- p_stopaction was called in ~sa_enough_energy, which didnt always guarantee protected access
- excalibur and dragon battle axe didnt start the special attack timer.

The reasoning for the p_stopaction in ~sa_enough_energy in the first place was because you can have multiple interaction attempts in the engine in certain scenarios. If you melee spec as you're moving to the target for example, you will try to interact multiple times:

https://github.com/user-attachments/assets/5bead3a3-4272-4d11-9c0b-bc209b8bf3b9

As you can see without p_stopaction, it doesnt exactly consume your attack in every scenario. We need to find a video of this to confirm. But for now I think the simplest solution is to just have no p_stopaction at all. Alternatively we could have p_stopaction in @pvp_special_attack and @player_special_attack, but again I'd like to find some video evidence of how this specific edge case worked.