### PR TITLE
fix: agilityarena changes

### DIFF
--- a/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
@@ -320,9 +320,9 @@ if(stat_random(agility, 240, 290) = false) {
     return;
 }
 sound_synth(climb_wall, 0, 40);
-~agility_exactmove(human_walk_crumbledwall, 30, 4, coord, movecoord(coord, multiply(3, $dx), 0, multiply(3, $dz)), 30, 100, $dir, true);
+~agility_exactmove(human_walk_crumbledwall, 30, 3, coord, movecoord(coord, multiply(3, $dx), 0, multiply(3, $dz)), 30, 100, $dir, true);
 // exact move for 270+ (changed sept 27 2004 most likely)
-// ~agility_exactmove(human_lowwall, 0, 4, coord, movecoord(coord, multiply(3, $dx), 0, multiply(3, $dz)), 0, 144, $dir, true);
+// ~agility_exactmove(human_lowwall, 0, 3, coord, movecoord(coord, multiply(3, $dx), 0, multiply(3, $dz)), 0, 144, $dir, true);
 stat_advance(agility, 80);
 
 [oploc1,agilityarena_monkeybars_end]

--- a/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
@@ -387,9 +387,11 @@ stat_advance(agility, 140);
 
 [label,agilityarena_ledge]
 p_delay(0);
+// https://youtu.be/eHMW2KRp9_Q?si=Q-j-HvEy1eKe5xOy&t=96 one side has no end seq, the other does
+// https://youtu.be/fu3V6gn4WWM?si=uskgi-XANqCyj9nm&t=204 this means the side with the seq takes 1t longer than the other
 def_int $x_dist = -1;
 def_seq $walk_seq = human_walk_sidestepl;
-def_seq $end_seq = human_outof_sidestepl;
+def_seq $end_seq = null;
 if(coordx(coord) < coordx(loc_coord)) {
     $x_dist = 1;
     $walk_seq = human_walk_sidestep;
@@ -417,8 +419,10 @@ sound_synth(balancing_ledge, 2, 0);
 p_delay(0);
 sound_synth(balancing_ledge, 2, 0);
 ~forcemove(movecoord(coord, multiply($x_dist, 2), 0, 0));
-anim($end_seq, 20);
-p_delay(0);
+if($end_seq ! null) {
+    anim($end_seq, 20);
+    p_delay(0);
+}
 ~update_bas;
 stat_advance(agility, 160);
 

--- a/scripts/minigames/game_agilityarena/scripts/agilityarena_clerk.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena_clerk.rs2
@@ -69,7 +69,11 @@ mes("You give Cap'n Izzy the 200 coin entrance fee.");
 
 [ai_timer,agilityarena_clerk]
 if(map_clock >= %agilityarena_next_pillar_time) {
-    %agilityarena_pillar_index = random(24);
+    def_int $new_pillar = random(24);
+    while ($new_pillar = %agilityarena_pillar_index) {
+        $new_pillar = random(24);
+    }
+    %agilityarena_pillar_index = $new_pillar;
     %agilityarena_next_pillar_time = add(map_clock, 100);
     ~agilityarena_change_planks;
 }

--- a/scripts/minigames/game_agilityarena/scripts/agilityarena_clerk.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena_clerk.rs2
@@ -77,21 +77,23 @@ if(map_clock >= %agilityarena_next_pillar_time) {
     %agilityarena_next_pillar_time = add(map_clock, 100);
     ~agilityarena_change_planks;
 }
-if(modulo(map_clock, 10) = 0) {
+if(modulo(map_clock, 7) = 0) {
     // these all happen at the same time afaik
-    if(loc_find(3_43_149_31_15, agilityarena_timedblade2_floor) = true) {
+    if(loc_find(3_43_149_31_15, agilityarena_timedblade2_floor) = true & .loc_find(3_43_149_31_16, agilityarena_timedblade2_floorl) = true) {
         ~activate_timedblade(0, 1);
     }
-    if(loc_find(3_43_149_9_48, agilityarena_timedblade2_floor) = true) {
+    if(loc_find(3_43_149_9_48, agilityarena_timedblade2_floor) = true & .loc_find(3_43_149_9_49, agilityarena_timedblade2_floorl) = true) {
         ~activate_timedblade(0, 1);
     }
-    if(loc_find(3_43_149_36_43, agilityarena_timedblade2_floor) = true) {
+    if(loc_find(3_43_149_36_43, agilityarena_timedblade2_floor) = true & .loc_find(3_43_149_37_43, agilityarena_timedblade2_floorl) = true) {
         ~activate_timedblade(1, 0);
     }
 }
 
 [proc,activate_timedblade](int $dx, int $dz)
 def_coord $dest;
+loc_del(5);
+.loc_del(5);
 loc_add(loc_coord, agilityarena_trap_timedblade2, loc_angle, centrepiece_straight, 5);
 huntall(loc_coord, 4, 0);
 while(huntnext = true) {

--- a/scripts/minigames/game_agilityarena/scripts/agilityarena_clerk.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena_clerk.rs2
@@ -74,7 +74,7 @@ if(map_clock >= %agilityarena_next_pillar_time) {
         $new_pillar = random(24);
     }
     %agilityarena_pillar_index = $new_pillar;
-    %agilityarena_next_pillar_time = add(map_clock, 100);
+    %agilityarena_next_pillar_time = add(map_clock, 99);
     ~agilityarena_change_planks;
 }
 if(modulo(map_clock, 7) = 0) {

--- a/scripts/minigames/game_agilityarena/scripts/agilityarena_clerk.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena_clerk.rs2
@@ -74,7 +74,7 @@ if(map_clock >= %agilityarena_next_pillar_time) {
         $new_pillar = random(24);
     }
     %agilityarena_pillar_index = $new_pillar;
-    %agilityarena_next_pillar_time = add(map_clock, 99);
+    %agilityarena_next_pillar_time = add(map_clock, 98);
     ~agilityarena_change_planks;
 }
 if(modulo(map_clock, 7) = 0) {

--- a/scripts/minigames/game_agilityarena/scripts/agilityarena_zones.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena_zones.rs2
@@ -224,7 +224,7 @@ if((inzone(3_43_149_25_43, 3_43_149_27_43, coord) = true | inzone(3_43_149_31_37
     }
     loc_anim(agilityarena_sawblades_twist);
     sound_synth(land_flat, 0, 30);
-    p_delay(1);
+    p_delay(0);
     stat_advance(agility, 280);
 }
 


### PR DESCRIPTION
- prevent same pillar from being picked twice in a row
- remove the additional 1t delay at the end of the sawblades and low wall obstacles
- tickets change every 98t instead of 100, source: https://oldschool.runescape.wiki/w/Agility_arena_ticket (re-measured in OSRS as well)