### PR TITLE
fix: move wildy warning from login to zone trigger with extra checks

### DIFF
--- a/scripts/areas/area_wilderness/configs/wilderness_levels.constant
+++ b/scripts/areas/area_wilderness/configs/wilderness_levels.constant
@@ -1,2 +1,3 @@
 ^wilderness_starting_z = 3520
 ^wilderness_warning_z = 3512
+^wilderness_warning_underground_z = 9912

--- a/scripts/areas/area_wilderness/scripts/wilderness_warning.rs2
+++ b/scripts/areas/area_wilderness/scripts/wilderness_warning.rs2
@@ -3,18 +3,21 @@
 // https://youtu.be/dpOJn0HyTx4?t=52
 // https://youtu.be/jdcT9ogpMwE?t=104 underground
 // all on the same z axis
-
-// remove wildy warning if logged in at wildy border https://youtu.be/hiUfg8MsKMo
-[proc,wilderness_warning_login]
-if (inzone(0_45_54_48_56, 0_52_54_63_63, coord) = true | inzone(0_48_154_56_56, 0_48_154_63_63, coord) = true) {
-    %wilderness = ^true;
-}
-
 [queue,wilderness_warning]
+// so there seems to be a check to see if you're south of the wildy warning zone.
+// Videos of people logging in on *north* of the zone yields no wildy warning:
+// - https://youtu.be/0OceTxHT0X0
+// - https://youtu.be/hiUfg8MsKMo
+// Whereas videos of people logging in *south* of the zone yields a wildy warning:
+// - https://youtu.be/rvljzSEQXLQ?t=278
+// - https://youtu.be/0OceTxHT0X0
+def_int $coordz = coordz(coord);
 if (%wilderness = ^false) {
     %wilderness = ^true;
-    p_stopaction;
-    if_openmain(wilderness_warning);
+    if (($coordz < add(^wilderness_warning_z, 4) & $coordz >= ^wilderness_warning_z) | ($coordz < add(^wilderness_warning_underground_z, 4) & $coordz >= ^wilderness_warning_underground_z)) {
+        p_stopaction;
+        if_openmain(wilderness_warning);
+    }
 }
 
 [zone,0_45_54_48_56] queue(wilderness_warning, 0);

--- a/scripts/login_logout/login.rs2
+++ b/scripts/login_logout/login.rs2
@@ -43,7 +43,6 @@ queue(macro_event_login, 0);
 ~ferment_wines_login;
 ~thieving_stall_timers_login;
 ~stat_boost_login; // f2p boost reset
-~wilderness_warning_login; // remove wildy warning if logged in at wildy border https://youtu.be/hiUfg8MsKMo
 
 if(inzone(movecoord(^grandtree_jail_coord, 0, 0, -2), movecoord(^grandtree_jail_coord, 3, 0, 2), coord) = true) {
     ~grandtree_spawn_charlie;


### PR DESCRIPTION
For 225-244

We found more videos of people logging in near the wilderness border! The conclusion we came to: Instead of `inzone()` checks in the login trigger, it just checked if you were at the southern portion of the wilderness warning zone.

Videos where they login *south* of the zone:
- [Video 1](https://youtu.be/rvljzSEQXLQ?t=278):

https://github.com/user-attachments/assets/d10c622d-a32b-4ce4-b736-193f29b49304

- [Video 2](https://youtu.be/EQq8t8GdN5I)

https://github.com/user-attachments/assets/7fad1bf4-fddc-482b-b4ed-e5229b442f32


Videos where they login *north* of the zone:
- [Video 1](https://youtu.be/hiUfg8MsKMo)

https://github.com/user-attachments/assets/b95a49b9-2fd4-4ccf-8f0f-76de013f156b

- [Video 2](https://youtu.be/0OceTxHT0X0)

https://github.com/user-attachments/assets/5befe50f-4651-4f0d-9944-1e835c9627f0

