### PR TITLE
fix: 244 mes changes

### DIFF
--- a/scripts/areas/area_karamja/scripts/customs_officer.rs2
+++ b/scripts/areas/area_karamja/scripts/customs_officer.rs2
@@ -75,8 +75,7 @@ if (inv_total(inv, coins) < 30) {
 }
 
 inv_del(inv, coins, 30);
-mes("You pay 30 coins..."); // https://imgur.com/myiOU5N may 2004
-def_string $sail_msg = "and board the ship.";
+def_string $sail_msg = "You pay 30 coins and board the ship."; // https://storage.googleapis.com/tannerdino/images/HolyGrail.jpg
 if(coordx(npc_coord) < 2815) { // officer in Brimhaven
     ~set_sail("Ardougne", $sail_msg, 1_41_51_59_4, ^sail_brimhaven_to_ardougne, 7);
 } else {

--- a/scripts/skill_mining/scripts/mining.rs2
+++ b/scripts/skill_mining/scripts/mining.rs2
@@ -191,7 +191,7 @@ if ($data = null) {
 }
 inv_add(inv, db_getfield($data, mining_table:rock_output, 0), 1);
 stat_advance(mining, db_getfield($data, mining_table:rock_exp, 0));
-mes("You manage to mine an unbound rune stone.");
+// mes("You manage to mine an unbound rune stone."); probably removed with law altar?
 p_oploc(3);
 
 


### PR DESCRIPTION
for 244+

Our old code matched a may 2004 screenshot:
<img width="732" height="515" alt="image" src="https://github.com/user-attachments/assets/d11a8c19-a176-4c95-814d-31f459483f6f" />

It seems this mes has been changed around [june 2004](https://web.archive.org/web/20050101155211/http://www.runescapecommunity.com/index.php?showtopic=146299) though:
<img width="787" height="530" alt="image" src="https://github.com/user-attachments/assets/6ca0205d-b886-4097-908d-fee777ab4473" />


- removes ess mining mes. The latest screenshot we have of this mes is from rs2 beta:
<img width="1024" height="742" alt="image" src="https://github.com/user-attachments/assets/bc4be38f-1331-4dff-a248-59206e53aa36" />

the earliest screenshot we have of it not having the mes is from dec 2004 - jan 2005?:
<img width="1242" height="933" alt="image" src="https://github.com/user-attachments/assets/d317e785-db81-4f8e-bdaa-320ef2f377e7" />

<img width="1238" height="937" alt="image" src="https://github.com/user-attachments/assets/37553796-5235-42f5-bdef-25071ca9e9e1" />