### PR TITLE
fix: Mime teleport

### DIFF
--- a/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -87,7 +87,7 @@ if (~inzone_coord_pair_table(trawler_game_zones, $coord) = true) {
     return(false);
 }
 if (~inzone_coord_pair_table(random_event_mime_zones, $coord) = true) {
-    ~mesbox("I need to finish my performance!"); // https://www.youtube.com/watch?v=aGIPPPlADys&t=92s
+    say("I need to finish my performance!"); // https://www.youtube.com/watch?v=aGIPPPlADys&t=92s
     return(false);
 }
 if (~in_duel_arena($coord) = true) {


### PR DESCRIPTION
Missed this when doing the cleanup, mime teleport away message is a say not a mesbox