### PR TITLE
fix: prevent placing cannon on top of other cannons

### DIFF
--- a/scripts/quests/quest_mcannon/scripts/cannon_setup.rs2
+++ b/scripts/quests/quest_mcannon/scripts/cannon_setup.rs2
@@ -157,10 +157,7 @@ if (last_useitem = twpart2) {
     return;
 }
 // in osrs, if you use a cannon base on a cannon base, itll have this message...
-// i think this is because they just check for category 'cannon_parts'...
-// However! 2004 didnt have categories, so either they never checked for other cannon parts
-// or they did. If they did, they probably didnt check for the same obj?
-if (oc_category(last_useitem) = cannon_parts & last_useitem ! twpart1) { 
+if (oc_category(last_useitem) = cannon_parts) { 
     mes("This cannon needs its stand."); // osrs
     return;
 }
@@ -199,7 +196,7 @@ if (last_useitem = twpart3) {
     %dropcannon = ^cannon_stage_barrels;
     return;
 }
-if (oc_category(last_useitem) = cannon_parts & last_useitem ! twpart2) { 
+if (oc_category(last_useitem) = cannon_parts) { 
     mes("This cannon needs its barrels."); // osrs
     return;
 }
@@ -239,7 +236,7 @@ if (last_useitem = twpart4) {
     %dropcannon = ^cannon_stage_full;
     @cannon_ready_start;
 }
-if (oc_category(last_useitem) = cannon_parts & last_useitem ! twpart3) { 
+if (oc_category(last_useitem) = cannon_parts) { 
     mes("This cannon needs its furnace."); // osrs
     return;
 }

--- a/scripts/quests/quest_mcannon/scripts/cannon_setup.rs2
+++ b/scripts/quests/quest_mcannon/scripts/cannon_setup.rs2
@@ -174,14 +174,7 @@ if (inv_freespace(inv) < 2) {
     mes("You need two free inventory spaces to pick that up."); // osrs
     return;
 }
-%ownedmcannon = null;
-%dropcannon = ^cannon_stage_none;
-mes("You pick up the cannon,");
-mes("It's really heavy.");
-sound_synth(pick, 0, 0);
-inv_add(inv, twpart1, 1);
-inv_add(inv, twpart2, 1);
-loc_del(1);
+~pickup_cannon;
 
 [oplocu,multicannon_stand]
 if (~cannon_belongs_to_player = false) {
@@ -213,15 +206,7 @@ if (inv_freespace(inv) < 3) {
     mes("You need three free inventory spaces to pick that up."); // osrs
     return;
 }
-%ownedmcannon = null;
-%dropcannon = ^cannon_stage_none;
-mes("You pick up the cannon,");
-mes("It's really heavy.");
-sound_synth(pick, 0, 0);
-inv_add(inv, twpart1, 1);
-inv_add(inv, twpart2, 1);
-inv_add(inv, twpart3, 1);
-loc_del(1);
+~pickup_cannon;
 
 [oplocu,multicannon_barrels]
 if (~cannon_belongs_to_player = false) {
@@ -254,21 +239,11 @@ if (inv_freespace(inv) < 4) {
     mes("You need 4 free inventory spaces to pick that up."); // osrs
     return;
 }
-mes("You pick up the cannon,"); // https://youtu.be/TeQXQDaawO0?t=518
-mes("It's really heavy.");
-sound_synth(pick, 0, 0);
-%ownedmcannon = null;
-%dropcannon = ^cannon_stage_none;
-inv_add(inv, twpart1, 1);
-inv_add(inv, twpart2, 1);
-inv_add(inv, twpart3, 1);
-inv_add(inv, twpart4, 1);
-
+~pickup_cannon;
 if (%rockthrower > 0) {
     inv_add(inv, mcannonball, min(30, %rockthrower));
 }
 %rockthrower = 0;
-loc_del(1);
 
 [oploc1,dwarf_multicannon1]
 if (~cannon_belongs_to_player = false) {
@@ -307,3 +282,26 @@ if (last_useitem = mcannonball) {
     ~displaymessage(^dm_default);
 }
 // --------------
+
+[proc,pickup_cannon]
+if (%dropcannon = ^cannon_stage_base) {
+    inv_add(inv, twpart1, 1);
+} else if (%dropcannon = ^cannon_stage_stand) {
+    inv_add(inv, twpart1, 1);
+    inv_add(inv, twpart2, 1);
+} else if (%dropcannon = ^cannon_stage_barrels) {
+    inv_add(inv, twpart1, 1);
+    inv_add(inv, twpart2, 1);
+    inv_add(inv, twpart3, 1);
+} else if (%dropcannon = ^cannon_stage_full) {
+    inv_add(inv, twpart1, 1);
+    inv_add(inv, twpart2, 1);
+    inv_add(inv, twpart3, 1);
+    inv_add(inv, twpart4, 1);
+}
+%ownedmcannon = null;
+%dropcannon = ^cannon_stage_none;
+mes("You pick up the cannon,"); // https://youtu.be/TeQXQDaawO0?t=518
+mes("It's really heavy.");
+sound_synth(pick, 0, 0);
+loc_del(1);

--- a/scripts/quests/quest_mcannon/scripts/cannon_setup.rs2
+++ b/scripts/quests/quest_mcannon/scripts/cannon_setup.rs2
@@ -113,6 +113,10 @@ facesquare($center);
 p_delay(0);
 
 def_coord $origin = movecoord($center, -1, 0, -1); // south-west tile
+if (map_locaddunsafe($origin) = true) { // check again after player movement
+    mes("There isn't enough space to set up here.");
+    return;
+}
 %ownedmcannon = $origin;
 %dropcannon = ^cannon_stage_base;
 


### PR DESCRIPTION
for 225+

- add loc_addunsafe check *after* movement in cannon script
- match category check in cannon opu script with osrs. Ours was slightly wrong because it wrongly assumed categories didnt exist in 2004.
- check %dropcannon when picking up cannon, instead of relying on loc type

https://github.com/user-attachments/assets/b55748f7-7d70-49d5-96f0-024243b84c5a

