### PR TITLE
fix: more brimhaven rate updates

### DIFF
--- a/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
@@ -260,7 +260,7 @@ if (.loc_find(movecoord(coord, 0, 0, 1), agilityarena_handholds_middle) = true) 
 // https://youtu.be/fu3V6gn4WWM?si=JsMRX4S23YvvD-Ev&t=355 2t delay instead of 1t (OSRS is 1t)
 sound_synth(handholds_grab_to_second, 0, 0);
 ~agility_exactmove($start_seq, 0, 1, loc_coord, movecoord(loc_coord, $dx, 0, $dz), 46, 60, $dir, false);
-if(stat_random(agility, 185, 255) = false) {
+if(stat_random(agility, 180, 280) = false) {
     ~update_bas;
     ~agility_exactmove($fall_seq, 0, 2, movecoord(loc_coord, $dx, 0, $dz), movecoord(loc_coord, multiply(2, $dx), 0, multiply(2, $dz)), 26, 44, $dir, false);
     p_teleport(movecoord(coord, 0, -3, 0));

--- a/scripts/minigames/game_agilityarena/scripts/agilityarena_zones.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena_zones.rs2
@@ -106,7 +106,7 @@ if(loc_find(coord, agilityarena_floorspikes) = true) {
     // https://youtu.be/eHMW2KRp9_Q?si=H8uk_KvSW2zFNcIQ&t=119 1t delay before activating, which osrs doesnt seem to have
     p_stopaction;
     p_delay(0);
-    if(stat_random(agility, 180, 250) = false | stat(agility) < 20) {
+    if(stat_random(agility, 150, 250) = false | stat(agility) < 20) {
         if(stat(agility) < 20) mes("You need an agility level of at least 20 to get past this trap!");
         mes("You were hit by some floor spikes!");
         sound_synth(floor_spikes, 0, 0);
@@ -143,7 +143,7 @@ if(loc_find(coord, agilityarena_pressurepad) = true) {
     // https://youtu.be/eHMW2KRp9_Q?si=4o0WDWs9VMAxXitO&t=137 1t delay before activating, which osrs doesnt seem to have (same as floor spikes bascially)
     p_stopaction;
     p_delay(0);
-    if(stat_random(agility, 165, 235) = false | stat(agility) < 20) {
+    if(stat_random(agility, 135, 235) = false | stat(agility) < 20) {
         if(stat(agility) < 20) mes("You need an agility level of at least 20 to get past this trap!");
         mes("You were hit by some falling rocks!");
         sound_synth(roof_collapse, 0, 0);
@@ -194,7 +194,7 @@ if((inzone(3_43_149_25_43, 3_43_149_27_43, coord) = true | inzone(3_43_149_31_37
     & loc_find(~get_sawblades_coord, agilityarena_sawblades) = true) {
     p_stopaction;
     p_delay(0);
-    if(stat_random(agility, 141, 191) = false | stat(agility) < 40) {
+    if(stat_random(agility, 91, 191) = false | stat(agility) < 40) {
         if(stat(agility) < 40) mes("You need an agility level of at least 40 to get past this trap!");
         if(~total_distance(coord, loc_coord) > 1) {
             // these could just be coord checks, theres only 3 of them and they all have different angles
@@ -254,7 +254,7 @@ if(coord = 3_43_149_42_38 | coord = 3_43_149_42_37 | coord = 3_43_149_37_21 | co
     p_stopaction;
     p_delay(0);
     $pillar_coord, $cam2, $cam3, $dart_target, $dest, $fail, $dir = ~get_poisondart_vals(coord);
-    if(stat_random(agility, 130, 180) = false | stat(agility) < 40) {
+    if(stat_random(agility, 80, 180) = false | stat(agility) < 40) {
         if(stat(agility) < 40) mes("You need an agility level of at least 40 to get past this trap!");
         sound_synth(dart_fire_hit, 0, 0);
         ~coord_projectile($pillar_coord, coord, bullettime_dart, 0, 10, 0, 2, 25, 40, 0);


### PR DESCRIPTION
according to the description of this Jebrim video: https://www.youtube.com/watch?v=IC4qvIcy0mM
and mentioned in this Autumn Elegy video: https://www.youtube.com/watch?v=T5Tu3qUGXhI&t=590s
you should stop failing obstacles that drop you down at 74/75, which means the handholds (that have a level 20 requirement) should likely stop failing here, thanks to Pasta on discord for bringing this up!

This also updates the timer traps (pressure pads, spikes, darts, sawblades) to fail more frequently at lower levels, based off old videos these should fail a lot (e.g. https://www.youtube.com/watch?v=fu3V6gn4WWM&t=75s)
