### PR TITLE
fix: macro dwarf hp and ring of recoil op2 check

### DIFF
--- a/scripts/macro events/configs/antimacro.npc
+++ b/scripts/macro events/configs/antimacro.npc
@@ -137,7 +137,7 @@ timer=20
 strength=10
 // attack and hp is completely guessed
 attack=50
-hitpoints=25
+hitpoints=255
 // these ranges are based off https://www.youtube.com/watch?v=ohRbhtCRL2c&list=PLn23LiLYLb1bhaCSJgRd1zQet3DFcY0yG&index=4
 wanderrange=3
 maxrange=3
@@ -1453,13 +1453,13 @@ head1=model_4_npc_head
 head2=model_6_npc_head
 // https://youtu.be/Ww-PkAr4vt4?list=PLn23LiLYLb1Y3P9S9qZbijcJihiD416jT
 wanderrange=50
-maxrange=50
+maxrange=52
 timer=10
+// https://youtu.be/azxoPxBRe3c
+hitpoints=255
 attack=50
 strength=1
 param=attack_anim,dwarf_stone_launch
-param=defend_anim,dwarf_block
-param=death_anim,dwarf_death
 param=attackrate,4
 param=attack_sound,thrown
 // stats are completely guessed

--- a/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -295,7 +295,7 @@ error("style of <tostring($style)> not defined in switch for npc_combat_defenceb
 
 //  this should be strong queued. Some damage is queued, some isnt
 [queue,combat_damage_player](int $damage)
-if (inv_getobj(worn, ^wearpos_ring) = ring_of_recoil & map_members = ^true & npc_finduid(%aggressive_npc) = true & %npc_attacking_uid = uid & $damage > 0 & stat(hitpoints) > 0) {
+if (inv_getobj(worn, ^wearpos_ring) = ring_of_recoil & map_members = ^true & npc_finduid(%aggressive_npc) = true & npc_hasop(2) = true & %npc_attacking_uid = uid & $damage > 0 & stat(hitpoints) > 0) {
     // https://oldschool.runescape.wiki/w/Update:Clue_Scroll_Step_Counter
     // - "Recoil damage will now always target the entity that caused the initial damage, rather than the most recent entity to deal damage."
     def_int $recoil_damage = add(scale(10, 100, $damage), 1);


### PR DESCRIPTION
for 225-244

- macro dwarf hp set to 255, and macro swarm to match. Source is from this [video](https://youtu.be/azxoPxBRe3c), the damage in order:
`3, 12, 3, 14, 8, 1, 4, 9, 11, 4, 7, 3, 1, 7, 8, 11, 3, 14, 14, 3, 1, 4, 1, 1, 2, 9, 10, 7, 9, 4, 6, 10, 5, 2, 2, 6, 10, 8, 14, 3, 7, total = 261
`
Since the video is 5 or so minutes long, the dwarf wouldve regened around 5-6 hp. 255 hp makes the most sense.

- Our ring of recoil also allowed you to kill the macro dwarf!! In osrs the ring of recoil has an op2 check