### PR TITLE
fix: clear duel queues on duel finish

### DIFF
--- a/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -86,6 +86,9 @@ hint_stop;
 ~sa_reset;
 %duelstatus = ^duelstatus_reset;
 %duel2accept = null;
+clearqueue(duel_arena_disconnect);
+clearqueue(duel_arena_prepare_start);
+clearqueue(duel_finish);
 
 [if_close,duel_win]
 if (~moveallinv_itemspace(duelwinnings, inv) = false) {


### PR DESCRIPTION
for 225-245

fixes:

https://github.com/user-attachments/assets/a76f34b3-35d7-4244-9256-312fe695f912

No idea if this bug is authentic, but there seems to be no record of it in the sea of duel arena bugs. Theres something similar from https://www.se7ensins.com/forums/threads/svews-bug-abuse-notes-everything-about-glitches-and-finding-them-in-runescape.437147/:
`However, when the duel timed out after waiting for you, you would be instantly teleported to the duel arena hospital. Normally it would only take about 3 seconds to time out, but using multiple teleothers you could rig it so that you could delay it infinitely. As a result, you could be in castle wars with say, an inventory of barricades, then trick the game into thinking you just ended a duel, and be teleported to the duel arena with barricades in tote.`

Which basically means theres no inzone check in the "Your opponent timed out, there was no winner!" queued teleport? So either the showcased video is an authentic bug, or they cleared duel arena queues on duel win/lose