### PR TITLE
feat: party room changes (july 27 2004)

### DIFF
--- a/scripts/minigames/game_partyroom/configs/partyroom.npc
+++ b/scripts/minigames/game_partyroom/configs/partyroom.npc
@@ -23,6 +23,7 @@ model9=model_181_idk
 head1=model_63_idk_head
 head2=model_77_npc_head
 head3=model_29_obj_wear
+timer=1
 
 [partyroom_knight]
 name=Knight

--- a/scripts/minigames/game_partyroom/scripts/party_pete.rs2
+++ b/scripts/minigames/game_partyroom/scripts/party_pete.rs2
@@ -38,4 +38,54 @@ switch_int(~p_choice4("So what's this room for?", 1, "What's the big lever over 
         npc_anim(partyroom_dance, 0);
 }
 
-// todo (for later versions): ai_timer to auto clean up the party chest (27 Jul 2004 and later will do this)
+[ai_timer,partyroom_pete]
+// not map_clock based since it starts when last call ended
+// resetdefaults doesn't affect so must be 1t timer
+%npc_int = add(%npc_int, 1);
+if(%npc_int < 1000) {
+    return;
+}
+npc_setmode(none);
+~npc_forcewalk(0_42_54_42_14);
+npc_facesquare(0_42_54_41_14);
+npc_delay(0);
+npc_anim(human_openchest, 0);
+npc_delay(0);
+if(loc_find(0_42_54_41_14, loc_2417) = true) {
+    loc_change(partyroom_chestopen, 500);
+    npc_delay(1);
+}
+npc_say("Right, let's have a look.");
+npc_delay(2);
+npc_anim(human_openchest, 0);
+npc_delay(3);
+def_int $slot = 0;
+def_int $dropped = 0;
+def_int $rand = random(5);
+huntall(npc_coord, 20, ^vis_off); // 20 tiles, no los/low check
+if(huntnext = true) { // this only checks 1 player, if it fails on them nothing happens
+    if(p_finduid(uid) = true) { // fails if no prot access
+        // check for junk items, if there are any pete will drop them for that user
+        // iterate through the slots of the chest in order and drop on random 1x1 free tile
+        while ($slot < inv_size(partyroom_dropinv)) {
+            def_obj $slotobj = inv_getobj(partyroom_dropinv, $slot);
+            // notes are untouched regardless of value
+            if ($slotobj ! null & oc_cert($slotobj) ! $slotobj & oc_cost($slotobj) <= 3) {
+                inv_dropslot(partyroom_dropinv, map_findsquare(npc_coord, 0, 1, ^map_findsquare_none), $slot, 200);
+                $dropped = add($dropped, 1);
+            }
+            $slot = add($slot, 1);
+        }
+        if($dropped > 0) {
+            if($rand = 0) npc_say("No good!");
+            else if($rand = 1) npc_say("Tut tut!");
+            else if($rand = 2) npc_say("Reject!");
+            else if($rand = 3) npc_say("Chaff!");
+            else npc_say("Pfft!");
+        } else {
+            npc_say("Good, good.");
+        }
+    }
+}
+%npc_int = 0;
+npc_setmode(null);

--- a/scripts/minigames/game_partyroom/scripts/partyroom.rs2
+++ b/scripts/minigames/game_partyroom/scripts/partyroom.rs2
@@ -4,8 +4,8 @@
 @multi3("Balloon Bonanza.", partyroom_balloons, "Nightly Dance.", partyroom_knights, "No action.", exit);
 
 [label,partyroom_balloons]
-~mesbox("Balloon Bonanza costs 5000 coins.");
-if(inv_total(inv, coins) < 5000) {
+~mesbox("Balloon Bonanza costs 1000 coins.");
+if(inv_total(inv, coins) < 1000) {
     return;
 }
 def_int $choice = ~p_choice2_header("Yes.", 1, "No.", 2, "Continue?");
@@ -14,7 +14,7 @@ if ($choice = 2) {
     return;
 }
 if (npc_find(coord, partyroom_pete, 16, 0) = true) {
-    ~pull_partylever(5000);
+    ~pull_partylever(1000);
     @partyroom_drop_balloons(0);
 }
 
@@ -26,8 +26,8 @@ anim(human_boxlever, 0);
 sound_synth(lever, 0, 0);
 
 [label,partyroom_knights]
-~mesbox("Nightly Dance costs 2000 coins.");
-if(inv_total(inv, coins) < 2000) {
+~mesbox("Nightly Dance costs 500 coins.");
+if(inv_total(inv, coins) < 500) {
     return;
 }
 def_int $choice = ~p_choice2_header("Yes.", 1, "No.", 2, "Continue?");
@@ -39,7 +39,7 @@ if(npc_find(coord, partyroom_knight, 7, 0) = true) {
     ~mesbox("The party room knights are already here!");
     return;
 }
-~pull_partylever(2000);
+~pull_partylever(500);
 def_int $knights_spawned = 0;
 while($knights_spawned < 6) {
     npc_add(movecoord(^partyroom_starting_knight_coord, $knights_spawned, 0, 0), partyroom_knight, 100);
@@ -128,14 +128,17 @@ anim(human_stamp, 0);
 p_delay(0);
 // Temp note: dur updated, does it need ? @indio
 loc_change($broken_balloon, 6);
-// todo: chance was fixed before Jul 2004, was changed to scale off of chest freespace afterwards (this chance is just a guess unfortunately)
-if (~inzone_coord_pair_table(party_room_zones, loc_coord) = true & random(4) = 0) {
-    def_int $partyroom_size = inv_size(partyroom_dropinv);
-    def_int $free_slots = calc($partyroom_size - inv_freespace(partyroom_dropinv));
-    def_int $rand_slot = random(calc($free_slots + ~partyroom_empty_slots($free_slots)));
-    def_obj $obj = inv_getobj(partyroom_dropinv, $rand_slot);
-    def_int $count = 1;
-    def_int $obj_total = inv_getnum(partyroom_dropinv, $rand_slot);
+// todo: scaled chance after july 2004, need more data as this is just an estimate
+def_int $partyroom_size = inv_size(partyroom_dropinv);
+def_int $free_slots = calc($partyroom_size - inv_freespace(partyroom_dropinv));
+def_int $rand_slot;
+def_obj $obj;
+def_int $count = 1;
+def_int $obj_total;
+if (~inzone_coord_pair_table(party_room_zones, loc_coord) = true & random(calc(1 + ($free_slots / 54))) = 0) {
+    $rand_slot = random(calc($free_slots + ~partyroom_empty_slots($free_slots)));
+    $obj = inv_getobj(partyroom_dropinv, $rand_slot);
+    $obj_total = inv_getnum(partyroom_dropinv, $rand_slot);
     if($obj = null) {
         return;
     }

--- a/scripts/minigames/game_partyroom/scripts/partyroom.rs2
+++ b/scripts/minigames/game_partyroom/scripts/partyroom.rs2
@@ -128,14 +128,18 @@ anim(human_stamp, 0);
 p_delay(0);
 // Temp note: dur updated, does it need ? @indio
 loc_change($broken_balloon, 6);
-// todo: scaled chance after july 2004, need more data as this is just an estimate
 def_int $partyroom_size = inv_size(partyroom_dropinv);
 def_int $free_slots = calc($partyroom_size - inv_freespace(partyroom_dropinv));
 def_int $rand_slot;
 def_obj $obj;
 def_int $count = 1;
 def_int $obj_total;
-if (~inzone_coord_pair_table(party_room_zones, loc_coord) = true & random(calc(1 + ($free_slots / 54))) = 0) {
+// estimated off OSRS
+def_int $rand_chest = random(4);
+if($free_slots >= 100) { // if 100 or more items are in the chest, something will always drop (OSRS)
+    $rand_chest = 0;
+}
+if (~inzone_coord_pair_table(party_room_zones, loc_coord) = true & $rand_chest = 0) {
     $rand_slot = random(calc($free_slots + ~partyroom_empty_slots($free_slots)));
     $obj = inv_getobj(partyroom_dropinv, $rand_slot);
     $obj_total = inv_getnum(partyroom_dropinv, $rand_slot);

--- a/scripts/npc/scripts/npc_walk.rs2
+++ b/scripts/npc/scripts/npc_walk.rs2
@@ -1,0 +1,30 @@
+[proc,npc_forcewalk](coord $dest)
+def_int $change_x = calc(coordx($dest) - coordx(npc_coord));
+def_int $change_z = calc(coordz($dest) - coordz(npc_coord));
+~npc_telewalk($change_x, $change_z);
+
+// agility_walk for npcs
+[proc,npc_telewalk](int $change_x, int $change_z)
+if($change_x = 0 & $change_z = 0) {
+    return;
+}
+def_int $move_x = 0;
+def_int $move_z = 0;
+if ($change_x >= 1) {
+    $move_x = 1;
+} else if ($change_x <= -1) {
+    $move_x = -1;
+}
+if ($change_z >= 1) {
+    $move_z = 1;
+} else if ($change_z <= -1) {
+    $move_z = -1;
+}
+// Perform movement and re-calc
+def_coord $movement_coord = movecoord(npc_coord, $move_x, 0, $move_z);
+npc_tele(movecoord(npc_coord, $move_x, 0, $move_z));
+$change_x = calc($change_x - $move_x);
+$change_z = calc($change_z - $move_z);
+npc_delay(0);
+// recursive call
+~npc_telewalk($change_x, $change_z);


### PR DESCRIPTION
for 254 (https://oldschool.runescape.wiki/w/Update:Agility,_Potions_and_Parties!)
- costs of balloon bonanza and party knights have dropped (5x and 4x cheaper)
- party pete will now clear out worthless items from the chest every 10 minutes (behaviour matching OSRS)
- balloons will now always drop an item when popped if there are >= 100 items in the chest