### PR TITLE
fix: various agilityarena fixes

### DIFF
--- a/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
@@ -216,6 +216,10 @@ sound_synth(jump_no_land, 0, 0);
 stat_advance(agility, 180);
 
 [oploc1,agilityarena_handholds]
+if(stat(agility) < 20) {
+    mes("You need an agility level of at least 20 to get past this obstacle!");
+    return;
+}
 p_delay(0);
 def_int $dx;
 def_int $dz;
@@ -350,7 +354,7 @@ sound_synth(monkeybars_on, 0, 0);
 p_delay(0);
 sound_synth(monkeybars_loop, 6, 0);
 ~forcemove(movecoord(coord, calc($dx * 2), 0, calc($dz * 2)));
-if(stat_random(agility, 235, 275) = false) {
+if(stat_random(agility, 230, 280) = false) {
     ~update_bas;
     anim(human_monkeybars_off, 0);
     sound_synth(monkeybars_off, 0, 0);
@@ -393,7 +397,20 @@ if(coordx(coord) < coordx(loc_coord)) {
 }
 ~set_forcemove_bas($walk_seq);
 sound_synth(balancing_ledge, 3, 10);
-~forcemove(movecoord(coord, multiply($x_dist, 3), 0, 0));
+~forcemove(movecoord(coord, multiply($x_dist, 2), 0, 0));
+if(stat_random(agility, 230, 280) = false) {
+    ~update_bas;
+    anim(human_walk_logbalance_stumble, 0);
+    facesquare(movecoord(coord, -1, 0, 0)); // face west
+    p_delay(0);
+    p_teleport(movecoord(coord, 0, -3, multiply($x_dist, 1)));
+    p_delay(0);
+    mes("You lost your balance!");
+    ~forcemove(movecoord(coord, multiply($x_dist, -1), 0, 0));
+    ~damage_self(calc((stat(hitpoints) * 5 / 100) + 2));
+    return;
+}
+~forcemove(movecoord(coord, $x_dist, 0, 0));
 p_delay(0);
 sound_synth(balancing_ledge, 2, 0);
 ~forcemove(movecoord(coord, multiply($x_dist, 2), 0, 0));


### PR DESCRIPTION
- change monkey bars fail rate to match some other level 1 obstacles
- add requirement to handholds. failing to ledge obstacle