### PR TITLE
fix: prevent logout from splashed magic npc attacks

### DIFF
--- a/scripts/login_logout/logout.rs2
+++ b/scripts/login_logout/logout.rs2
@@ -23,3 +23,9 @@ if (p_finduid(uid) = true) {
 
     p_logout;
 }
+
+[proc,combat_preventlogout]
+p_preventlogout("You can't log out until 10 seconds after the end of combat.", 16);
+
+[proc,.combat_preventlogout]
+.p_preventlogout("You can't log out until 10 seconds after the end of combat.", 16);

--- a/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -309,7 +309,6 @@ if (inv_getobj(worn, ^wearpos_ring) = ring_of_recoil & map_members = ^true & npc
     npc_queue(2, $recoil_damage, 0);
     ~ring_of_recoil_lose_charge($recoil_damage);
 }
-p_preventlogout("You can't log out until 10 seconds after the end of combat.", 16);
 ~damage_self($damage);
 
 [proc,npc_retaliate](int $queue_delay)

--- a/scripts/skill_combat/scripts/player/auto_retaliate.rs2
+++ b/scripts/skill_combat/scripts/player/auto_retaliate.rs2
@@ -1,4 +1,5 @@
 [queue,playerhit_n_retaliate](npc_uid $nid)
+~combat_preventlogout;
 if (%option_nodef = ^player_auto_retaliate_on & npc_finduid($nid) = true & busy2 = false) {
     // npc flinches player
     if (%action_delay < map_clock) {
@@ -22,7 +23,7 @@ if (%option_nodef = ^player_auto_retaliate_on & npc_finduid($nid) = true & busy2
 
 // this needs fixing, and .queue support
 [queue,pvp_retaliate](player_uid $uid)
-p_preventlogout("You can't log out until 10 seconds after the end of combat.", 16);
+~combat_preventlogout;
 if (%option_nodef = ^player_auto_retaliate_on & .finduid($uid) = true & busy2 = false) {
     // npc flinches player
     if (%action_delay < map_clock) {

--- a/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_combat.rs2
@@ -160,7 +160,7 @@ stat_advance(hitpoints, scale($multiplier, 1000, scale(133, 100, $base)));
 [proc,.pvp_damage](int $delay, int $damage)
 .if_close;
 if (.p_finduid(.uid) = true) {
-    .p_preventlogout("You can't log out until 10 seconds after the end of combat.", 16);
+    ~.combat_preventlogout;
 }
 if ($damage < 0) {
     return;


### PR DESCRIPTION
For 225-245

For npc combat, these fixes move the p_preventlogout from damage queue to the retaliation queue. Also, this behavior might explain why jagex chose to make splashing instantly retaliate the player?

Before fix:

https://github.com/user-attachments/assets/cb2894da-89d3-434f-be9f-caa8c4a3c10b

After fix:


https://github.com/user-attachments/assets/1b8d7a1c-72e2-4478-9cf3-bd1a8fccb58a

