### PR TITLE
feat(content): support musicmulti_7 varp (cosmic altar)

### DIFF
--- a/scripts/_test/scripts/cheats/cheat_music.rs2
+++ b/scripts/_test/scripts/cheats/cheat_music.rs2
@@ -6,6 +6,7 @@ if (p_finduid(uid) = true) {
     %music4 = 0;
     %music5 = 0;
     %music6 = 0;
+    %musicmulti_7 = 0;
 } else {
     @please_finish;
 }
@@ -18,6 +19,7 @@ if (p_finduid(uid) = true) {
     %music4 = 0xFFFFFFFF;
     %music5 = 0xFFFFFFFF;
     %music6 = 0xFFFFFFFF;
+    %musicmulti_7 = 0xFFFFFFFF;
 } else {
     @please_finish;
 }

--- a/scripts/_unpack/244/all.varp
+++ b/scripts/_unpack/244/all.varp
@@ -5,6 +5,7 @@
 [musiclength]
 
 [musicmulti_7]
+scope=perm
 transmit=yes
 
 [elemental_workshop_bits]

--- a/scripts/music/configs/music.dbrow
+++ b/scripts/music/configs/music.dbrow
@@ -920,6 +920,12 @@ data=name,Understanding
 data=playbutton,music:understanding
 data=unlock,6,27
 
+[music_Stratosphere]
+table=music
+data=name,Stratosphere
+data=playbutton,music:stratosphere
+data=unlock,7,3
+
 [music_Unknown_Land]
 table=music
 data=name,Unknown Land

--- a/scripts/music/configs/musicregion.dbrow
+++ b/scripts/music/configs/musicregion.dbrow
@@ -31,7 +31,7 @@ data=name,Iban
 [musicregion_33_75]
 table=musicregion
 data=mapsquare,0_33_75_0_0
-data=name,Quest
+data=name,Stratosphere
 
 [musicregion_34_75]
 table=musicregion

--- a/scripts/music/scripts/music.rs2
+++ b/scripts/music/scripts/music.rs2
@@ -11,6 +11,8 @@ if ($var = 1) {
     return(%music5);
 } else if ($var = 6) {
     return(%music6);
+} else if ($var = 7) {
+    return(%musicmulti_7);
 }
 return(null);
 
@@ -27,6 +29,8 @@ if ($var = 1) {
     %music5 = setbit(%music5, $bit);
 } else if ($var = 6) {
     %music6 = setbit(%music6, $bit);
+} else if ($var = 7) {
+    %musicmulti_7 = setbit(%musicmulti_7, $bit);
 }
 
 [proc,music_playbybutton](component $playbutton)


### PR DESCRIPTION
This adds `musicmulti_7` to the music varps used by the content scripts. Bit 3 is used for the Stratosphere song, unlocked at the Cosmic Altar.

- ::~unlockalltracks updated for new varp
- ::~lockalltracks updated for new varp
- Added dbrow for Stratosphere
- Cosmic Altar music corrected from Quest (which is for the Fire Altar) to Stratosphere

---
### Sources

https://oldschool.runescape.wiki/w/Stratosphere
https://oldschool.runescape.wiki/w/Quest_(music_track)
