### PR TITLE
fix: move shadow spider drain to shadow spider retal queue

### DIFF
--- a/scripts/npc/scripts/shadow_spider.rs2
+++ b/scripts/npc/scripts/shadow_spider.rs2
@@ -24,8 +24,8 @@ mes("The spider drains your prayer...");
 sound_synth(prayer_drain, 0, 0);
 stat_sub(prayer, divide(stat(prayer), 2), 0); // division by 2 round up, thats why percent isn't being used 
 
-[ai_queue2,shadow_spider]
+[ai_queue1,shadow_spider]
 if (~npc_retal_ready = true & finduid(%npc_aggressive_player) = true) {
     ~shadow_spider_drain;
 }
-~npc_default_damage(last_int);
+~npc_default_retaliate;


### PR DESCRIPTION
For 225-244

If the drain checks are in damage, itll never go through since npc retaliation is queued before damage is (setting action_delay and making ~npc_reta_ready return false)