### PR TITLE
fix: check prayer after accuracy roll, apply poison if accuracy roll passes

### DIFF
--- a/scripts/areas/area_burthorpe/scripts/death_troll_thrower.rs2
+++ b/scripts/areas/area_burthorpe/scripts/death_troll_thrower.rs2
@@ -28,10 +28,7 @@ def_int $duration = 64;
 // map_projanim_v2	id=troll_rock_travel (276), starttime=31, endtime=50, angle=8, progress=128, startheight=146, endheight=146
 $duration = ~player_projectile(npc_coord, coord, uid, npc_param(proj_travel), 36, 36, 31, 8, 15, 128, 1);
 
-if (~check_protect_prayer(^ranged_style) = false) { // bypasses defence, but checks prayer
-    ~playerhit_n_ranged(randominc($maxhit), $duration, npc_param(attackrate));
-    return;
-}
-~playerhit_n_ranged(0, $duration, npc_param(attackrate));
+// bypasses defence, but checks prayer
+~playerhit_n_ranged(true, randominc($maxhit), $duration, npc_param(attackrate));
 
 [ai_queue3,_troll_thrower] @troll_drop_table;

--- a/scripts/areas/area_taverly/scripts/druid.rs2
+++ b/scripts/areas/area_taverly/scripts/druid.rs2
@@ -35,7 +35,7 @@ if (random(5) = 0) {
 def_dbrow $spell_data = ~get_spell_data(^entangle);
 def_int $duration = ~npc_spell_cast($spell_data, 4);
 
-if (~npc_player_hit_roll(^magic_style) = true) {
+if (~npc_player_hit_roll(^magic_style) = true & ~check_protect_prayer(^magic_style) = false) {
     ~npc_spell_success($spell_data, 4, $duration);
     // osrs queues a "The holding effect is beginning to fade." after 6 ticks
     // but this video shows no message. https://youtu.be/fxCXNO-46pc

--- a/scripts/areas/area_wilderness/scripts/king_black_dragon.rs2
+++ b/scripts/areas/area_wilderness/scripts/king_black_dragon.rs2
@@ -156,7 +156,7 @@ spotanim_pl(fireblast_impact, 124, $duration); // https://web.archive.org/web/20
 
 def_int $damage = 0;
 
-def_int $attack_roll = ~npc_magic_attack_roll_no_prot;
+def_int $attack_roll = ~npc_magic_attack_roll;
 def_int $defence_roll = ~player_defence_roll_specific(^magic_style);
 if (randominc($attack_roll) > randominc($defence_roll)) {
     $damage = randominc(~kbd_fiery_breath_maxhit);
@@ -181,7 +181,7 @@ sound_synth(dragonbreath, 0, 30);
 
 def_int $damage = 0;
 
-def_int $attack_roll = ~npc_magic_attack_roll_no_prot;
+def_int $attack_roll = ~npc_magic_attack_roll;
 def_int $defence_roll = ~player_defence_roll_specific(^magic_style);
 if (randominc($attack_roll) > randominc($defence_roll)) {
     $damage = randominc(~kbd_fiery_breath_maxhit);
@@ -206,7 +206,7 @@ sound_synth(toxicbreath, 0, 30);
 
 def_int $damage = 0;
 
-def_int $attack_roll = ~npc_magic_attack_roll_no_prot;
+def_int $attack_roll = ~npc_magic_attack_roll;
 def_int $defence_roll = ~player_defence_roll_specific(^magic_style);
 if (randominc($attack_roll) > randominc($defence_roll)) {
     $damage = randominc(~kbd_special_breath_maxhit);
@@ -237,7 +237,7 @@ spotanim_pl(nezik_flamestrike, 0, 60);
 
 def_int $damage = 0;
 
-def_int $attack_roll = ~npc_magic_attack_roll_no_prot;
+def_int $attack_roll = ~npc_magic_attack_roll;
 def_int $defence_roll = ~player_defence_roll_specific(^magic_style);
 if (randominc($attack_roll) > randominc($defence_roll)) {
     $damage = randominc(~kbd_special_breath_maxhit);
@@ -283,7 +283,7 @@ sound_synth(kingicebreath, 0, 30);
 // freeze player
 def_int $damage = 0;
 
-def_int $attack_roll = ~npc_magic_attack_roll_no_prot;
+def_int $attack_roll = ~npc_magic_attack_roll;
 def_int $defence_roll = ~player_defence_roll_specific(^magic_style);
 if (randominc($attack_roll) > randominc($defence_roll)) {
     $damage = randominc(~kbd_special_breath_maxhit);

--- a/scripts/npc/scripts/chaos_druid.rs2
+++ b/scripts/npc/scripts/chaos_druid.rs2
@@ -35,7 +35,7 @@ def_dbrow $spell_data = ~get_spell_data(^bind);
 def_dbrow $effect_spell = ~get_spell_data(^confuse);
 def_int $duration = ~npc_spell_cast($spell_data, 4);
 
-if (~npc_player_hit_roll(^magic_style) = true) {
+if (~npc_player_hit_roll(^magic_style) = true & ~check_protect_prayer(^magic_style) = false) {
     ~npc_spell_success($spell_data, null, $duration);
     if(~npc_debuff_allowed($effect_spell) = true) ~npc_stat_change_effect($effect_spell);
     queue(chaosdruid_freeze_player, 0, 0);

--- a/scripts/npc/scripts/dragon.rs2
+++ b/scripts/npc/scripts/dragon.rs2
@@ -95,7 +95,7 @@ npc_anim(dragon_firebreath_middle_attack, 0);
 sound_synth(dragonbreath, 0, 30);
 %npc_action_delay = add(map_clock, 4);
 
-def_int $attack_roll = ~npc_magic_attack_roll_no_prot;
+def_int $attack_roll = ~npc_magic_attack_roll;
 def_int $defence_roll = ~player_defence_roll_specific(npc_param(damagetype));
 
 // damage player

--- a/scripts/quests/quest_dragon/scripts/melzar_the_mad.rs2
+++ b/scripts/quests/quest_dragon/scripts/melzar_the_mad.rs2
@@ -84,7 +84,7 @@ spotanim_npc(zap, 92, 0);
 sound_synth(zap, 0, 0);
 
 def_int $damage = 0;
-if (~npc_player_hit_roll(^magic_style) = true) {
+if (~npc_player_hit_roll(^magic_style) = true & ~check_protect_prayer(^magic_style) = false) {
     $damage = randominc($maxhit);
 }
 if ($damage > 0) {

--- a/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
@@ -112,12 +112,10 @@ def_int $damage = randominc($maxhit);
 if ($maxhit ! null) {
     // npc vs player spells have no 1t extra damage delay. Whereas player vs npc spells do (osrs)
     queue(combat_damage_player, calc($duration / 30), $damage);
-    if (npc_param(poison_severity) > 0 & $damage > 0) {
-        queue(poison_player, 0, npc_param(poison_severity));
-    }
     // player anim for flinching doesnt exist, even in osrs
     // anim(~combat_defend_anim(inv_getobj(worn, ^wearpos_rhand)), $duration);
 }
+~npc_poison_player;
 spotanim_pl(db_getfield($spell_data, magic_spell_table:spotanim_target, 0), $duration);
 queue*(playerhit_n_retaliate, calc($duration / 30))(npc_uid);
 

--- a/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat_magic.rs2
@@ -1,13 +1,4 @@
 [proc,npc_magic_attack_roll]()(int)
-if (~check_protect_prayer(^magic_style) = true) {
-    return(0);
-}
-def_int $magicattack = npc_param(magicattack);
-def_int $effective_magic = ~combat_effective_stat(npc_stat(magic), 100); // no prayerbonus
-$effective_magic = add($effective_magic, 9); // 'style bonus' of 1
-return(~combat_stat($effective_magic, $magicattack));
-
-[proc,npc_magic_attack_roll_no_prot]()(int)
 def_int $magicattack = npc_param(magicattack);
 def_int $effective_magic = ~combat_effective_stat(npc_stat(magic), 100); // no prayerbonus
 $effective_magic = add($effective_magic, 9); // 'style bonus' of 1
@@ -43,7 +34,7 @@ if($defined_max_hit ! null) {
     $maxhit = db_getfield($spell_data, magic_spell_table:maxhit, 0);
 }
 
-if (~npc_player_hit_roll(^magic_style) = true) {
+if (~npc_player_hit_roll(^magic_style) = true & ~check_protect_prayer(^magic_style) = false) {
     ~npc_spell_success($spell_data, $maxhit, $duration);
     ~npc_stat_change_effect($spell_data);
     ~npc_freeze_effect($spell_data);

--- a/scripts/skill_combat/scripts/npc/npc_combat_melee.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat_melee.rs2
@@ -10,9 +10,6 @@ return(~combat_maxhit($melee_strength));
 // returns the npc attack roll for this npc
 // npcs only have one attackbonus.
 [proc,npc_melee_attack_roll]()(int)
-if (~check_protect_prayer(^melee_style) = true) {
-    return(0);
-}
 def_int $attackbonus = npc_param(attackbonus);
 def_int $effective_attack = ~combat_effective_stat(npc_stat(attack), 100); // no prayerbonus
 $effective_attack = add($effective_attack, 9); // 'style bonus' of 1
@@ -28,12 +25,12 @@ def_int $maxhit = ~npc_melee_maxhit;
 // npc_say("Clock: <tostring(map_clock)>, NPC A: <tostring($attack_roll)>, Player D: <tostring($defence_roll)>, NPC Max: <tostring($maxhit)>");
 
 if (randominc($attack_roll) > randominc($defence_roll)) {
-    ~playerhit_n_melee(randominc($maxhit), npc_param(attackrate));
+    ~playerhit_n_melee(true, randominc($maxhit), npc_param(attackrate));
     return;
 }
-~playerhit_n_melee(0, npc_param(attackrate));
+~playerhit_n_melee(true, 0, npc_param(attackrate));
 
-[proc,playerhit_n_melee](int $damage, int $delay)
+[proc,playerhit_n_melee](boolean $check_protect_prayer, int $damage, int $delay)
 //~damage_self($damage);
 if_close; // close the player interface when taking a hit.
 // not sure if this is correct
@@ -42,6 +39,9 @@ if_close; // close the player interface when taking a hit.
 if (npc_stat(hitpoints) = 0) {
     return; // melee npc's on 0 health play the hit animation but dont actually damage you
     // but ranged/mage npcs do! This is unique to melee!
+}
+if ($check_protect_prayer = true & ~check_protect_prayer(^melee_style) = true) { 
+    $damage = 0;
 }
 queue(combat_damage_player, 0, $damage);
 if (npc_param(poison_severity) > 0 & $damage > 0) {

--- a/scripts/skill_combat/scripts/npc/npc_combat_melee.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat_melee.rs2
@@ -26,6 +26,7 @@ def_int $maxhit = ~npc_melee_maxhit;
 
 if (randominc($attack_roll) > randominc($defence_roll)) {
     ~playerhit_n_melee(true, randominc($maxhit), npc_param(attackrate));
+    ~npc_poison_player;
     return;
 }
 ~playerhit_n_melee(true, 0, npc_param(attackrate));

--- a/scripts/skill_combat/scripts/npc/npc_combat_ranged.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat_ranged.rs2
@@ -1,7 +1,4 @@
 [proc,npc_ranged_attack_roll]()(int)
-if (~check_protect_prayer(^ranged_style) = true) {
-    return(0);
-}
 def_int $rangeattack = npc_param(rangeattack);
 def_int $effective_ranged = ~combat_effective_stat(npc_stat(ranged), 100); // no prayerbonus
 $effective_ranged = add($effective_ranged, 9); // 'style bonus' of 1
@@ -41,14 +38,16 @@ def_int $duration = 64;
 $duration = ~player_projectile(npc_coord, coord, uid, npc_param(proj_travel), 40, 36, 32, 15, 0, 11, 5);
 
 if (randominc($attack_roll) > randominc($defence_roll)) {
-    ~playerhit_n_ranged(randominc($maxhit), $duration, npc_param(attackrate));
+    ~playerhit_n_ranged(true, randominc($maxhit), $duration, npc_param(attackrate));
     return;
 }
-~playerhit_n_ranged(0, $duration, npc_param(attackrate));
+~playerhit_n_ranged(true, 0, $duration, npc_param(attackrate));
 
-[proc,playerhit_n_ranged](int $damage, int $duration, int $delay)
+[proc,playerhit_n_ranged](boolean $check_protect_prayer, int $damage, int $duration, int $delay)
 if_close; // close the player interface when taking a hit.
-// not sure if this is correct
+if ($check_protect_prayer = true & ~check_protect_prayer(^ranged_style) = true) { 
+    $damage = 0;
+}
 queue(combat_damage_player, calc($duration / 30), $damage);
 if (npc_param(poison_severity) > 0 & $damage > 0) {
     queue(poison_player, 0, npc_param(poison_severity));

--- a/scripts/skill_combat/scripts/npc/npc_combat_ranged.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat_ranged.rs2
@@ -39,6 +39,7 @@ $duration = ~player_projectile(npc_coord, coord, uid, npc_param(proj_travel), 40
 
 if (randominc($attack_roll) > randominc($defence_roll)) {
     ~playerhit_n_ranged(true, randominc($maxhit), $duration, npc_param(attackrate));
+    ~npc_poison_player;
     return;
 }
 ~playerhit_n_ranged(true, 0, $duration, npc_param(attackrate));
@@ -49,9 +50,6 @@ if ($check_protect_prayer = true & ~check_protect_prayer(^ranged_style) = true) 
     $damage = 0;
 }
 queue(combat_damage_player, calc($duration / 30), $damage);
-if (npc_param(poison_severity) > 0 & $damage > 0) {
-    queue(poison_player, 0, npc_param(poison_severity));
-}
 queue*(playerhit_n_retaliate, calc($duration / 30))(npc_uid);
 ~npc_set_attack_vars;
 if(npc_param(npc_ammo) ! null) {

--- a/scripts/skill_combat/scripts/poison.rs2
+++ b/scripts/skill_combat/scripts/poison.rs2
@@ -1,3 +1,8 @@
+[proc,npc_poison_player]
+if (npc_param(poison_severity) > 0) {
+    queue(poison_player, 0, npc_param(poison_severity));
+}
+
 [queue,poison_player](int $severity)
 if (map_members = ^false) {
     // nothing poisons in f2p


### PR DESCRIPTION
for 225+

- Matches osrs, npcs can poison you through protection prayers.

- In order to accomplish this, I changed the playerhit_n procs to take a boolean, matches screenshots such as:
<img width="543" height="206" alt="image" src="https://github.com/user-attachments/assets/7acf8e84-c909-45a8-b7d0-328d2c205cad" />
