### PR TITLE
fix: Drezel's door shouldn't open automatically

### DIFF
--- a/scripts/areas/area_varrock/scripts/king_roald.rs2
+++ b/scripts/areas/area_varrock/scripts/king_roald.rs2
@@ -34,6 +34,8 @@ if(inv_total(inv, arravshield1) > 0 & inv_total(inv, arravshield2) > 0) {
     ~chatnpc("<p,neutral>If you get the authenticity of the shield verified|by the curator at the museum|and then return here with authentication,|I will grant you your reward.");
     return;
 }
+// No members check as F2P players can start Priest in Peril until 2013:
+// https://runescape.wiki/w/Update:Patch_Notes_(13_August_2013) (Free-to-play players can no longer start the Priest in Peril.)
 if (%priestperil >= ^priestperil_not_started & %priestperil < ^priestperil_complete) {
     @roald_priestperil_dialogue;
 }

--- a/scripts/quests/quest_priestperil/scripts/trapped_drezel.rs2
+++ b/scripts/quests/quest_priestperil/scripts/trapped_drezel.rs2
@@ -41,9 +41,8 @@ if(last_useitem = pipkey_iron) {
     if (npc_find(coord, priestperiltrappedmonk, 15, 0) = true) {
         %priestperil = ^priestperil_unlocked_drezel;
         inv_del(inv, pipkey_iron, 1);
-        mes("You unlock the cell door.");
         ~chatnpc("<p,happy >Oh! Thank you! You have found the key!");
-        ~open_and_close_metal_gate(loc_param(next_loc_stage), ~check_axis(coord, loc_coord, loc_angle), false);
+        mes("You unlock the cell door.");
         return;
     }
 } else if (last_useitem = pipkey_gold) {


### PR DESCRIPTION
Drezel's door shouldn't open automatically after unlocking with the iron key. Player is seen clicking the door manually, when slowing the video down by a lot: https://youtu.be/_YOX1OcqCvI?si=6A5Nq1gQrc2jLoZy&t=236