### PR TITLE
fix: set tab on gnomeball gate, initalltabs on gnomeball exit

### DIFF
--- a/scripts/minigames/game_gnomeball/scripts/gnomeball.rs2
+++ b/scripts/minigames/game_gnomeball/scripts/gnomeball.rs2
@@ -8,10 +8,12 @@ if (%gnomeball_progress = ^gnomeball_game_started) {
     }
     if ($ball_worn > 0) {
         inv_del(worn, ball_gnomeball_game, $ball_worn);
+        ~update_all(null);
     }
     ~gnomeball_reset;
+    return;
 }
-~update_all(null);
+~initalltabs;
 
 [oploc1,gnomeball_gate]
 def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);
@@ -35,6 +37,7 @@ if ($exiting = false) {
         inv_del(inv, ball_gnomeball_game, inv_total(inv, ball_gnomeball_game));
         %gnomeball_owedball = ^true;
     }
+    if_settab(gnomeball, 0);
 } else {
     ~open_and_close_door(loc_param(next_loc_stage), $exiting, false);
     if (%gnomeball_owedball = ^true) {
@@ -67,6 +70,7 @@ if (%gnomeball_progress > ^gnomeball_not_started) {
 if (inv_getobj(worn, ^wearpos_rhand) = ball_gnomeball_game) {
     inv_delslot(worn, ^wearpos_rhand);
 }
+~initalltabs;
 %gnomeball_owedball = ^false;
 %gnomeball = 0;
 npc_findallany(^gnomeball_centre_coord, 14, ^vis_off);

--- a/scripts/minigames/game_gnomeball/scripts/gnomeball.rs2
+++ b/scripts/minigames/game_gnomeball/scripts/gnomeball.rs2
@@ -8,10 +8,10 @@ if (%gnomeball_progress = ^gnomeball_game_started) {
     }
     if ($ball_worn > 0) {
         inv_del(worn, ball_gnomeball_game, $ball_worn);
-        ~update_all(null);
     }
     ~gnomeball_reset;
 }
+~update_all(null);
 
 [oploc1,gnomeball_gate]
 def_obj $rhand = inv_getobj(worn, ^wearpos_rhand);


### PR DESCRIPTION
For 225-244

Fixes an issue with keeping the gnomeball interface on exit. Gnomeball interface only appeared when starting the game instead of entering, which is wrong I think? Might need a good source for this claim.