### PR TITLE
fix: slash web success chance

### DIFF
--- a/scripts/general_use/scripts/web.rs2
+++ b/scripts/general_use/scripts/web.rs2
@@ -16,17 +16,14 @@ if (oc_param($item, slashattack_anim) = human_unarmedpunch & $item ! knife) {
 @cut_web($item);
 
 [label,cut_web](obj $item)
-def_int $chance;
 if ($item = knife) {
     anim(human_knife_slash, 0);
-    $chance = 2;
 } else {
     anim(oc_param($item, slashattack_anim), 0);
-    $chance = 5;
 }
 sound_synth(hacksword_slash, 0, 15);
 
-if (random($chance) = 1) {
+if (random(2) = 1) {
     mes("You slash the web apart.");
     p_delay(1); // osrs
     // Temp note: dur does not need updated


### PR DESCRIPTION
Webs should be 50% success rate for weapons and knives. 20% chance comes from a 2019 OSRS update that allowed any slash weapon to work for cutting webs.

Ash tweet with success chances noting that weapons which previously worked maintained their 50% rate:
https://x.com/JagexAsh/status/1164479217804947456

This also matches RS3: https://runescape.wiki/w/Spiderweb