### PR TITLE
fix: Allow Wrought Iron key to be reclaimable after escaping the desert

### DIFF
--- a/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
+++ b/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
@@ -299,7 +299,7 @@ if(inv_total(inv, metal_key) = 0) {
     inv_add(inv, metal_key, 1);
     $found = true;
 }
-if(%desertrescue_progress = ^desertrescue_escaped & inv_total(inv, thgoodminekey) = 0) {
+if(%desertrescue_progress >= ^desertrescue_escaped & inv_total(inv, thgoodminekey) = 0) {
     ~objbox(thgoodminekey, "You find the key to the main gate.", 250, 0, 0);
     inv_add(inv, thgoodminekey, 1);
     $found = true;


### PR DESCRIPTION
For 225 & 244

Reported by a player in-game
Right now the key cannot be reclaimed after this step.


