### PR TITLE
fix: mime queue check, standarize general macro event chances

### DIFF
--- a/scripts/_test/scripts/cheats/cheat_macro_event.rs2
+++ b/scripts/_test/scripts/cheats/cheat_macro_event.rs2
@@ -11,6 +11,14 @@ if ($event < 1 | $event > ~macro_event_general_count) {
 }
 ~macro_event_general_spawn($event);
 
+[debugproc,random_event]
+if_close;
+if (p_finduid(uid) = false) {
+    @please_finish;
+    return;
+}
+~macro_event_general_spawn(~macro_event_set_random);
+
 [debugproc,random]
 if (p_finduid(uid) = true) {
     %macro_event = ^no_macro_event;

--- a/scripts/macro events/configs/macro_events.constant
+++ b/scripts/macro events/configs/macro_events.constant
@@ -5,14 +5,14 @@
 
 ^macro_triffidseed = 5
 
-^macro_bigfish = 6
+^macro_cube = 6
 
 ^macro_mime = 7
-^macro_mime_solve_1 = 8
-^macro_mime_solve_2 = 9
-^macro_mime_solve_3 = 10
+^macro_mime_solve_1 = 100
+^macro_mime_solve_2 = 101
+^macro_mime_solve_3 = 102
 
-^macro_maze = 11
+^macro_maze = 8
 
 ^no_macro_event = 0
 
@@ -49,3 +49,5 @@
 ^macro_mime_glass_box = 1
 ^macro_mime_climb_rope = 2
 ^macro_mime_lean = 3
+
+^members_macro_count = 1

--- a/scripts/macro events/configs/macro_events.enum
+++ b/scripts/macro events/configs/macro_events.enum
@@ -1,4 +1,4 @@
-[general_macro_events_members]
+[general_macro_events]
 inputtype=int
 outputtype=npc
 val=1,macro_swarm
@@ -6,14 +6,9 @@ val=2,macro_geni
 val=3,macro_dwarf
 val=4,macro_mysterious_old_man
 val=5,macro_triffidseed
-
-[general_macro_events_free]
-inputtype=int
-outputtype=npc
-val=1,macro_swarm
-val=2,macro_geni
-val=3,macro_dwarf
-val=4,macro_mysterious_old_man
+val=6,macro_mysterious_old_man
+val=7,macro_mysterious_old_man
+val=8,macro_mysterious_old_man
 
 [macro_event_zombie_levels]
 inputtype=int

--- a/scripts/macro events/scripts/general/macro_event_mime.rs2
+++ b/scripts/macro events/scripts/general/macro_event_mime.rs2
@@ -93,7 +93,7 @@ npc_settimer(2); // Called every 2 ticks
 
 
 [queue,mime_step_right_up]
-p_teleport(0_31_74_24_26);
+if(coord = 0_31_74_24_28) p_teleport(movecoord(coord, 0, 0, -2));
 
 
 // Trigger: All the button clicks

--- a/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
+++ b/scripts/macro events/scripts/general/macro_event_mysterious_old_man.rs2
@@ -1,23 +1,22 @@
-[proc,macro_mysterious_old_man_spawn]
-def_int $random_old_man_event = random(4);
+[proc,macro_mysterious_old_man_spawn](int $random_old_man_event)
 spotanim_map(smokepuff, npc_coord, 124, 0);
 sound_synth(smokepuff, 0, 0);
 // to match genie in this video: https://www.youtube.com/watch?v=el-h9hbSH80&t=293s
 npc_setmode(playerfollow);
 
-if ($random_old_man_event = 1 & inv_freespace(inv) = 0) { // Cannot give strange box if no inventory space, so becomes Maze... Possibly also Mime?
-    $random_old_man_event = 2;
+if ($random_old_man_event = ^macro_cube & inv_freespace(inv) = 0) { // Cannot give strange box if no inventory space, so becomes Maze... Possibly also Mime?
+    $random_old_man_event = ^macro_maze;
 }
 
 switch_int ($random_old_man_event) {
-    case 0 : // Mime
+    case ^macro_mime : // Mime
         npc_say("Aha, you're required <displayname>!"); // https://www.youtube.com/watch?v=aqNlh2YPezM&t=49s No bow or greetings. Unsure if mime or maze
         p_delay(1);
         npc_del;
         %macro_event = ^macro_mime;
         ~mime_entry_point;
         return;
-    case 1 : // Strange box
+    case ^macro_cube : // Strange box
         npc_anim(emote_bow, 20);
         npc_say("Greetings <displayname>!");
         p_delay(1);
@@ -27,20 +26,18 @@ switch_int ($random_old_man_event) {
         ~macro_events_varps_reset;
         ~give_strange_box;
         return;
-    case 2 : // Maze
+    case ^macro_maze : // Maze
         npc_say("Aha, you'll do <displayname>!"); // No bowing for maze event, either according to https://youtu.be/A0V4NJn11ow?si=iVJ16Z7Yv4ueT4ao&t=11
         p_delay(1);
         npc_del;
         %macro_event = ^macro_maze;
         ~start_macro_maze;
         return;
-    case 3 : // Gift
+    case ^macro_mysterious_old_man : // Gift
         npc_anim(emote_bow, 20);
         npc_say("Greetings <displayname>!");
         p_delay(1);
         %npc_macro_event_target = uid;
-        return;
-    case default :
         return;
 }
 

--- a/scripts/macro events/scripts/macro_events.rs2
+++ b/scripts/macro events/scripts/macro_events.rs2
@@ -90,7 +90,7 @@ def_int $random = ~random_range(1, enum_getoutputcount(general_macro_events));
 if(map_members = ^false) {
     while($random = ^macro_triffidseed) $random = ~random_range(1, enum_getoutputcount(general_macro_events));
 }
-return(~random_range(1, enum_getoutputcount(general_macro_events)));
+return($random);
 
 // used for skilling random events
 [proc,macro_event_general_count]()(int)

--- a/scripts/macro events/scripts/macro_events.rs2
+++ b/scripts/macro events/scripts/macro_events.rs2
@@ -41,7 +41,7 @@ switch_int ($event) {
     case ^macro_triffidseed : ~macro_event_triffid_spawn;
     case ^macro_dwarf : ~macro_dwarf_spawn;
     case ^macro_geni : ~macro_geni_spawn;
-    case ^macro_mysterious_old_man : ~macro_mysterious_old_man_spawn;
+    case ^macro_mysterious_old_man, ^macro_cube, ^macro_mime, ^macro_maze : ~macro_mysterious_old_man_spawn($event);
 }
 
 [proc,macro_event_area](coord $coord)(boolean)
@@ -83,27 +83,20 @@ if (npc_finduid(%macro_event_uid) = true) {
 }
 
 [proc,macro_event_npc](int $event)(npc)
-def_npc $event_npc;
-if (map_members = ^true) {
-    $event_npc = enum(int, npc, general_macro_events_members, $event);
-} else {
-    $event_npc = enum(int, npc, general_macro_events_free, $event);
-}
-return($event_npc);
+return(enum(int, npc, general_macro_events, $event));
 
 [proc,macro_event_set_random]()(int)
-if (map_members = ^true) {
-    return(~random_range(1, enum_getoutputcount(general_macro_events_members)));
-} else {
-    return(~random_range(1, enum_getoutputcount(general_macro_events_free)));
+def_int $random = ~random_range(1, enum_getoutputcount(general_macro_events));
+if(map_members = ^false) {
+    while($random = ^macro_triffidseed) $random = ~random_range(1, enum_getoutputcount(general_macro_events));
 }
+return(~random_range(1, enum_getoutputcount(general_macro_events)));
 
 // used for skilling random events
 [proc,macro_event_general_count]()(int)
-if (map_members = ^true) {
-    return(enum_getoutputcount(general_macro_events_members));
-}
-return(enum_getoutputcount(general_macro_events_free));
+def_int $count = enum_getoutputcount(general_macro_events);
+if(map_members = ^false) $count = sub($count, ^members_macro_count);
+return($count);
 
 // teleports the player to a random location, using the coords in configs/macro_events_teleports.enum
 [queue,macro_event_fail_teleport]


### PR DESCRIPTION
for 254
- create debugproc for general random events
- add coord check to mime movement queue, prevents queue from running after death
- change the odds of the new mysterious old man random events to match all other events, also remove the f2p enum and use a shared enum for all general randoms (with a hardcoded check for the p2p random, only 2 general randoms in 2004-2009 will be p2p)