### PR TITLE
fix: prevent dragon spear from pushing map_blocked targets

### DIFF
--- a/scripts/skill_combat/scripts/player/specs/scripts/pvm_dragon_spear.rs2
+++ b/scripts/skill_combat/scripts/player/specs/scripts/pvm_dragon_spear.rs2
@@ -22,6 +22,9 @@ npc_delay(4); // 5t delay
 
 
 [proc,dragon_spear_push](int $dir, coord $target_coord)(coord)
+if (map_blocked($target_coord) = true) {
+    return ($target_coord);
+}
 def_coord $end_coord = $target_coord;
 switch_int ($dir) {
     case ^exact_west : 


### PR DESCRIPTION
for 244-245

Fixes the issue of ducks getting pushed onto land:
<img width="765" height="504" alt="image" src="https://github.com/user-attachments/assets/bd3f1738-8162-44c9-874f-f76bcb78201c" />


Turns out! They just check if the target coord is on a map_blocked square. Some tests in osrs:

- Pushing ducks 

https://github.com/user-attachments/assets/1c4c77aa-f3d8-45af-a1df-885e5af8a349

- Pushing ardougne knight thats stuck in a door

https://github.com/user-attachments/assets/f2bfe54d-3914-4d8a-b44d-5e0c86ee245f

- Pushing a player thats stuck in a door

https://github.com/user-attachments/assets/1956bb5c-c055-4f5e-810d-0f3c33cc12c1

- Pushing a player whilst you are stuck in a door

https://github.com/user-attachments/assets/f80152e0-8a28-4b2b-8de0-19953c5e318b

