### PR TITLE
fix: a few Maze random event fixes

### DIFF
--- a/scripts/macro events/scripts/general/macro_event_maze.rs2
+++ b/scripts/macro events/scripts/general/macro_event_maze.rs2
@@ -172,7 +172,7 @@ if (%xplamp <= 0) {
 
 def_int $roll;
 if (map_members() = ^false) {
-    $roll = random(7); // F2P
+    $roll = random(8); // F2P
 } else {
     $roll = random(10); // Members
 }

--- a/scripts/macro events/scripts/general/macro_event_maze.rs2
+++ b/scripts/macro events/scripts/general/macro_event_maze.rs2
@@ -185,9 +185,9 @@ switch_int($roll) {
     case 4 : { ~macro_maze_give_chest_loot(bronze_arrow, 20, "You've found some bronze arrows!", 0); }
     case 5 : { ~macro_maze_give_chest_loot(bolt, 10, "You've found some bolts!", ^objbox_height); }
     case 6 : { ~macro_maze_give_chest_loot(iron_arrow, 15, "You've found some iron arrows!", 0); }
+    case 7 : { ~macro_maze_give_chest_loot(2dose1strength, 1, "You've found a strength potion!", ^objbox_height); }
     // Members-only
-    case 7 : { ~macro_maze_give_chest_loot(2dose1attack, 1, "You've found an attack potion!", ^objbox_height); }
-    case 8 : { ~macro_maze_give_chest_loot(2dose1strength, 1, "You've found a strength potion!", ^objbox_height); }
+    case 8 : { ~macro_maze_give_chest_loot(2dose1attack, 1, "You've found an attack potion!", ^objbox_height); }
     case 9 : { ~macro_maze_give_chest_loot(2dose1defense, 1, "You've found a defence potion!", ^objbox_height); }
 }
 

--- a/scripts/macro events/scripts/general/macro_event_maze.rs2
+++ b/scripts/macro events/scripts/general/macro_event_maze.rs2
@@ -171,7 +171,11 @@ if (%xplamp <= 0) {
 }
 
 def_int $roll;
-$roll = random(10);
+if (map_members() = ^false) {
+    $roll = random(7); // F2P
+} else {
+    $roll = random(10); // Members
+}
 
 switch_int($roll) {
     case 0 : { ~macro_maze_give_chest_loot(airrune, 15, "You've found some air runes!", 0); }
@@ -181,6 +185,7 @@ switch_int($roll) {
     case 4 : { ~macro_maze_give_chest_loot(bronze_arrow, 20, "You've found some bronze arrows!", 0); }
     case 5 : { ~macro_maze_give_chest_loot(bolt, 10, "You've found some bolts!", ^objbox_height); }
     case 6 : { ~macro_maze_give_chest_loot(iron_arrow, 15, "You've found some iron arrows!", 0); }
+    // Members-only
     case 7 : { ~macro_maze_give_chest_loot(2dose1attack, 1, "You've found an attack potion!", ^objbox_height); }
     case 8 : { ~macro_maze_give_chest_loot(2dose1strength, 1, "You've found a strength potion!", ^objbox_height); }
     case 9 : { ~macro_maze_give_chest_loot(2dose1defense, 1, "You've found a defence potion!", ^objbox_height); }

--- a/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -91,7 +91,7 @@ if (~inzone_coord_pair_table(random_event_mime_zones, $coord) = true) {
     return(false);
 }
 if (~inzone_coord_pair_table(random_event_maze_zones, $coord) = true) {
-    say("I need to reach the maze centre!"); // Best guess, similar to mime
+    say("I need to find the center of the maze!"); // https://www.youtube.com/watch?v=SFugJO98ap4
     return(false);
 }
 if (~in_duel_arena($coord) = true) {


### PR DESCRIPTION
- Fixed Maze chests to give P2P items on P2P worlds only.
- Updated the 'say' from the player when attempting to teleport out of the Maze random event, with authentic message from: https://www.youtube.com/watch?v=SFugJO98ap4