### PR TITLE
fix: rewrite player death queue

### DIFF
--- a/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -1,23 +1,23 @@
-[queue,player_death_duel]
-if (%duelstatus < ^duelstatus_lost) { // in a duel
+[label,player_death_duel]
+if (~in_duel_arena(coord) = true & %duelstatus < ^duelstatus_lost) {
     %duelstatus = ^duelstatus_lost;
-}
-if (~in_duel_arena(coord) = true) {
     ~player_death;
-}
-clearqueue(duel_finish);
-queue(duel_finish, 0);
 
-if (%duelstatus = ^duelstatus_lost & .finduid(%duelpartner) = true) {
-    session_log(^log_moderator, "Lost a duel against <.name>");
-    .if_close;
-    .%duelstatus = ^duelstatus_victory;
-    both_moveinv(dueloffer, duelwinnings);
-    .clearqueue(duel_finish);
-    .queue(duel_finish, 0);
+    clearqueue(duel_finish);
+    queue(duel_finish, 0);
+
+    if (%duelstatus = ^duelstatus_lost & .finduid(%duelpartner) = true) {
+        session_log(^log_moderator, "Lost a duel against <.name>");
+        .if_close;
+        .%duelstatus = ^duelstatus_victory;
+        both_moveinv(dueloffer, duelwinnings);
+        .clearqueue(duel_finish);
+        .queue(duel_finish, 0);
+    }
+    // ur able to get double mes if opponent kills u with knives: https://youtu.be/KRDZJKa1whI?list=PLn23LiLYLb1bQ7Hwp77KoNBjKvpZQTfJT&t=12
+    midi_jingle(^death_jingle_2, ^death_jingle_2_millis);
 }
-// ur able to get double mes if opponent kills u with knives: https://youtu.be/KRDZJKa1whI?list=PLn23LiLYLb1bQ7Hwp77KoNBjKvpZQTfJT&t=12
-midi_jingle(^death_jingle_2, ^death_jingle_2_millis);
+
 // https://storage.googleapis.com/tannerdino/images/6543.jpg
 // https://youtu.be/gWmwSYxzUfo
 mes("Oh dear you are dead!");
@@ -78,7 +78,7 @@ p_stopaction;
 ~stat_reset_all;
 healenergy(10000);
 ~combat_clearqueue;
-clearqueue(player_death_default);
+clearqueue(player_death);
 ~clear_pk_skull;
 ~clear_poison;
 ~update_all(inv_getobj(worn, ^wearpos_rhand));

--- a/scripts/player/scripts/combat_clearqueue.rs2
+++ b/scripts/player/scripts/combat_clearqueue.rs2
@@ -4,6 +4,9 @@ clearqueue(combat_damage_player);
 clearqueue(pvp_damage);
 clearqueue(damage_player);
 clearqueue(pvp_retaliate);
+// todo: verify these in osrs
+clearqueue(recoil_damage);
+clearqueue(poison_damage);
 
 [proc,.combat_clearqueue]
 .clearqueue(playerhit_n_retaliate);
@@ -11,3 +14,5 @@ clearqueue(pvp_retaliate);
 .clearqueue(pvp_damage);
 .clearqueue(damage_player);
 .clearqueue(pvp_retaliate);
+.clearqueue(recoil_damage);
+.clearqueue(poison_damage);

--- a/scripts/player/scripts/damage.rs2
+++ b/scripts/player/scripts/damage.rs2
@@ -1,6 +1,5 @@
 [proc,damage_self](int $amount)
 if (stat(hitpoints) = 0) {
-    ~player_die;
     return;
 }
 if_close;
@@ -12,7 +11,7 @@ if ($amount > 0) {
 }
 
 if (stat(hitpoints) = 0){
-    ~player_die;
+    queue(player_death, 0);
     return;
 }
 

--- a/scripts/player/scripts/death.rs2
+++ b/scripts/player/scripts/death.rs2
@@ -1,12 +1,3 @@
-[proc,player_die]
-if (.finduid(%duelpartner) = true) {
-    if (~.in_duel_arena(.coord) = true & ~in_duel_arena(coord) = true) {
-        queue(player_death_duel, 0);
-        return;
-    }
-}
-queue(player_death_default, 0);
-
 [proc,player_death]
 %death = ^true;
 p_delay(1);
@@ -16,7 +7,10 @@ anim(human_death, 0);
 p_delay(3);
 %death = ^false;
 
-[queue,player_death_default]
+[queue,player_death]
+if (.finduid(%duelpartner) = true & ~.in_duel_arena(.coord) = true) {
+    @player_death_duel;
+}
 ~player_death;
 midi_jingle(^death_jingle_2, ^death_jingle_2_millis);
 // https://storage.googleapis.com/tannerdino/images/6543.jpg
@@ -24,7 +18,7 @@ midi_jingle(^death_jingle_2, ^death_jingle_2_millis);
 mes("Oh dear you are dead!");
 
 ~combat_clearqueue;
-clearqueue(player_death_default);
+clearqueue(player_death);
 
 def_obj $prev_wep = inv_getobj(worn, ^wearpos_rhand);
 if (findhero = true) {

--- a/scripts/skill_agility/scripts/agility.rs2
+++ b/scripts/skill_agility/scripts/agility.rs2
@@ -114,7 +114,7 @@ if (gender() = 0) {
 mes($message);
 p_delay(0);
 if (stat(hitpoints) = 0){
-    ~player_die;
+    queue(player_death, 0);
     return;
 }
 ~ring_of_life_check;

--- a/scripts/skill_combat/scripts/poison.rs2
+++ b/scripts/skill_combat/scripts/poison.rs2
@@ -49,7 +49,7 @@ if (gender() = 0) {
 sound_synth($sound, 0, 20);
 
 if (stat(hitpoints) = 0) {
-    ~player_die;
+    queue(player_death, 0);
 }
 
 


### PR DESCRIPTION
for 225-244

- adds poison damage and recoil damage to combat_clearqueue (this probably needs to be verified in osrs)
- Restructures some of the death queue


From this [clip](https://youtube.com/clip/Ugkx7cccOZHE_YX0mzf805HszMeWfGuT00lt?si=GX0YReJLamnmVDqD), recoil damage doesnt get cleared as hes dying, so death gets queued multiple times.


Before fix:

https://github.com/user-attachments/assets/d220a57e-dfbf-498f-9587-a96408ed45c6



After fix:

https://github.com/user-attachments/assets/e8e35465-336f-430a-969d-d3129f13538c



Previously, the death queue code had the following logic:
```
[queue,damage]
if died from damage:
    if duel:
        run duel death queue
    else:
        run normal death queue
```
When it should probably be like:
```
[queue,damage]
if died from damage:
     run death queue

[queue,death]
if duel:
    run duel arena finish logic
else:
    treat as normal death
```

It was originally coded this way to help recreate this bug:

https://github.com/user-attachments/assets/4e72649f-f905-4de7-8c62-849885cc65b8

Normally when you die, any extra death queues on you get cleared. The theory is that duel death is a separate queue, so it doesnt get cleared on duel arena death. This theory falls short though, theres something else going on; in the clip above, he only gets damaged once? Theres no way death couldve been called multiple times.

Maybe it queues death on interaction too, if the target is at 0 hp? This could make sense, but coding it this way would *guarantee* you get double mes's almost every time. Old videos make it seem like its pid related - sometimes it happens, sometimes it doesnt. Pid doesnt matter here, death will be queued on damage, and there will always be enough time to interact with your opponent one more time before the death anim plays. Hence guaranteeing double mes's.

Im thinking about some check like.... `if (.stat(hitpoints) = 0 & .getqueue(player_death) < 1)`,  as an anti bug abuse measure. This limits it to two mes's basically, but it doesnt solve our pid issue.

Maybe it only happens if the opponent spam clicks? This would mean your death queue would p_stopaction your opponent (which it doesnt have direct access to).... This doesnt sound right to me IMO.

Maybe its an interaction *after* death? Just grasping at straws at this point, the teleport after death happens basically instantly. No way its this

I think what we need is a video of it happening to someone twice. Almost all videos I've found of it, they rage quit after one death (grrr). But i'll keep looking, would be good to just get more info on it.