### PR TITLE
fix: Legends Guild door typo (225 & 244)

### DIFF
--- a/scripts/quests/quest_legends/scripts/legends_door.rs2
+++ b/scripts/quests/quest_legends/scripts/legends_door.rs2
@@ -3,7 +3,7 @@
 
 [label,open_legends_door](int $side)
 if (%legends_progress >= ^legends_returned_to_radimus) {
-    mes("You approach the the Legends Guild main doors.");
+    mes("You approach the Legends Guild main doors.");
     mes("You push the huge Legends Guild doors open.");
     ~open_and_close_double_door2(~check_axis(coord, loc_coord, loc_angle), $side, door_open);
 } else {


### PR DESCRIPTION
Used this as source; forgot to include in commit :(
https://youtu.be/5MwrA2Ci39Q?si=qydNKrkUZyLeHVse&t=117