### PR TITLE
fix: book arrows werent hiding

### DIFF
--- a/scripts/general/scripts/book.rs2
+++ b/scripts/general/scripts/book.rs2
@@ -82,15 +82,15 @@ if (%book_page > $max_page) {
 }
 
 if (%book_page = $min_page) {
-    if_sethide(book:com_1, true);
+    if_sethide(book:com_2, true);
 } else {
-    if_sethide(book:com_1, false);
+    if_sethide(book:com_2, false);
 }
 
 if (%book_page = $max_page) {
-    if_sethide(book:com_3, true);
+    if_sethide(book:com_4, true);
 } else {
-    if_sethide(book:com_3, false);
+    if_sethide(book:com_4, false);
 }
 
 gosub($proc);

--- a/scripts/quests/quest_upass/scripts/history_of_iban.rs2
+++ b/scripts/quests/quest_upass/scripts/history_of_iban.rs2
@@ -9,8 +9,8 @@ mes("inside are several chapters...");
 @multi4_header("Introduction.", history_of_iban_introduction, "Iban.", history_of_iban, "The Resurrection.", history_of_iban_resurrection, "The Four Elements.", history_of_iban_elements, "Pick a chapter...");
 
 [label,history_of_iban_introduction]
-if_sethide(book:com_1, true);
-if_sethide(book:com_3, true);
+if_sethide(book:com_2, true);
+if_sethide(book:com_4, true);
 ~book("Introduction", "Introduction:||Gather round, all ye followers of the dark arts. Read carefully the words that I hereby inscribe, as I detail the heady brew that is responsible for my greatest creation in all my time on this world. I am Kardia, the most wretched witch in the land; scorned by beauty, the world and its inhabitants, see what I have created: The most fearsome and powerful force of darkness the like of which has never before been seen in this world, in human form...");
 
 [label,history_of_iban]
@@ -26,21 +26,21 @@ switch_int (%book_page) {
 }
 
 [label,history_of_iban_resurrection]
-if_sethide(book:com_1, true);
-if_sethide(book:com_3, true);
+if_sethide(book:com_2, true);
+if_sethide(book:com_4, true);
 ~book("Iban's Resurrection", "I knew of Iban's life, though of course I had not met him. Using the power of my dark practices, I vowed to resurrect this greatest of warriors. I would raise him again to fulfil the promise of his human life. To be a master...|of the undead...");
 
 [label,history_of_iban_elements]
 @multi4_header("Flesh.", history_of_iban_flesh, "Blood.", history_of_iban_blood, "Shadow.", history_of_iban_shadow, "Conscience.", history_of_iban_conscience, "The 4 Elements:");
 
 [label,history_of_iban_flesh]
-if_sethide(book:com_1, true);
-if_sethide(book:com_3, true);
+if_sethide(book:com_2, true);
+if_sethide(book:com_4, true);
 ~book("The 4 Elements: Flesh", "Flesh:|Taking a small doll with the likeness of Iban I smeared my effigy with the four elements that together bring existence into being. Essence of his darkness. At the battlefield where Iban lay, I had been able to steal a piece of Iban's cold flesh. Clasping some in my hand, I smeared it over the figure of Iban, and chanted his name with mighty incantation.");
 
 [label,history_of_iban_blood]
-if_sethide(book:com_1, true);
-if_sethide(book:com_3, true);
+if_sethide(book:com_2, true);
+if_sethide(book:com_4, true);
 ~book("The 4 Elements: Blood", "Blood:|I also needed blood, the giver of life force. By now Iban's body was a hardened vessel, the blood drained empty. But those caverns are home to the giant spider, a venomous creature known to feed on the warm blood of humans. I found and killed one of these foul beasts, and wiped the blood from its vile body onto the effigy of Iban that I had fashioned.");
 
 [label,history_of_iban_shadow]

--- a/scripts/quests/quest_upass/scripts/quest_upass.rs2
+++ b/scripts/quests/quest_upass/scripts/quest_upass.rs2
@@ -103,8 +103,8 @@ p_delay(3);
 p_teleport(0_38_51_4_51);
 
 [label,open_randas_diary]
-if_sethide(book:com_1, true);
-if_sethide(book:com_3, true);
+if_sethide(book:com_2, true);
+if_sethide(book:com_4, true);
 ~book("The Diary of Randas", "It began as a whisper in my ears. Dismissing the sounds as the whistling of the wind, I steeled myself against these forces, and continued on my way.||But the whispers became|moans...|||At once fearsome and enticing like the call of some beautiful siren.|||Join us!||Our greatness lies within you, but only Zamorak can unlock your potential...");
 
 [label,destroy_orboflight](obj $orb)


### PR DESCRIPTION
for 244 only

The interface data for books changed the layer com's from com_1 & com_3 -> com_2 & com_4. So any code trying to hide the layers are using the wrong com's.

Arrows are supposed to be hidden here for example:

https://github.com/user-attachments/assets/11954ca8-2126-4873-9f9f-d3097b23f02d

