### PR TITLE
fix: missing comma in Witch's dialogue in Black Knight's Fortress

### DIFF
--- a/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
+++ b/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
@@ -138,7 +138,7 @@ if (%spy = 1) {
     ~chatnpc_specific("Witch", fortwitch, "<p,neutral>It's a specially grown cabbage.|Grown by my cousin Helda who lives in Draynor Manor.");
     ~chatnpc_specific("Witch", fortwitch, "<p,neutral>The soil there is slightly magical.|And it gives the cabbages slight magic properties.");
     ~chatnpc_specific("Witch", fortwitch, "<p,shock>Not to mention the trees!");
-    ~chatnpc_specific("Witch", fortwitch, "<p,neutral>Now remember Greldo only a Draynor Manor| cabbage will do! Don't get lazy| and bring any old cabbage, THAT| would ENTIRELY wreck the potion!"); // https://web.archive.org/web/*/http://zybez.com/img/qimg/blackknight/6_grill.jpg
+    ~chatnpc_specific("Witch", fortwitch, "<p,neutral>Now remember Greldo, only a Draynor Manor| cabbage will do! Don't get lazy| and bring any old cabbage, THAT| would ENTIRELY wreck the potion!"); // https://web.archive.org/web/*/http://zybez.com/img/qimg/blackknight/6_grill.jpg
     ~chatnpc_specific("Greldo", greldo, "<p,goblinchat>Yes mithreth."); // neutral in osrs
     ~update_blackknight_progress;
 } else {


### PR DESCRIPTION
Added a small comma which was missing from the Witch's dialogue in Black Knight's Fortress quest, from the Discord #game-issues, thread id: ``1472352239497642135``

To quote Carsten from Discord:
> Source: https://web.archive.org/web/20060112013126/http://zybez.com/img/qimg/blackknight/6_grill.jpg
> The source is already linked in the code, comma after "Greldo" is missing.

Sourced: 

![source](https://i.imgur.com/Ya9Jofh.png)

Current:

![current](https://i.imgur.com/Jw5dQPM.png)