### PR TITLE
fix: typos and anainabarrel check

### DIFF
--- a/scripts/areas/area_fishing_platform/scripts/fisherman.rs2
+++ b/scripts/areas/area_fishing_platform/scripts/fisherman.rs2
@@ -1,7 +1,7 @@
 [opnpc1,_fisherman_platform]
 // RSC has 1 variant use one dialogue and 2 use another, RS2 has 4 variants, looks like RS2 probably uses random (but added new dialogues after rework)
 ~chatplayer("<p,happy>Hello there.");
-~mesbox("His eyes are fixated|starting at the sea..");
+~mesbox("His eyes are fixated|staring at the sea..");
 if_close;
 p_delay(2);
 if(random(2) = 0) { 

--- a/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
+++ b/scripts/quests/quest_desertrescue/scripts/quest_desertrescue.rs2
@@ -1,30 +1,30 @@
 [oploc2,miningcampgateclosedl] @search_desertcamp_gate;
 [oploc2,miningcampgateclosedr] @search_desertcamp_gate;
 
-[oploc1,miningcampgateclosedl] @open_desertcamp_gate(^left);
-[oploc1,miningcampgateclosedr] @open_desertcamp_gate(^right);
+[oploc1,miningcampgateclosedl] ~open_desertcamp_gate(^left);
+[oploc1,miningcampgateclosedr] ~open_desertcamp_gate(^right);
 
 [oplocu,miningcampgateclosedl] 
 if(last_useitem = metal_key) {
     // this is to replicate osrs behaviour where you get nothing interesting happens after opening gate to leave w/key
     // this could just be a rework bug
     def_boolean $entering = ~check_axis(coord, loc_coord, loc_angle);
-    if($entering = false) {
-        ~open_and_close_double_door2(~check_axis(coord, loc_coord, loc_angle), ^left, grate_open);
-    } else {
-        @open_desertcamp_gate(^left);
+    if($entering = true) {
+        ~open_desertcamp_gate(^left);
+        return;
     }
+    ~open_desertcamp_gate(^left);
 }
 ~displaymessage(^dm_default);
 
 [oplocu,miningcampgateclosedr]
 if(last_useitem = metal_key) {
     def_boolean $entering = ~check_axis(coord, loc_coord, loc_angle);
-    if($entering = false) {
-        ~open_and_close_double_door2(~check_axis(coord, loc_coord, loc_angle), ^right, grate_open);
-    } else {
-        @open_desertcamp_gate(^right);
+    if($entering = true) {
+        ~open_desertcamp_gate(^right);
+        return;
     }
+    ~open_desertcamp_gate(^right);
 }
 ~displaymessage(^dm_default);
 
@@ -65,7 +65,7 @@ if(($lhand ! null & oc_category($lhand) = armour_shield) | ($hands ! null & oc_c
 }
 return (false);
 
-[label,open_desertcamp_gate](int $side)
+[proc,open_desertcamp_gate](int $side)
 def_boolean $entering = ~check_axis(coord, loc_coord, loc_angle);
 def_loc $loc_type = loc_type;
 def_locshape $loc_shape = loc_shape;

--- a/scripts/quests/quest_legends/scripts/gujuo.rs2
+++ b/scripts/quests/quest_legends/scripts/gujuo.rs2
@@ -77,7 +77,7 @@ else if (%legendsquest >= ^legends_accepted_rescue_ungadulu & %legendsquest < ^l
                 "If I went in search of the source, could you help me?", gujuo_searchsource,
                 "Ok thanks for your help.", gujuo_thanks);
     }
-} else if (%legendsquest >= ^legends_defeated_nezikchened_water & %legendsquest < ^legends_defeated_nezikchened_final) {
+} else if (%legendsquest >= ^legends_defeated_nezikchened_water & %legendsquest <= ^legends_defeated_nezikchened_final) {
     ~chatnpc("<p,happy>Hello Bwana, I'm very pleased to see you again. Things seem much happier now in the Kharazi Jungle. I suspect that it is down to your good doings!");
     if(inv_total(inv, thtotempole) > 0) {
         @multi4("I made the Totem pole, now what do I do with it?", gujuo_madetotem, "I found the source of the spring and I got the water.", gujuo_foundsource, "I killed the demon again.", gujuo_demon, "Ok thanks for your help.", gujuo_thanks);

--- a/scripts/quests/quest_legends/scripts/quest_legends.rs2
+++ b/scripts/quests/quest_legends/scripts/quest_legends.rs2
@@ -944,6 +944,7 @@ if ($pickaxe = null) {
         mes("You decide not to take the pickaxe.");
         return;
     }
+    inv_add(inv, bronze_pickaxe, 1);
     ~objbox(bronze_pickaxe, "You carefully prise the pickaxe from the unfortunate dwarf's cold, dead hands.", 250, 0, 0);
     return;
 }


### PR DESCRIPTION
for 225-245

- fix typo in fisherman dialogue (fishing platform)
- correct check when leaving desert camp through oplocu
- change check in gujuo dialogue to account for missing stage
- add missing inv_add to the bronze pickaxe skeleton in the viyeldi caves