### PR TITLE
fix: split Maze dialogue over 2 lines as per new source

### DIFF
--- a/scripts/macro events/configs/macro_events.dbrow
+++ b/scripts/macro events/configs/macro_events.dbrow
@@ -1,3 +1,7 @@
 [random_event_mime_zones]
 table=coord_pair_table
 data=coord_pair,0_31_74_0_0,0_31_74_63_63
+
+[random_event_maze_zones]
+table=coord_pair_table
+data=coord_pair,0_45_71_0_0,0_45_71_63_63

--- a/scripts/macro events/scripts/general/macro_event_maze.rs2
+++ b/scripts/macro events/scripts/general/macro_event_maze.rs2
@@ -4,23 +4,22 @@
 [mapzone,0_45_71]
 if (%macro_event ! ^macro_maze) {
     %macro_event = ^macro_maze;
-    queue(maze_start, 0, 0);
+    settimer(macro_maze, 5);
+    ~update_macro_maze_progress;
+    if_openoverlay(mazetimer);
     //https://youtu.be/yCBpihIGy68?si=CsTkheu7cAfGpjHa&t=13 login inside maze
 }
 ~macro_events_set_tabs;
 @music_playbyregion(coord);
-
-[queue,maze_start]
-settimer(macro_maze, 5);
-~update_macro_maze_progress;
-if_openoverlay(mazetimer);
 
 [proc,start_macro_maze]
 def_coord $coord = enum(int, coord, macro_maze_teleports, random(enum_getoutputcount(macro_maze_teleports)));
 %xplamp = 100;
 %macro_event_target_coord = coord;
 p_telejump($coord);
-queue(maze_start, 0, 0);
+settimer(macro_maze, 5);
+~update_macro_maze_progress;
+if_openoverlay(mazetimer);
 mes("You need to reach the maze centre, then you'll be returned to where you were.");
 ~chatnpc_specific("Mysterious Old Man", macro_mysterious_old_man, "<p,neutral>You need to reach the maze centre,|then you'll be returned to where you were."); // Split line as per https://imgur.com/riCliBA
 

--- a/scripts/macro events/scripts/general/macro_event_maze.rs2
+++ b/scripts/macro events/scripts/general/macro_event_maze.rs2
@@ -22,7 +22,7 @@ def_coord $coord = enum(int, coord, macro_maze_teleports, random(enum_getoutputc
 p_telejump($coord);
 queue(maze_start, 0, 0);
 mes("You need to reach the maze centre, then you'll be returned to where you were.");
-~chatnpc_specific("Mysterious Old Man", macro_mysterious_old_man, "<p,neutral>You need to reach the maze centre, then you'll be returned to where you were.");
+~chatnpc_specific("Mysterious Old Man", macro_mysterious_old_man, "<p,neutral>You need to reach the maze centre,|then you'll be returned to where you were."); // Split line as per https://imgur.com/riCliBA
 
 [proc,end_macro_maze]
 if_openoverlay(null);
@@ -90,7 +90,7 @@ if (p_finduid(uid) = false) {
 def_coord $coord = enum(int, coord, macro_maze_teleports, random(enum_getoutputcount(macro_maze_teleports)));
 %xplamp = 100;
 p_telejump($coord);
-~chatnpc_specific("Mysterious Old Man", macro_mysterious_old_man, "<p,neutral>You need to reach the maze centre, then you'll be returned to where you were.");
+~chatnpc_specific("Mysterious Old Man", macro_mysterious_old_man, "<p,neutral>You need to reach the maze centre,|then you'll be returned to where you were."); // Split line as per https://imgur.com/riCliBA
 mes("You need to reach the maze centre, then you'll be returned to where you were.");
 
 [debugproc,mazeend]

--- a/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -90,6 +90,10 @@ if (~inzone_coord_pair_table(random_event_mime_zones, $coord) = true) {
     say("I need to finish my performance!"); // https://www.youtube.com/watch?v=aGIPPPlADys&t=92s
     return(false);
 }
+if (~inzone_coord_pair_table(random_event_maze_zones, $coord) = true) {
+    say("I need to reach the maze centre!"); // Best guess, similar to mime
+    return(false);
+}
 if (~in_duel_arena($coord) = true) {
     mes("Coward! You can't teleport from a duel."); //RS3 message: https://archive.org/details/runelibris
     //Colored in #AB0908 in RS3, but was likely not colored in 2004


### PR DESCRIPTION
Source from Tanner in #sources shows the dialogue upon Maze Random Event starting is split over 2 lines:  https://imgur.com/riCliBA

Previous behaviour without manual split matches newer sources, however, as seen below:
https://www.youtube.com/watch?v=2gpzn9oNdy0
<img width="1606" height="1104" alt="image" src="https://github.com/user-attachments/assets/4d8437c2-1ba2-4280-bfe3-f128d4e165a4" />