### PR TITLE
fix: Mime random additional cleanup

### DIFF
--- a/scripts/interface_controls/scripts/player_controls.rs2
+++ b/scripts/interface_controls/scripts/player_controls.rs2
@@ -62,6 +62,10 @@ if (p_finduid(uid) = true) {
 [if_button,controls:com_22] @controls_emote(emote_laugh);
 [if_button,controls:com_23] @controls_emote(emote_cheer);
 [if_button,controls:com_24] @controls_emote(emote_clap);
+[if_button,controls:com_41] @controls_emote(seq_1128);
+[if_button,controls:com_42] @controls_emote(seq_1131);
+[if_button,controls:com_43] @controls_emote(seq_1130);
+[if_button,controls:com_44] @controls_emote(seq_1129);
 
 [label,controls_emote](seq $anim)
 if_close;

--- a/scripts/macro events/configs/macro_events.dbrow
+++ b/scripts/macro events/configs/macro_events.dbrow
@@ -1,0 +1,3 @@
+[random_event_mime_zones]
+table=coord_pair_table
+data=coord_pair,0_31_74_0_0,0_31_74_63_63

--- a/scripts/macro events/scripts/general/macro_event_mime.rs2
+++ b/scripts/macro events/scripts/general/macro_event_mime.rs2
@@ -1,3 +1,44 @@
+// MIME RANDOM EVENT
+// Entry points:
+// macro_mysterious_old_man - the man who will abduct you
+// mapzone - when you enter the mime area, or log into the mime area
+// ai_timer - the mime npc has a state timer that globally shows the emote to follow
+// if_button - the buttons when you click on the interface with all the emotes
+
+// Enter map trigger: 
+[mapzone,0_31_74]
+def_int $count = divide(modulo(map_clock, multiply(16,2)), 2);
+if ($count < 4) {
+    if (loc_find(0_31_74_23_25, loc_3644) = true) {
+        loc_anim(seq_1135);
+    }
+    if (loc_find(0_31_74_26_25, loc_3644) = true) {
+        loc_anim(seq_1136);
+    }
+} else {
+    if (loc_find(0_31_74_23_25, loc_3644) = true) {
+        loc_anim(seq_1136);
+    }
+    if (loc_find(0_31_74_26_25, loc_3644) = true) {
+        loc_anim(seq_1135);
+    }
+}
+mes("You need to copy the mime's performance, then you'll return to");
+mes("where you were.");
+if_settab(null, 0);
+if_settab(null, 1);
+if_settab(null, 2);
+if_settab(null, 3);
+if_settab(null, 4);
+if_settab(null, 5);
+if_settab(null, 6);
+if_settab(null, 11);
+if_settab(null, 12);
+
+// Exit map trigger: restore tabs
+[mapzoneexit,0_31_74]
+~initalltabs;
+
 [ai_timer,npc_1056]
 def_int $count = divide(modulo(map_clock, multiply(16,2)), 2);
 if($count = 0) {
@@ -10,6 +51,7 @@ if($count = 0) {
     }
     huntall(0_31_74_24_28, 1, 0);
     while(huntnext = true) {
+        if_close();
         queue(mime_step_right_up, 0);
     }
     huntall(0_31_74_24_26, 1, 0);
@@ -83,9 +125,27 @@ if ($num = $curr_emote) {
         // Return where you are from
         p_delay(4);
         p_teleport(%macro_chest_gas_coord);
+        inv_add(inv, ~macro_mime_reward);
+        ~initalltabs;
         %macro_event = 0;
     }
 } else {
     p_delay(4);
     anim(emote_cry, 0);
 }
+
+
+[proc,macro_mime_reward]()(namedobj, int)
+//  
+if(inv_total(inv, obj_3057) = 0 & inv_total(worn, obj_3057) = 0 & inv_total(bank, obj_3057) = 0) {
+    return(obj_3057, 1);
+} else if(inv_total(inv, obj_3058) = 0 & inv_total(worn, obj_3058) = 0 & inv_total(bank, obj_3058) = 0) {
+    return(obj_3058, 1); // Mime top
+} else if(inv_total(inv, obj_3059) = 0 & inv_total(worn, obj_3059) = 0 & inv_total(bank, obj_3059) = 0) {
+    return(obj_3059, 1); // Mime legs
+} else if(inv_total(inv, obj_3060) = 0 & inv_total(worn, obj_3060) = 0 & inv_total(bank, obj_3060) = 0) {
+    return(obj_3060, 1); // Mime gloves
+} else if(inv_total(inv, obj_3061) = 0 & inv_total(worn, obj_3061) = 0 & inv_total(bank, obj_3061) = 0) {
+    return(obj_3061, 1); // Mime boots
+}
+// Emotes were not unlockables in 254

--- a/scripts/macro events/scripts/general/macro_event_mime.rs2
+++ b/scripts/macro events/scripts/general/macro_event_mime.rs2
@@ -5,6 +5,24 @@
 // ai_timer - the mime npc has a state timer that globally shows the emote to follow
 // if_button - the buttons when you click on the interface with all the emotes
 
+// Mysterious Old Man:
+[proc,mime_entry_point]()
+~macro_event_disappear;
+%macro_event = ^macro_mime;
+%macro_chest_gas_coord = coord();
+p_teleport(0_31_74_24_28);
+if_settab(null, 0);
+if_settab(null, 1);
+if_settab(null, 2);
+if_settab(null, 3);
+if_settab(null, 4);
+if_settab(null, 5);
+if_settab(null, 6);
+if_settab(null, 11);
+if_settab(null, 12);
+~chatnpc("<p,neutral>You need to copy the mime's performance, then you'll be returned to where you were.");
+
+
 // Enter map trigger: 
 [mapzone,0_31_74]
 def_int $count = divide(modulo(map_clock, multiply(16,2)), 2);
@@ -25,15 +43,6 @@ if ($count < 4) {
 }
 mes("You need to copy the mime's performance, then you'll return to");
 mes("where you were.");
-if_settab(null, 0);
-if_settab(null, 1);
-if_settab(null, 2);
-if_settab(null, 3);
-if_settab(null, 4);
-if_settab(null, 5);
-if_settab(null, 6);
-if_settab(null, 11);
-if_settab(null, 12);
 
 // Exit map trigger: restore tabs
 [mapzoneexit,0_31_74]
@@ -136,7 +145,6 @@ if ($num = $curr_emote) {
 
 
 [proc,macro_mime_reward]()(namedobj, int)
-//  
 if(inv_total(inv, obj_3057) = 0 & inv_total(worn, obj_3057) = 0 & inv_total(bank, obj_3057) = 0) {
     return(obj_3057, 1);
 } else if(inv_total(inv, obj_3058) = 0 & inv_total(worn, obj_3058) = 0 & inv_total(bank, obj_3058) = 0) {

--- a/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
+++ b/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
@@ -72,11 +72,7 @@ if (%npc_int = ^mysterious_old_man_happy) {
 // For 254, The old man can either give you a gift, a strange box, send you to the maze, send you to the mime
 def_int $random_old_man_event = random(4);
 if ($random_old_man_event = 2 | $random_old_man_event = 3) {
-    ~macro_event_disappear;
-    %macro_event = ^macro_mime;
-    %macro_chest_gas_coord = coord();
-    p_teleport(0_31_74_24_28);
-    ~chatnpc("<p,neutral>You need to copy the mime's performance, then you'll be returned to where you were.");
+    ~mime_entry_point;
     return;
 }
 

--- a/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
+++ b/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
@@ -76,6 +76,7 @@ if ($random_old_man_event = 2 | $random_old_man_event = 3) {
     %macro_event = ^macro_mime;
     %macro_chest_gas_coord = coord();
     p_teleport(0_31_74_24_28);
+    ~chatnpc("<p,neutral>You need to copy the mime's performance, then you'll be returned to where you were.");
     return;
 }
 

--- a/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -86,6 +86,10 @@ if (~inzone_coord_pair_table(trawler_game_zones, $coord) = true) {
     ~mesbox("You're too far from shore to teleport!"); // osrs
     return(false);
 }
+if (~inzone_coord_pair_table(random_event_mime_zones, $coord) = true) {
+    ~mesbox("I need to finish my performance!"); // https://www.youtube.com/watch?v=aGIPPPlADys&t=92s
+    return(false);
+}
 if (~in_duel_arena($coord) = true) {
     mes("Coward! You can't teleport from a duel."); //RS3 message: https://archive.org/details/runelibris
     //Colored in #AB0908 in RS3, but was likely not colored in 2004


### PR DESCRIPTION
Fixed the following for the mime random

- Give rewards one by one everytime you finish a mime random
- Added initial mysterious old man dialogue when going to the mime random
- Hide and show tabs when in the mime random
- Add messaging