### PR TITLE
fix: chompy bird changes

### DIFF
--- a/scripts/general/configs/xplamp.obj
+++ b/scripts/general/configs/xplamp.obj
@@ -10,3 +10,4 @@ model=model_3348_obj
 weight=100g
 iop1=Rub
 tradeable=no
+param=unbankable,^true

--- a/scripts/interface_bank/configs/bank.param
+++ b/scripts/interface_bank/configs/bank.param
@@ -1,0 +1,3 @@
+[unbankable]
+type=int
+default=0

--- a/scripts/interface_bank/scripts/bank.rs2
+++ b/scripts/interface_bank/scripts/bank.rs2
@@ -101,7 +101,7 @@ if ($deposit > 0) {
 }
 
 [proc,bank_check_nobreak](obj $obj)(boolean)
-if (~bank_find_obj_unbankable($obj) = true) {
+if (oc_param($obj, unbankable) = ^true) {
     mes("A magical force prevents you from banking this item!"); // osrs
     return(true);
 }
@@ -123,14 +123,6 @@ if (playermember = ^false) {
     }
 }
 return(false);
-
-// returns if an obj is considered to be unbankable.
-// experience lamps, quest items, etc.
-[proc,bank_find_obj_unbankable](obj $obj)(boolean)
-switch_obj ($obj) {
-    case macro_genilamp : return(true); // cant bank xp lamps
-    case default : return(false);
-}
 
 [label,insert_bank](int $start_slot, int $target_slot)
 def_int $src = $start_slot;

--- a/scripts/quests/quest_chompybird/configs/quest_chompybird.hunt
+++ b/scripts/quests/quest_chompybird/configs/quest_chompybird.hunt
@@ -7,5 +7,5 @@ find_keephunting=on
 check_notcombat=%lastcombat
 check_notcombat_self=%npc_lastcombat
 // confirm rate
-rate=10
+rate=3
 find_newmode=queue4

--- a/scripts/quests/quest_chompybird/configs/quest_chompybird.npc
+++ b/scripts/quests/quest_chompybird/configs/quest_chompybird.npc
@@ -101,7 +101,7 @@ param=defend_sound,chompy_bird_hit
 param=death_sound,chompy_bird_death
 // Hunt range is a guess
 // If removed, chompy won't hunt for toads during quest
-huntrange=2
+huntrange=7
 // osrs stats and Vislvl match 1:1
 // https://raw.githubusercontent.com/Joshua-F/osrs-dumps/refs/heads/master/config/dump.npc npc_1475
 

--- a/scripts/quests/quest_chompybird/configs/quest_chompybird.npc
+++ b/scripts/quests/quest_chompybird/configs/quest_chompybird.npc
@@ -102,6 +102,7 @@ param=death_sound,chompy_bird_death
 // Hunt range is a guess
 // If removed, chompy won't hunt for toads during quest
 huntrange=7
+timer=3
 // osrs stats and Vislvl match 1:1
 // https://raw.githubusercontent.com/Joshua-F/osrs-dumps/refs/heads/master/config/dump.npc npc_1475
 

--- a/scripts/quests/quest_chompybird/configs/quest_chompybird.obj
+++ b/scripts/quests/quest_chompybird/configs/quest_chompybird.obj
@@ -73,6 +73,7 @@ iop1=Drop
 iop4=Release All
 iop5=Release
 tradeable=no
+param=unbankable,^true
 
 [raw_chompy]
 name=Raw chompy

--- a/scripts/quests/quest_chompybird/scripts/bloated_toad.rs2
+++ b/scripts/quests/quest_chompybird/scripts/bloated_toad.rs2
@@ -128,14 +128,3 @@ while (.huntnext = true) {
     // is damage random per-player or per-toad?
     .queue(damage_player, calc(random(1) + 1), 0);
 }
-
-// The toad is being eaten by the Chompy
-[ai_queue5,bloated_toad]
-npc_delay(3);
-
-// todo do we need to check that the Chompy is still there and eating the toad?
-//      should test on OSRS to confirm
-
-npc_say("!!Croak!!");
-npc_delay(2);
-npc_del;

--- a/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -33,12 +33,15 @@ if (.npc_find(npc_coord, bloated_toad, 7, ^vis_lineofwalk) = true) {
 
 [ai_queue5,chompy_bird]
 if (.npc_finduid(%rantz_attacking_chompy) = true & distance(npc_coord, .npc_coord) = 1 & %npc_aggressive_player = null) {
+    %npc_int = ^true;
     npc_walk(npc_coord);
     npc_facesquare(.npc_coord);
     npc_say("Sqwark!");
+    ~sound_area(chompy_bird_squak, 0, npc_coord, 5);
     npc_delay(1);
     npc_anim(chompy_attack, 0);
     npc_delay(1);
+    ~sound_area(toad_croak, 0, npc_coord, 5);
     .npc_say("!!Croak!!");
     npc_say("Gobble!");
     .npc_delay(1);
@@ -52,6 +55,19 @@ if (.npc_finduid(%rantz_attacking_chompy) = true & distance(npc_coord, .npc_coor
 } else {
     npc_setmode(null);
     npc_sethuntmode(chompybird);
+}
+
+[ai_timer,chompy_bird]
+if(%npc_int = ^true) {
+    if(npc_getmode = playerescape) npc_setmode(null);
+    return;
+}
+huntall(npc_coord, 2, ^vis_lineofsight);
+if (huntnext = true) {
+    %npc_int = ^true;
+    npc_say("Screech!");
+    sound_synth(chompy_bird_screech, 0, 0);
+    npc_setmode(playerescape);
 }
 
 [opnpc4,chompybird_dead]
@@ -162,12 +178,6 @@ if (npc_param(defend_sound) ! null) {
 p_opnpc(5);
 
 ~ranged_dropammo_npc($ammo, divide($delay, 30));
-
-if (random(4) = 0) {
-    // There's some randomness here, this is a guess
-    npc_say("Screech!");
-    npc_setmode(playerescape);
-}
 
 // Ogre arrow launch spotanim is higher than other arrows by default, so we compensate for that here
 [proc,player_use_ogre_bow](obj $ammo)(int)

--- a/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -1,7 +1,6 @@
 [proc,spawn_chompy_bird](coord $coord, player_uid $baiter_uid)
 {
-    // def_coord $spawn_coord = map_findsquare($coord, 3, 10, 1);
-    def_coord $spawn_coord = map_findsquare($coord, 4, 4, 1);
+    def_coord $spawn_coord = map_findsquare($coord, 3, 10, ^map_findsquare_lineofsight);
     
     npc_add($spawn_coord, chompy_bird, 100); // no seq for flying away at end, prob just despawned?
     %quest_chompybird_baiter = $baiter_uid;
@@ -15,35 +14,44 @@
     npc_sethuntmode(chompybird);
 }
 
-// triggered by the .hunt config, the Chompy has found, and arrived at, the Bloated Toad
+// triggered by the .hunt config, walks the chompy bird to a targeted toad
 [ai_queue4,chompy_bird]
-if (.npc_find(npc_coord, bloated_toad, 2, ^vis_lineofwalk) = true) {
+if (%npc_aggressive_player ! null) {
+    return;
+}
+def_int $dist;
+def_coord $dest;
+if (.npc_find(npc_coord, bloated_toad, 7, ^vis_lineofwalk) = true) {
+    %rantz_attacking_chompy = .npc_uid;
+    $dest = map_findsquare(.npc_coord, 1, 1, ^vis_lineofwalk);
+    $dist = add(distance(npc_coord, $dest), 1);
+    npc_walk($dest);
     npc_sethuntmode(null);
     npc_setmode(none);
-    npc_walk(npc_coord);
-    npc_facesquare(.npc_coord);
-    npc_queue(5, 0, 0);
-    .npc_queue(5, 0, 0);
+    npc_queue(5, 0, $dist);
 }
 
-
-// the Chompy is eating the toad
 [ai_queue5,chompy_bird]
-npc_say("Sqwark!");
-npc_anim(chompy_attack, 0);
-npc_delay(3);
-npc_say("Gobble!");
-npc_delay(2);
-npc_setmode(null);
-npc_sethuntmode(chompybird);
-
-// todo consider some check that the toad actually still exists?
-//      might not be necessary though
-
-if (p_finduid(%quest_chompybird_baiter) = true) {
-    if (%chompybird = ^chompybird_dropped_toad) {
-        %chompybird = ^chompybird_chompy_ate_toad;
+if (.npc_finduid(%rantz_attacking_chompy) = true & distance(npc_coord, .npc_coord) = 1 & %npc_aggressive_player = null) {
+    npc_walk(npc_coord);
+    npc_facesquare(.npc_coord);
+    npc_say("Sqwark!");
+    npc_delay(1);
+    npc_anim(chompy_attack, 0);
+    npc_delay(1);
+    .npc_say("!!Croak!!");
+    npc_say("Gobble!");
+    .npc_delay(1);
+    .npc_del;
+    npc_setmode(null);
+    if (p_finduid(%quest_chompybird_baiter) = true) {
+        if (%chompybird = ^chompybird_dropped_toad) {
+            %chompybird = ^chompybird_chompy_ate_toad;
+        }
     }
+} else {
+    npc_setmode(null);
+    npc_sethuntmode(chompybird);
 }
 
 [opnpc4,chompybird_dead]
@@ -141,7 +149,7 @@ if (~player_npc_hit_roll(%damagetype) = true) {
     ~give_combat_experience(%damagestyle, $damage_capped, %npc_combat_xp_multiplier);
     npc_heropoints($damage_capped);
 }
-
+%npc_aggressive_player = uid;
 def_int $delay = add(~player_use_ogre_bow($ammo), 30); // osrs it seems to be delayed an extra tick
 anim(%com_attackanim, 0);
 sound_synth(%com_attacksound, 0, 0);
@@ -155,7 +163,7 @@ p_opnpc(5);
 
 ~ranged_dropammo_npc($ammo, divide($delay, 30));
 
-if (random(2) = 0) {
+if (random(4) = 0) {
     // There's some randomness here, this is a guess
     npc_say("Screech!");
     npc_setmode(playerescape);


### PR DESCRIPTION
for 225+

- adjustments to chompy bird npcs huntrange, spawn range relative to toads and prevent continued hunting after being attacked/ or eating a toad, also fixes with delays used to match osrs + old videos
- change bloated toads to be unbankable