### PR TITLE
fix: updates to party room auto-clean

### DIFF
--- a/scripts/_unpack/225/all.obj
+++ b/scripts/_unpack/225/all.obj
@@ -246,6 +246,7 @@ model=model_2724_obj
 2dzan=260
 2dxan=460
 weight=1lb
+param=party_clean_exempt,^true
 
 [edgevilledungeonkey]
 name=Brass key

--- a/scripts/general_use/configs/holiday.obj
+++ b/scripts/general_use/configs/holiday.obj
@@ -44,6 +44,7 @@ womanwear=model_363_obj_wear,0
 manhead=model_29_obj_wear
 womanhead=model_87_obj_wear
 weight=2oz
+param=party_clean_exempt,^true
 
 [yellow_partyhat]
 name=Yellow partyhat
@@ -63,6 +64,7 @@ womanwear=model_363_obj_wear,0
 manhead=model_29_obj_wear
 womanhead=model_87_obj_wear
 weight=2oz
+param=party_clean_exempt,^true
 
 [blue_partyhat]
 name=Blue partyhat
@@ -82,6 +84,7 @@ womanwear=model_363_obj_wear,0
 manhead=model_29_obj_wear
 womanhead=model_87_obj_wear
 weight=2oz
+param=party_clean_exempt,^true
 
 [green_partyhat]
 name=Green partyhat
@@ -101,6 +104,7 @@ womanwear=model_363_obj_wear,0
 manhead=model_29_obj_wear
 womanhead=model_87_obj_wear
 weight=2oz
+param=party_clean_exempt,^true
 
 [purple_partyhat]
 name=Purple partyhat
@@ -120,6 +124,7 @@ womanwear=model_363_obj_wear,0
 manhead=model_29_obj_wear
 womanhead=model_87_obj_wear
 weight=2oz
+param=party_clean_exempt,^true
 
 [white_partyhat]
 name=White partyhat
@@ -139,6 +144,7 @@ womanwear=model_363_obj_wear,0
 manhead=model_29_obj_wear
 womanhead=model_87_obj_wear
 weight=2oz
+param=party_clean_exempt,^true
 
 [santa_hat]
 name=Santa hat
@@ -156,6 +162,7 @@ manhead=model_69_obj_wear
 womanhead=model_127_obj_wear
 iop2=Wear
 weight=4oz
+param=party_clean_exempt,^true
 
 [halloweenmask_green]
 name=Halloween mask
@@ -176,6 +183,7 @@ womanhead=model_3187_obj_wear
 2dzoom=730
 2dxan=516
 iop2=Wear
+param=party_clean_exempt,^true
 
 [halloweenmask_blue]
 name=Halloween mask
@@ -196,6 +204,7 @@ womanhead=model_3187_obj_wear
 2dzoom=730
 2dxan=516
 iop2=Wear
+param=party_clean_exempt,^true
 
 [halloweenmask_red]
 name=Halloween mask
@@ -214,3 +223,4 @@ womanhead=model_3187_obj_wear
 2dzoom=730
 2dxan=516
 iop2=Wear
+param=party_clean_exempt,^true

--- a/scripts/minigames/game_partyroom/configs/partyroom.param
+++ b/scripts/minigames/game_partyroom/configs/partyroom.param
@@ -1,0 +1,3 @@
+[party_clean_exempt]
+type=int
+default=0

--- a/scripts/minigames/game_partyroom/scripts/party_pete.rs2
+++ b/scripts/minigames/game_partyroom/scripts/party_pete.rs2
@@ -69,8 +69,8 @@ if(huntnext = true) { // this only checks 1 player, if it fails on them nothing 
         // iterate through the slots of the chest in order and drop on random 1x1 free tile
         while ($slot < inv_size(partyroom_dropinv)) {
             def_obj $slotobj = inv_getobj(partyroom_dropinv, $slot);
-            // notes are untouched regardless of value
-            if ($slotobj ! null & oc_cert($slotobj) ! $slotobj & oc_cost($slotobj) <= 3) {
+            // notes/stackables are untouched regardless of value
+            if ($slotobj ! null & oc_stackable($slotobj) = false & oc_param($slotobj, party_clean_exempt) = ^false & oc_cost($slotobj) < 100) {
                 inv_dropslot(partyroom_dropinv, map_findsquare(npc_coord, 0, 1, ^map_findsquare_none), $slot, 200);
                 $dropped = add($dropped, 1);
             }

--- a/scripts/skill_combat/configs/melee/trails.obj
+++ b/scripts/skill_combat/configs/melee/trails.obj
@@ -89,6 +89,7 @@ manwear=model_243_obj_wear,0
 womanwear=model_416_obj_wear,0
 manhead=model_76_obj_wear
 womanhead=model_134_obj_wear
+param=party_clean_exempt,^true
 
 [berret_blue]
 name=Berret
@@ -110,6 +111,7 @@ manwear=model_198_obj_wear,0
 womanwear=model_373_obj_wear,0
 manhead=model_40_obj_wear
 womanhead=model_98_obj_wear
+param=party_clean_exempt,^true
 
 [berret_black]
 name=Berret
@@ -131,6 +133,7 @@ manwear=model_198_obj_wear,0
 womanwear=model_373_obj_wear,0
 manhead=model_40_obj_wear
 womanhead=model_98_obj_wear
+param=party_clean_exempt,^true
 
 [berret_white]
 name=Berret
@@ -152,6 +155,7 @@ manwear=model_198_obj_wear,0
 womanwear=model_373_obj_wear,0
 manhead=model_40_obj_wear
 womanhead=model_98_obj_wear
+param=party_clean_exempt,^true
 
 [cavalier_brown]
 name=Cavalier
@@ -235,6 +239,7 @@ manwear=model_201_obj_wear,0
 womanwear=model_376_obj_wear,0
 manhead=model_43_obj_wear
 womanhead=model_101_obj_wear
+param=party_clean_exempt,^true
 
 [headband_black]
 name=Headband
@@ -257,6 +262,7 @@ manwear=model_201_obj_wear,0
 womanwear=model_376_obj_wear,0
 manhead=model_43_obj_wear
 womanhead=model_101_obj_wear
+param=party_clean_exempt,^true
 
 [headband_brown]
 name=Headband
@@ -279,6 +285,7 @@ manwear=model_201_obj_wear,0
 womanwear=model_376_obj_wear,0
 manhead=model_43_obj_wear
 womanhead=model_101_obj_wear
+param=party_clean_exempt,^true
 
 [piratehat]
 name=Pirate's hat

--- a/scripts/skill_cooking/configs/cooking_generic/cooking.obj
+++ b/scripts/skill_cooking/configs/cooking_generic/cooking.obj
@@ -220,6 +220,7 @@ model=model_2591_obj
 2dxan=132
 weight=500g
 category=category_131
+param=party_clean_exempt,^true
 
 [easter_egg]
 name=Easter egg
@@ -232,6 +233,7 @@ model=model_2534_obj
 2dxan=2044
 weight=3oz
 category=category_59
+param=party_clean_exempt,^true
 
 // Typo of `bannana` in model name is Jagex consistent.
 [banana]


### PR DESCRIPTION
- change value check to match the grand exchange value used in OSRS
- add param to prevent dropping certain items below the value threshold
- change check to prevent dropping any stackable items