### PR TITLE
fix: run p_preventlogout immediately in interactions to match osrs

### DIFF
--- a/scripts/login_logout/logout.rs2
+++ b/scripts/login_logout/logout.rs2
@@ -23,3 +23,6 @@ if (p_finduid(uid) = true) {
 
     p_logout;
 }
+
+[queue,preventlogout_combat]
+p_preventlogout("You can't log out until 10 seconds after the end of combat.", 16);

--- a/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -309,7 +309,6 @@ if (inv_getobj(worn, ^wearpos_ring) = ring_of_recoil & map_members = ^true & npc
     npc_queue(2, $recoil_damage, 0);
     ~ring_of_recoil_lose_charge($recoil_damage);
 }
-p_preventlogout("You can't log out until 10 seconds after the end of combat.", 16);
 ~damage_self($damage);
 
 [proc,npc_retaliate](int $queue_delay)
@@ -326,6 +325,13 @@ if(.%npc_lastcombat < map_clock) .%npc_lastcombat = map_clock;
 %lastcombat = map_clock;
 %npc_attacking_uid = uid;
 %aggressive_npc = npc_uid;
+
+if_close;
+if (p_finduid(uid) = false) {
+    queue(preventlogout_combat, 0);
+    return;
+}
+p_preventlogout("You can't log out until 10 seconds after the end of combat.", 16);
 
 [proc,npc_check_notcombat]()(boolean)
 if (map_multiway(npc_coord) = false) { // checks npc coord ALWAYS!

--- a/scripts/skill_combat/scripts/player/auto_retaliate.rs2
+++ b/scripts/skill_combat/scripts/player/auto_retaliate.rs2
@@ -22,7 +22,6 @@ if (%auto_retaliate = ^player_auto_retaliate_on & npc_finduid($nid) = true & bus
 
 // this needs fixing, and .queue support
 [queue,pvp_retaliate](player_uid $uid)
-p_preventlogout("You can't log out until 10 seconds after the end of combat.", 16);
 if (%auto_retaliate = ^player_auto_retaliate_on & .finduid($uid) = true & busy2 = false) {
     // npc flinches player
     if (%action_delay < map_clock) {

--- a/scripts/skill_combat/scripts/pvp/pk_skull.rs2
+++ b/scripts/skill_combat/scripts/pvp/pk_skull.rs2
@@ -25,6 +25,13 @@ if (~deserves_pk_skull = true) {
 .%lastcombat_pvp = map_clock;
 .%aggressive_npc = null; // prevents npc's from attacking your opponent after you attack them.
 
+.if_close;
+if (.p_finduid(.uid) = false) {
+    .queue(preventlogout_combat, 0);
+    return;
+}
+.p_preventlogout("You can't log out until 10 seconds after the end of combat.", 16);
+
 // requires active_player
 [proc,pk_skull](int $duration)
 ~headicon_add(^headicon_skull);

--- a/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
@@ -159,9 +159,6 @@ stat_advance(hitpoints, scale($multiplier, 1000, scale(133, 100, $base)));
 
 [proc,.pvp_damage](int $delay, int $damage)
 .if_close;
-if (.p_finduid(.uid) = true) {
-    .p_preventlogout("You can't log out until 10 seconds after the end of combat.", 16);
-}
 if ($damage < 0) {
     return;
 }


### PR DESCRIPTION
for 225-244

- Osrs test 1: does recoiled damage prevent logout? 
    - Result: No
- Osrs test 2: if damage is not called (i.e. mage splash), does p_preventlogout still run in interactions?
    - Result: Yes
    - Tick 132 splash
    - Tick 148 logout
- Osrs test 3: If the player is p_delay'd, and they get attacked, does p_preventlogout run when the p_delay is over?
    - Result: Yes
