### PR TITLE
fix: Add NW map_blocked check for cannon setup

### DIFF
--- a/scripts/quests/quest_mcannon/scripts/cannon_setup.rs2
+++ b/scripts/quests/quest_mcannon/scripts/cannon_setup.rs2
@@ -92,6 +92,7 @@ if (map_blocked($center) = true | // center
     map_blocked(movecoord($center, 0, 0, -1)) = true | // south
     map_blocked(movecoord($center, -1, 0, -1)) = true | // south-west
     map_blocked(movecoord($center, -1, 0, 0)) = true | // west
+    map_blocked(movecoord($center, -1, 0, 1)) = true | // north-west
     lineofwalk(movecoord($center, 0, 0, 1), movecoord($center, 0, 0, -1)) = false |
     lineofwalk(movecoord($center, 1, 0, 0), movecoord($center, -1, 0, 0)) = false |
     lineofwalk(movecoord($center, 1, 0, 1), movecoord($center, -1, 0, -1)) = false |


### PR DESCRIPTION
Applies to 225 & 244

Discovered over the weekend when a player placed a cannon on the docks at the fishing guild:
<img width="448" height="329" alt="image" src="https://github.com/user-attachments/assets/10621341-75b6-4831-a39c-92f827076989" />
