### PR TITLE
fix: special mes for hold spells in no movement duels

### DIFF
--- a/scripts/player/scripts/walktrigger.rs2
+++ b/scripts/player/scripts/walktrigger.rs2
@@ -1,6 +1,0 @@
-// no idea if this is the right approach, might need some refactoring.
-[proc,high_priority_walktrigger_exists]()(boolean)
-if (getwalktrigger() = duel_arena_no_move) {
-    return(true);
-}
-return(false);

--- a/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_magic.rs2
@@ -97,6 +97,10 @@ if (db_getfield($spell_data, magic_spell_table:freeze_time, 0) > 0) {
         return(false);
     }
 }
+if (getwalktrigger() = duel_arena_no_move) {
+    mes("You can not use a hold spell in a no movement duel."); // https://www.youtube.com/watch?v=u2KZbLyCpgI&t=345s
+    return(false);
+}
 return(true);
 
 
@@ -147,9 +151,6 @@ while ($i < db_getfieldcount($spell_data, magic_spell_table:stat_change)) {
 }
 
 [proc,pvp_freeze_effect](dbrow $spell_data)
-if (~high_priority_walktrigger_exists = true) {
-    return;
-}
 def_int $freeze_time = db_getfield($spell_data, magic_spell_table:freeze_time, 0);
 if ($freeze_time > 0) {
     if (~.check_protect_prayer(^magic_style) = true) {


### PR DESCRIPTION
from [video](https://www.youtube.com/watch?v=u2KZbLyCpgI&t=345s):
![VS--YouTube-stakingatduelarenarunescape-5’49”](https://github.com/user-attachments/assets/ca4fdc31-5360-4eda-96b9-6bc9944d7970)


before this video, I just assumed there was no walktrigger called and the spell would go through. But it looks like it stopped the spell entirely, this can be easily implemented in our ~pvp_freeze_allowed proc