### PR TITLE
fix: only set %duelstatus to ^duelstatus_lost if duel hasnt ended

### DIFF
--- a/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -1,5 +1,7 @@
 [queue,player_death_duel]
-%duelstatus = ^duelstatus_lost;
+if (%duelstatus < ^duelstatus_lost) { // in a duel
+    %duelstatus = ^duelstatus_lost;
+}
 if (~in_duel_arena(coord) = true) {
     ~player_death;
 }


### PR DESCRIPTION
For 225-244
First of all thank you to cakemix on discord on helping me fix this bug!

This fixes a particularly rare bug, where if you *dont* have pid on your opponent, and you die the same exact tick they spawn back into the duel arena, you both lose.

Before the fix:

https://github.com/user-attachments/assets/0186c666-8ea8-42d7-be31-21deed24aeb0

After the fix:

https://github.com/user-attachments/assets/f684359f-3294-4d39-9034-fc6dc1122be0

