### PR TITLE
chore: redo MOM Random Event logic with new source for bowing anims

### DIFF
--- a/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
+++ b/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
@@ -5,43 +5,44 @@ sound_synth(smokepuff, 0, 0);
 // to match genie in this video: https://www.youtube.com/watch?v=el-h9hbSH80&t=293s
 npc_setmode(playerfollow);
 
-if ($random_old_man_event = 0) {
-    npc_say("Aha, you're required <displayname>!"); //https://www.youtube.com/watch?v=aqNlh2YPezM&t=49s No bow or greetings. Unsure if mime or maze
-    p_delay(1);
-    npc_del;
-    %macro_event = ^macro_mime;
-    ~mime_entry_point;
-    npc_del;
-} else {
-    npc_anim(emote_bow, 20);
-    npc_say("Greetings <displayname>!");
-    p_delay(1);
-    // For 254, The old man can either give you a gift, a strange box, send you to the maze, send you to the mime
-    switch_int ($random_old_man_event) {
-            case 1 : // https://www.youtube.com/watch?v=39XCOOLY-kM // Part of MOM spawn - Strange Box
-                    //You can only get this event if your inv is not full, otherwise he always sends you to a maze (maybe mime too?) on a full inv. 
-                    if(inv_freespace(inv) = 0) {
-                        npc_say("Hey, <displayname>, come and solve a maze for me!"); // Not sure. Roughly taken from OSRS
-                        p_delay(1);
-                        npc_del;
-                        %macro_event = ^macro_maze;
-                        ~start_macro_maze;
-                    } else {
-                        npc_say("Here you go <displayname>, it's all yours!");
-                        p_delay(1);
-                        npc_del;
-                        ~macro_events_varps_reset;
-                        ~give_strange_box;
-                    }
-            case 2 : 
-                    npc_say("Hey, <displayname>, come and solve a maze for me!"); // Not sure. Roughly taken from OSRS
-                    p_delay(1);
-                    npc_del;
-                    %macro_event = ^macro_maze;
-                    ~start_macro_maze;
-            case 3 : %npc_macro_event_target = uid; // gift
-            case default : return;
-    }
+if ($random_old_man_event = 1 & inv_freespace(inv) = 0) { // Cannot give strange box if no inventory space, so becomes Maze... Possibly also Mime?
+    $random_old_man_event = 2;
+}
+
+switch_int ($random_old_man_event) {
+    case 0 : // Mime
+        npc_say("Aha, you're required <displayname>!"); // https://www.youtube.com/watch?v=aqNlh2YPezM&t=49s No bow or greetings. Unsure if mime or maze
+        p_delay(1);
+        npc_del;
+        %macro_event = ^macro_mime;
+        ~mime_entry_point;
+        npc_del;
+        return;
+    case 1 : // Strange box
+        npc_anim(emote_bow, 20);
+        npc_say("Greetings <displayname>!");
+        p_delay(1);
+        npc_say("Here you go <displayname>, it's all yours!");
+        p_delay(1);
+        npc_del;
+        ~macro_events_varps_reset;
+        ~give_strange_box;
+        return;
+    case 2 : // Maze
+        npc_say("Aha, you'll do <displayname>!"); // No bowing for maze event, either according to https://youtu.be/A0V4NJn11ow?si=iVJ16Z7Yv4ueT4ao&t=11
+        p_delay(1);
+        npc_del;
+        %macro_event = ^macro_maze;
+        ~start_macro_maze;
+        return;
+    case 3 : // Gift
+        npc_anim(emote_bow, 20);
+        npc_say("Greetings <displayname>!");
+        p_delay(1);
+        %npc_macro_event_target = uid;
+        return;
+    case default :
+        return;
 }
 
 // other videos:

--- a/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
+++ b/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
@@ -16,7 +16,6 @@ switch_int ($random_old_man_event) {
         npc_del;
         %macro_event = ^macro_mime;
         ~mime_entry_point;
-        npc_del;
         return;
     case 1 : // Strange box
         npc_anim(emote_bow, 20);


### PR DESCRIPTION
New source to show no bow anim & different overhead 'say' for Maze. Restructured logic to better handle each scenario.