### PR TITLE
chore: rename wildlever back to essencemine_exit_coord

### DIFF
--- a/pack/varp.pack
+++ b/pack/varp.pack
@@ -62,7 +62,7 @@
 61=sheepherdervar
 62=goblinquest
 63=runemysteries
-64=wildlever
+64=essencemine_exit_coord
 65=waterfall_quest
 66=varp_66
 67=hetty

--- a/scripts/_unpack/377/all.varp
+++ b/scripts/_unpack/377/all.varp
@@ -134,8 +134,6 @@ protect=no
 
 [goblinquest]
 
-[wildlever]
-
 [waterfall_quest]
 
 [varp_66]

--- a/scripts/skill_runecraft/configs/essence_mine.varp
+++ b/scripts/skill_runecraft/configs/essence_mine.varp
@@ -1,3 +1,3 @@
-// [exit_essence_mine_coord]
-// scope=perm
-// type=coord
+[essencemine_exit_coord]
+scope=perm
+type=coord

--- a/scripts/skill_runecraft/scripts/essence_mine.rs2
+++ b/scripts/skill_runecraft/scripts/essence_mine.rs2
@@ -4,37 +4,37 @@ if (%runemysteries < ^runemysteries_complete) {
     mes("You need to have completed the Rune Mysteries Quest to use this feature.");
     return;
 }
-// if_close;
-// %exit_essence_mine_coord = $tele_back_coord;
-// // this is lowercase
-// npc_say("Senventior disthine molenko!");
-// if ($tele_back_coord ! ^essence_mine_to_brimstail) { // brimstall anim buggy, need gnome equivalent (or no anim like OSRS)
-//     npc_anim(human_castcurse, 0); // No anim in osrs
-// }
-// spotanim_npc(curse_casting, 92, 0);
-// sound_synth(curse_all, 0, 0);
-// def_int $duration = ~player_projectile(npc_coord, coord, uid, curse_travel, 31, 31, 61, 16, 0, 128, 5);
-// // osrs is 100 but 70 lines up better with our different sound synth
-// spotanim_pl(curse_impact, 124, 70);
-// // IncompleteProjectile(id = 109, startHeight = 31, endHeigsht = 31, delay = 61, angle = 16, distOffset = 128)	
-// p_delay(4);
-// // select random coord
-// def_coord $coord = enum(int, coord, essence_mine_teleports, random(enum_getoutputcount(essence_mine_teleports)));
-// // select random coord at a radius of 1
-// $coord = map_findsquare($coord, 0, 1, ^map_findsquare_lineofsight);
-// p_telejump($coord);
-// 
-// // portal
-// [oploc1,loc_2492]
-// // IncompleteProjectile(id = 109, startHeight = 15, endHeight = 31, delay = 0, angle = 16, distOffset = 128)	| distance = 1, flightDuration = 30, visualStart = Location(x = 9557, y = 3778, z = 0)
-// def_int $duration = ~player_projectile(loc_coord, coord, uid, curse_travel, 15, 31, 0, 16, 0, 128, 5);
-// spotanim_pl(curse_impact, 124, 30);
-// sound_synth(teleport_all, 0, 0);
-// p_delay(1);
-// if (%exit_essence_mine_coord = null) {
-//     %exit_essence_mine_coord = ^essence_mine_to_sedridor;
-// } else if (%exit_essence_mine_coord ! ^essence_mine_to_aubury & %exit_essence_mine_coord ! ^essence_mine_to_sedridor & map_members = ^false) {
-//     %exit_essence_mine_coord = ^essence_mine_to_sedridor; // in osrs, if you hop to a f2p world from f2p when inside the ess mine, if your exit coord is in a p2p area it reset to sedridor!
-// }
-// def_coord $coord = map_findsquare(%exit_essence_mine_coord, 0, 2, ^map_findsquare_lineofwalk);
-// p_telejump($coord);
+if_close;
+%essencemine_exit_coord = $tele_back_coord;
+// this is lowercase
+npc_say("Senventior disthine molenko!");
+if ($tele_back_coord ! ^essence_mine_to_brimstail) { // brimstall anim buggy, need gnome equivalent (or no anim like OSRS)
+    npc_anim(human_castcurse, 0); // No anim in osrs
+}
+spotanim_npc(curse_casting, 92, 0);
+sound_synth(curse_all, 0, 0);
+def_int $duration = ~player_projectile(npc_coord, coord, uid, curse_travel, 31, 31, 61, 16, 0, 128, 5);
+// osrs is 100 but 70 lines up better with our different sound synth
+spotanim_pl(curse_impact, 124, 70);
+// IncompleteProjectile(id = 109, startHeight = 31, endHeigsht = 31, delay = 61, angle = 16, distOffset = 128)	
+p_delay(4);
+// select random coord
+def_coord $coord = enum(int, coord, essence_mine_teleports, random(enum_getoutputcount(essence_mine_teleports)));
+// select random coord at a radius of 1
+$coord = map_findsquare($coord, 0, 1, ^map_findsquare_lineofsight);
+p_telejump($coord);
+
+// portal
+[oploc1,essencemine_portal]
+// IncompleteProjectile(id = 109, startHeight = 15, endHeight = 31, delay = 0, angle = 16, distOffset = 128)	| distance = 1, flightDuration = 30, visualStart = Location(x = 9557, y = 3778, z = 0)
+def_int $duration = ~player_projectile(loc_coord, coord, uid, curse_travel, 15, 31, 0, 16, 0, 128, 5);
+spotanim_pl(curse_impact, 124, 30);
+sound_synth(teleport_all, 0, 0);
+p_delay(1);
+if (%essencemine_exit_coord = null) {
+    %essencemine_exit_coord = ^essence_mine_to_sedridor;
+} else if (%essencemine_exit_coord ! ^essence_mine_to_aubury & %essencemine_exit_coord ! ^essence_mine_to_sedridor & map_members = ^false) {
+    %essencemine_exit_coord = ^essence_mine_to_sedridor; // in osrs, if you hop to a f2p world from f2p when inside the ess mine, if your exit coord is in a p2p area it reset to sedridor!
+}
+def_coord $coord = map_findsquare(%essencemine_exit_coord, 0, 2, ^map_findsquare_lineofwalk);
+p_telejump($coord);


### PR DESCRIPTION
Renames the osrs `wildlever` varp back to `essencemine_exit_coord` and re-enables essencemine teleports. 

The `wildlever` in osrs is used for wildy lever warnings, as per [wiki's chisel database](https://chisel.weirdgloop.org/varbs/display?varplayer=64). I believe this is just them reusing an old varp considering that osrs' essencemine works a bit differently from our revision.