### PR TITLE
fix: Require using knife on webs to slash them

### DIFF
--- a/scripts/general/scripts/slash_checker.rs2
+++ b/scripts/general/scripts/slash_checker.rs2
@@ -9,9 +9,6 @@ if (inv_getobj(worn, ^wearpos_rhand) ! null) {
 
 // Post June 14th 2023: https://oldschool.runescape.wiki/w/Update:Ruinous_Powers_Beta_v2
 // Prior to this, weapon was required to be equipped to slash (noted webs, assumed any instance fo this.)
-if (inv_total(inv, knife) > 0) {
-    return (knife);
-}
 
 // Nothing functional found, return null.
 return (null);


### PR DESCRIPTION
This is for 244 as well.

Removing the inventory check for a knife on slashing a web as it should only work when using the knife on the web.

Posts from '05 and '06 stating that you must use the knife on the web to slash it:
https://www.neoseeker.com/forums/2410/t538079-wheres-this-lever/#m8470248
https://www.rsbandb.com/forums/viewtopic.php?f=2&t=27837

This wiki also states that you need to use a knife on a cactus, and they should use the same slash check logic: 
https://runescape.fandom.com/wiki/Cactus