### PR TITLE
fix: set magic tab properly when using utility spells

### DIFF
--- a/scripts/skill_magic/scripts/spells/alchemy.rs2
+++ b/scripts/skill_magic/scripts/spells/alchemy.rs2
@@ -2,6 +2,7 @@
 [opheldt,magic:lowlvl_alchemy]@magic_spell_low_alch(^lowlvl_alchemy, last_item);
 
 [label,magic_spell_high_alch](int $spell, obj $item)
+if_settabactive(^tab_magic);
 if_close;
 // look for spell in db
 def_dbrow $spell_data = ~get_spell_data($spell);
@@ -32,11 +33,11 @@ if (afk_event = ^true) {
 // https://www.neoseeker.com/forums/2410/t960058-useless-rs-facts/2.htm
 // > When you high alch while your cannon is spinning, it stops spinning until you finish alching
 // Also this video: https://www.youtube.com/watch?v=P_o3Cxg73Tg&t=91s
-if_settabactive(^tab_magic);
 p_delay(3);
 
 
 [label,magic_spell_low_alch](int $spell, obj $item)
+if_settabactive(^tab_magic); // osrs always sets tab back
 if_close;
 // look for spell in db
 def_dbrow $spell_data = ~get_spell_data($spell);
@@ -59,7 +60,6 @@ def_int $profit = max(scale(4, 10, oc_cost($item)), 1);
 wealth_event(^wealth_low_alch, oc_debugname($item), 1, $profit);
 inv_del(inv, $item, 1);
 inv_add(inv, coins, $profit);
-if_settabactive(^tab_magic);
 if (afk_event = ^true) {
     ~macro_event_general_spawn(~macro_event_set_random);
 }
@@ -97,7 +97,7 @@ switch_obj($item) {
             return(false);
         }
         if(oc_category($item) = cat) { // you can alch witches cat (RS3)
-            mes("You can't do that to a defenceless cat!");
+            mes("You can't do that to a defenceless cat!"); // https://youtu.be/jZUswQjpW4A?t=93
             return(false);
         }
         if (oc_param($item, no_alchemy) = ^true) {

--- a/scripts/skill_magic/scripts/spells/enchant.rs2
+++ b/scripts/skill_magic/scripts/spells/enchant.rs2
@@ -5,8 +5,8 @@
 [opheldt,magic:enchant_lvl5]@magic_spell_enchant(^enchant_lvl5, last_slot);
 
 [label,magic_spell_enchant](int $spell, int $slot)
+if_settabactive(^tab_magic);
 def_obj $initial_obj = inv_getobj(inv, $slot);
-// if player has casted a spell recently then return
 if (inv_total(inv, $initial_obj) < 1) {
     return;
 }

--- a/scripts/skill_magic/scripts/spells/superheat.rs2
+++ b/scripts/skill_magic/scripts/spells/superheat.rs2
@@ -1,6 +1,7 @@
 [opheldt,magic:superheat_item]@magic_spell_superheat(^superheat_item, last_item);
 
 [label,magic_spell_superheat](int $spell, obj $ore1)
+if_settabactive(^tab_magic); // osrs sets tab back no matter what
 // look for spell in db
 def_dbrow $spell_data = ~get_spell_data($spell);
 if (~check_spell_requirements($spell_data)= false) {
@@ -60,7 +61,6 @@ if ($ore2 ! null) {
     inv_del(inv, $ore2, struct_param($bar_struct, ingredient_secondary_count));
 }
 inv_add(inv, $bar, 1);
-if_settabactive(^tab_magic);
 p_delay(1);
 
 if (afk_event = ^true) {


### PR DESCRIPTION
for 225-245

- enchant spell now sets you back to your magic tab. Matches [video](https://youtu.be/aqKVRa-wreo) (this video also shows that itll enchant the specific slot, just like osrs): 

https://github.com/user-attachments/assets/839a8367-767d-48bb-bd73-0fb586ed01a9


- alching/superheat now sets back to magic tab *on failure* as well. This matches osrs and this [video](https://youtu.be/jZUswQjpW4A?t=69):

https://github.com/user-attachments/assets/746248da-b1fb-4acf-a0ef-561ba80d0768

