### PR TITLE
fix: remove scatter and noting when ignoring random events

### DIFF
--- a/scripts/macro events/scripts/general/macro_event_genie.rs2
+++ b/scripts/macro events/scripts/general/macro_event_genie.rs2
@@ -30,11 +30,7 @@ if (finduid(%npc_macro_event_target) = true) {
         npc_say("No one ignores me!");
         npc_anim(human_castteleport, 0);
         %macro_event = ^no_macro_event;
-        if (random(2) = 0 & inv_freespace(inv) < inv_size(inv)) { // 50% chance to teleport or scatter inv. Only scatter if they actually have items
-            queue(macro_event_fail_scatter_inv, 0);
-        } else {
-            queue(macro_event_fail_teleport, 0);
-        }
+        queue(macro_event_fail_teleport, 0);
         npc_delay(0);
         npc_del;
         return;

--- a/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
+++ b/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
@@ -36,7 +36,6 @@ if (finduid(%npc_macro_event_target) = true) {
         %macro_event = ^no_macro_event;
         // https://youtu.be/Ai89wqupYqA?t=45
         queue(macro_event_fail_teleport, 0);
-        queue(macro_event_fail_note_inv, 0);
         npc_delay(0);
         npc_del;
         return;

--- a/scripts/macro events/scripts/macro_events.rs2
+++ b/scripts/macro events/scripts/macro_events.rs2
@@ -124,49 +124,6 @@ sound_synth(smokepuff2, 0, 0);
 //--
 ~p_telejump_safe($teleport_coord); // todo: Confirm this
 
-
-[queue,macro_event_fail_scatter_inv]
-session_log(^log_adventure, "Failed random event and had their items scattered");
-%macro_event = ^no_macro_event;
-p_delay(1);
-def_int $i = 0;
-while ($i < inv_size(inv)) {
-    def_obj $obj = inv_getobj(inv, $i);
-    if ($obj ! null & oc_tradeable($obj) = true) {
-        def_coord $coord = map_findsquare(coord, 0, 5, ^map_findsquare_lineofwalk); // 11x11 for now. todo: confirm how scattering works
-        inv_dropslot(inv, $coord, $i, ^lootdrop_duration);
-        spotanim_map(smokepuff, $coord, 124, 0);
-    }
-    $i = calc($i + 1);
-}
-
-// not sure if this is a thing but people seem to remember it being a thing
-[queue,macro_event_fail_note_inv]
-session_log(^log_adventure, "Failed random event and had their items noted");
-def_int $i = 0;
-while ($i < inv_size(inv)) {
-    def_obj $obj = inv_getobj(inv, $i);
-    // make sure the item is not stackable, and not already noted
-    if ($obj ! null & oc_stackable($obj) = false & oc_cert($obj) ! $obj) {
-        // cert the item in the inv
-        inv_moveitem_cert(inv, inv, $obj, inv_total(inv, $obj));
-    }
-    $i = calc($i + 1);
-}
-def_obj $prev = inv_getobj(worn, ^wearpos_rhand);
-$i = 0;
-while ($i < inv_size(worn)) {
-    def_obj $obj = inv_getobj(worn, $i);
-    // make sure the item is not stackable, and not already noted
-    if ($obj ! null & oc_stackable($obj) = false & oc_cert($obj) ! $obj) {
-        // cert the item and move it into the inv
-        inv_moveitem_cert(worn, inv, $obj, inv_total(worn, $obj));
-    }
-    $i = calc($i + 1);
-}
-~update_all($prev);
-
-
 // called when the npc needs to be poofed away
 [proc,macro_event_disappear]
 if (npc_findhero = ^true) {


### PR DESCRIPTION
Most old guides and official runescape manual only mention these randoms teleporting you if you ignore them. Theres really no screenshots of it happening, or people complaining about it happening. The only source we have really is just runehq's random event guide, and a couple other guides copying from it.

Theres also no indication of when the supposed scattering was removed. Theres old forum posts of people saying how they got teleported after looking away from the screen (such as https://web.archive.org/web/20050208014405/https://runehq.com/RHQInn/index.php?showtopic=63307). But theres no stories or complaints of a genie scattering someones items.

I also remove noting from random events. I think this was mostly a thing when you attempted the random and failed, like picking the wrong choice for giles:
![VS--YouTube-RS07CastleWarsItemSmuggle-RuneScapeGlitchTutorial-ftDinosaur-0’59”](https://github.com/user-attachments/assets/14cbc83d-6c72-4be3-9e6d-0e828eaf2280)
