### PR TITLE
Fix content: missing magic level requirements. 225/244

### DIFF
--- a/scripts/areas/area_mage_arena/scripts/god_gear.rs2
+++ b/scripts/areas/area_mage_arena/scripts/god_gear.rs2
@@ -1,27 +1,47 @@
-[opheld2,saradomin_cape] if (~check_conflicting_god_staff(zamorak_staff, guthix_staff) = true) ~equip(last_slot);
-[opheld2,zamorak_cape] if (~check_conflicting_god_staff(saradomin_staff, guthix_staff) = true) ~equip(last_slot);
-[opheld2,guthix_cape] if (~check_conflicting_god_staff(saradomin_staff, zamorak_staff) = true) ~equip(last_slot);
+//[opheld2,saradomin_cape] if (~check_conflicting_god_staff(zamorak_staff, guthix_staff) = true) ~equip(last_slot);
+//[opheld2,zamorak_cape] if (~check_conflicting_god_staff(saradomin_staff, guthix_staff) = true) ~equip(last_slot);
+//[opheld2,guthix_cape] if (~check_conflicting_god_staff(saradomin_staff, zamorak_staff) = true) ~equip(last_slot);
 
-[opheld2,saradomin_staff] if (~check_conflicting_god_cape(zamorak_cape, guthix_cape) = true) ~equip(last_slot);
-[opheld2,zamorak_staff] if (~check_conflicting_god_cape(saradomin_cape, guthix_cape) = true) ~equip(last_slot);
-[opheld2,guthix_staff] if (~check_conflicting_god_cape(saradomin_cape, zamorak_cape) = true) ~equip(last_slot);
+//[opheld2,saradomin_staff] if (~check_conflicting_god_cape(zamorak_cape, guthix_cape) = true) ~equip(last_slot);
+//[opheld2,zamorak_staff] if (~check_conflicting_god_cape(saradomin_cape, guthix_cape) = true) ~equip(last_slot);
+//[opheld2,guthix_staff] if (~check_conflicting_god_cape(saradomin_cape, zamorak_cape) = true) ~equip(last_slot);
 
+//[proc,check_conflicting_god_cape](namedobj $item1, namedobj $item2)(boolean)
+//if (inv_total(worn, $item1) > 0 | inv_total(worn, $item2) > 0) {
+//    mes("You may not wield this staff whilst wearing the cape of another god.");
+//    mes("The conflicting powers of staff and cape drive them apart.");
+//    return(false);
+//}
+//return(true);
 
-[proc,check_conflicting_god_cape](namedobj $item1, namedobj $item2)(boolean)
-if (inv_total(worn, $item1) > 0 | inv_total(worn, $item2) > 0) {
-    mes("You may not wield this staff whilst wearing the cape of another god.");
-    mes("The conflicting powers of staff and cape drive them apart.");
-    return(false);
+//[proc,check_conflicting_god_staff](namedobj $item1, namedobj $item2)(boolean)
+//if (inv_total(worn, $item1) > 0 | inv_total(worn, $item2) > 0) {
+//    mes("You may not wear this cape whilst wielding the staff of another god.");
+//    mes("The conflicting powers of staff and cape drive them apart.");
+//    return(false);
+//}
+//return(true);
+
+[opheld2,saradomin_cape] @require_magic_and_conflict(60, last_slot, zamorak_staff, guthix_staff);
+[opheld2,zamorak_cape] @require_magic_and_conflict(60, last_slot, saradomin_staff, guthix_staff);
+[opheld2,guthix_cape] @require_magic_and_conflict(60, last_slot, saradomin_staff, zamorak_staff);
+
+[opheld2,saradomin_staff] @require_magic_and_conflict(60, last_slot, zamorak_cape, guthix_cape);
+[opheld2,zamorak_staff] @require_magic_and_conflict(60, last_slot, saradomin_cape, guthix_cape);
+[opheld2,guthix_staff] @require_magic_and_conflict(60, last_slot, saradomin_cape, zamorak_cape);
+
+[label,require_magic_and_conflict](int $level, int $slot, namedobj $item1, namedobj $item2)
+if (stat_base(magic) < $level) {
+    mes("You are not a high enough level to use this item.");
+    mes("You need to have a Magic level of <tostring($level)>.");   //Try to confirm this. Should magic be with Caps or without?
+    return;
 }
-return(true);
-
-[proc,check_conflicting_god_staff](namedobj $item1, namedobj $item2)(boolean)
 if (inv_total(worn, $item1) > 0 | inv_total(worn, $item2) > 0) {
     mes("You may not wear this cape whilst wielding the staff of another god.");
     mes("The conflicting powers of staff and cape drive them apart.");
-    return(false);
+    return;
 }
-return(true);
+~equip($slot);
 
 [opheld5,saradomin_cape] @drop_god_cape;
 [opheld5,zamorak_cape] @drop_god_cape;

--- a/scripts/levelrequire/scripts/levelrequire.rs2
+++ b/scripts/levelrequire/scripts/levelrequire.rs2
@@ -27,6 +27,14 @@ if (stat_base(ranged) < $level) {
 }
 ~equip($slot);
 
+[label,levelrequire_magic](int $level, int $slot)
+if (stat_base(magic) < $level) {
+    mes("You are not a high enough level to use this item.");
+    mes("You need to have a magic level of <tostring($level)>.");   //Try to confirm this. Should magic be with Caps or without?
+    return;
+}
+~equip($slot);
+
 [label,levelrequire_magic_and_attack](int $magic_level, int $attack_level, int $slot)
 if (stat_base(magic) < $magic_level | stat_base(attack) < $attack_level) {
     mes("You are not a high enough level to use this item.");

--- a/scripts/levelrequire/scripts/tier20.rs2
+++ b/scripts/levelrequire/scripts/tier20.rs2
@@ -39,3 +39,4 @@
 [opheld2,mithril_javelin_p] @levelrequire_ranged(20, last_slot);
 
 // Magic
+[opheld2,boots_wizard] @levelrequire_magic(20, last_slot);


### PR DESCRIPTION
*Mage Arena capes/staves now have a level requirement of 60 magic.
*wizards boots now have a level requirement of 20 magic.