### PR TITLE
fix: IAUA mes edge cases

### DIFF
--- a/scripts/skill_combat/scripts/player/player_combat.rs2
+++ b/scripts/skill_combat/scripts/player/player_combat.rs2
@@ -68,9 +68,36 @@ switch_int ($damagetype) {
 if (map_multiway(npc_coord) = false) {
     // player has been attacked in the last 8 ticks, and not by the current npc
     // or player has been attacked in the last 8 ticks, and %aggressive_npc is null (for pvp)
-    // https://cdn.discordapp.com/attachments/1126857544523063367/1332910417856565249/found-old-drive-with-rsdemon-and-some-screenshots-v0-36uacu7glqzd1.png?ex=67999c0f&is=67984a8f&hm=a4c34a40791a120dba06adebb15a652a722e486fddd6d5a9e47ee9aa2c329fb3&
-    // 2006 year / osrs mes I'm already under attack.
-    // here's one from 2004: https://youtu.be/IC2n8t76DDY?t=34
+    // "I'm already under attack!" probably existed for op2'ing an npc
+    // - 2004: https://storage.googleapis.com/tannerdino/images/Old%20Runescape%202004%20screenshots%20(%20From%20December%202004%20to%20January%202005%20)%20(7).jpeg
+    // - 2004: https://storage.googleapis.com/tannerdino/images/115combat.jpg
+    // - 2006: https://storage.googleapis.com/tannerdino/images/MyTrainingSpot.jpg
+    // - may 2006: https://www.youtube.com/watch?v=4uVvAwcJd9M&t=307s
+    if (add(%lastcombat_pvp, 8) > map_clock) {
+        mes("I'm already under attack!");
+        return(false);
+    }
+    if (add(%lastcombat, 8) > map_clock & (%aggressive_npc ! npc_uid & %aggressive_npc ! null)) {
+        mes("I'm already under attack!");
+        return(false);
+    }
+    // npc has been attacked in the last 8 ticks, and not by the current player
+    if ((add(%npc_lastcombat, 8) > map_clock & %npc_aggressive_player ! uid)) {
+        mes("Someone else is fighting that.");
+        return(false);
+    }
+}
+if (%npc_macro_event_target ! null & %npc_macro_event_target ! uid) {
+    mes("It's not after you."); // https://youtu.be/y58EFTJNIH8
+    return(false);
+}
+return(true);
+
+// version of this has no period, used for crumble undead?
+[proc,player_in_combat_check2]()(boolean)
+if (map_multiway(npc_coord) = false) {
+    // "I'm already under attack" with no period:
+    // - 2004: https://web.archive.org/web/20130303093547/http://img86.exs.cx/img86/271/80mage.jpg
     if (add(%lastcombat_pvp, 8) > map_clock) {
         mes("I'm already under attack");
         return(false);

--- a/scripts/skill_combat/scripts/player/spells/scripts/crumble_undead.rs2
+++ b/scripts/skill_combat/scripts/player/spells/scripts/crumble_undead.rs2
@@ -2,12 +2,33 @@
 [opnpct,magic:crumble_undead] ~pvm_crumble_undead;
 
 [proc,pvm_crumble_undead]
+// order of these checks are from osrs:
+// - action_delay check
+// - rune requirements
+// - in combat check
+// - op2 check
+// - undead check
+// - attackable opt check
+if (map_clock < %action_delay) {
+    p_opnpct(magic:crumble_undead);
+    return;
+}
 def_dbrow $spell_data = ~get_spell_data(^crumble_undead);
-if (~pvm_combat_spell_checks($spell_data) = false) {
+if (~check_spell_requirements($spell_data) = false) {
+    return;
+}
+if (~player_in_combat_check2 = false) {
+    return;
+}
+if (npc_hasop(2) = false) {
+    mes("You can't attack this npc.");
     return;
 }
 if (npc_param(undead) = ^false) {
     mes("This spell only affects skeletons, zombies, ghosts and shades.");
+    return;
+}
+if (~npc_is_attackable_opt = false) {
     return;
 }
 def_int $duration = ~pvm_spell_cast($spell_data);

--- a/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
@@ -84,16 +84,16 @@ if (~pvp_in_combat_check = false) {
 if (map_multiway(.coord) = false) {
     // if you have been attacked in the last 8 ticks, and the last person to attack you isnt your opponent
     // or an npc attacked you
-    // https://cdn.discordapp.com/attachments/1126857544523063367/1332910417856565249/found-old-drive-with-rsdemon-and-some-screenshots-v0-36uacu7glqzd1.png?ex=67999c0f&is=67984a8f&hm=a4c34a40791a120dba06adebb15a652a722e486fddd6d5a9e47ee9aa2c329fb3&
-    // 2006 year / osrs mes I'm already under attack.
-    // here's one from 2004: https://youtu.be/IC2n8t76DDY?t=34
+    // pvp's "I'm already under attack." has a period (most likely):
+    // - 2005: https://storage.googleapis.com/tannerdino/images/owned___1.png
+    // - 2004: https://storage.googleapis.com/tannerdino/images/scubamcm69arrow.jpg
     if (add(%lastcombat, 8) > map_clock) {
         if (%pk_predator1 ! .uid & %pk_predator1 ! null) {
-            mes("I'm already under attack");
+            mes("I'm already under attack.");
             return(false);
         }
         if (npc_finduid(%aggressive_npc) = true) {
-            mes("I'm already under attack");
+            mes("I'm already under attack.");
             return(false);
         }
     }


### PR DESCRIPTION
for 225-244

So... there's three different versions of `I'm already under attack`:
- `I'm already under attack!`
    
<img width="803" height="603" alt="image" src="https://github.com/user-attachments/assets/1d666dda-9a15-4f54-8206-f6f5fe749c20" />

<img width="790" height="533" alt="image" src="https://github.com/user-attachments/assets/6928343e-49b2-4551-8a50-f5f0ddc4d4cf" />

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/d20fcf74-37ff-4ab2-af6b-e7372e51e91c" />
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/3d3eb254-d869-4edf-9c16-b343fee70e3b" />
<img width="765" height="501" alt="image" src="https://github.com/user-attachments/assets/84d41095-9274-4e1b-a202-47c6542d396d" />

[video](https://www.youtube.com/watch?v=4uVvAwcJd9M&t=307s):
![VS--YouTube-YankinDeezHattricksPKVidRunescape-5’09”](https://github.com/user-attachments/assets/a440b265-a308-4aa2-9d16-3166358fca7d)

- `I'm already under attack.`
<img width="751" height="499" alt="image" src="https://github.com/user-attachments/assets/12aa1968-9978-4bde-8e5e-2a5540cff084" />
<img width="739" height="444" alt="image" src="https://github.com/user-attachments/assets/0dc66a8f-ecc9-4729-a798-80da8e341d65" />
Notice, this is the same person, same day, same area as one of the screenshots above:
<img width="754" height="503" alt="image" src="https://github.com/user-attachments/assets/d0497e77-b045-4aba-9168-7c698a8473c3" />

- `I'm already under attack`
<img width="775" height="598" alt="image" src="https://github.com/user-attachments/assets/8dca39c4-9f92-4a0e-9dcd-f97b1284d685" />


Given all these screenshots we have, my theory is:
- `.` = pvp
- `!` = pvm
- ` ` = crumble undead?
From old videos it looks like they made all of them `.` around June/July 2006