### PR TITLE
fix: Allow fishing lava eels in f2p

### DIFF
--- a/scripts/skill_fishing/configs/fishing.param
+++ b/scripts/skill_fishing/configs/fishing.param
@@ -13,6 +13,7 @@ default=null
 [fishing_struct]
 type=struct
 default=null
+autodisable=no
 
 [baitrequired]
 type=namedobj


### PR DESCRIPTION
This is for both 225 and 244.

We delete the fishing_struct param on all ObjTypes in f2p since it's a members' item. This will cause a client crash when you fish a lava eel in f2p since it does not have an associated struct. 

This will fix that issue and allow you to fish them in f2p even though it is a members' item [(expected result)](https://oldschool.runescape.wiki/w/Raw_lava_eel). I think we can change the configs on params but if not, just yell at me.