### PR TITLE
fix: chests during watchtower

### DIFF
--- a/scripts/general_use/scripts/chests.rs2
+++ b/scripts/general_use/scripts/chests.rs2
@@ -18,7 +18,12 @@ if(map_members = ^true) {
 }
 ~open_chest(loc_param(chest_other));
 
-[oploc3,_chest_open] ~close_chest(loc_param(chest_other));
+[oploc3,_chest_open] 
+if(~is_quest_chest = true) { 
+    ~displaymessage(^dm_default);
+    return;
+}
+~close_chest(loc_param(chest_other));
 
 [oploc2,_chest_open]
 // Treasure Trail
@@ -34,6 +39,10 @@ if(map_members = ^true) {
         return;
     }
 }
+if(~is_quest_chest = true) { 
+    ~displaymessage(^dm_default);
+    return;
+}
 if (random(^findsomethingnice_chance) = 0 & ~in_tutorial_island(coord) = false) {
     mes("You search the chest..."); // guess
     p_delay(2);
@@ -41,6 +50,13 @@ if (random(^findsomethingnice_chance) = 0 & ~in_tutorial_island(coord) = false) 
     return;
 }
 mes("You find nothing."); // guess
+
+// for quest chests that use the regular open chest loc (i'm assuming they had this to prevent breaking them...)
+[proc,is_quest_chest]()(boolean)
+if(loc_coord = 1_33_71_24_34 | loc_coord = 0_40_47_15_23 | loc_coord = 0_39_47_30_24 | loc_coord = 0_39_47_15_16) {
+    return (true);
+}
+return (false);
 
 [proc,open_chest](loc $other_chest)
 p_arrivedelay;

--- a/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
+++ b/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
@@ -208,7 +208,7 @@ mes("The chest is locked.");
 if(last_useitem = toban_key) {
     if(inv_freespace(inv) = 0) {
         // Temp note: dur does not need updated ??
-        loc_change(cavewitchchestopen, 20);
+        loc_change(loc_378, 20);
         sound_synth(chest_open, 0, 0);
         ~mesbox("There is something in there.|But you don't have the free space to hold it.");
         return;
@@ -219,7 +219,7 @@ if(last_useitem = toban_key) {
 
 [label,open_toban_chest]
 // Temp note: dur does not need updated ?? @indio
-loc_change(cavewitchchestopen, 20);
+loc_change(loc_378, 20);
 sound_synth(chest_open, 0, 0);
 if(inv_total(inv, stolen_gold) > 0) {
     mes("You have already got the stolen gold.");
@@ -341,7 +341,7 @@ anim(human_openchest, 0);
 sound_synth(chest_open, 0, 0);
 p_delay(0);
 // Temp note: dur does not need updated
-loc_change(cavewitchchestopen, 300);
+loc_change(loc_378, 300);
 mes("Ahh! There is a spider inside.");
 mes("Someone's idea of a joke...");
 npc_add(coord, poisonspider, 1000);
@@ -353,7 +353,7 @@ anim(human_openchest, 0);
 sound_synth(chest_open, 0, 0);
 p_delay(0);
 // Temp note: dur does not need updated
-loc_change(cavewitchchestopen, 300);
+loc_change(loc_378, 300);
 switch_int(random(8)) {
     case 0 :
         inv_add(inv, emerald, 1);


### PR DESCRIPTION
change the watchtower quests to use the regular open chest loc instead of sharing the upass one (https://youtu.be/FjCsJTQmTVA?si=AVmNpvUabnDv-ep5&t=669), also add case checks to the open loc to prevent temporarily breaking those chests

applicable to 225-244