### PR TITLE
fix: various typos fixed, prayer bonus swapped on monk robes, stage check for enchanted meat

### DIFF
--- a/scripts/areas/area_taverly/scripts/sanfew.rs2
+++ b/scripts/areas/area_taverly/scripts/sanfew.rs2
@@ -1,9 +1,10 @@
 [opnpc1,sanfew]
+if(%druidquest = ^druid_spoken_sanfew) {
+    @druid_sanfew_give_ingredients;
+}
 ~chatnpc("<p,quiz>What can I do for you young 'un?");
 if(%druidquest = ^druid_started) {
     @multi2("I've been sent to help purify the Varrock stone circle.", druid_sanfew_information, "Actually I don't need to speak to you.", sanfew_dont_need);
-} else if(%druidquest = ^druid_spoken_sanfew) {
-    @druid_sanfew_give_ingredients;
 } else if(%druidquest >= ^druid_given_ingredients) {
     @multi2("Have you any more work for me, to help reclaim the circle?", sanfew_more_work, "Actually I don't need to speak to you.", sanfew_dont_need);
 } else if(%druidquest = ^druid_not_started) {

--- a/scripts/quests/quest_druid/scripts/quest_druid.rs2
+++ b/scripts/quests/quest_druid/scripts/quest_druid.rs2
@@ -13,7 +13,10 @@ if(npc_finduid($uid) = true) {
 
 [oplocu,cauldron_of_thunder]
 def_obj $useitem = last_useitem;
-p_arrivedelay;
+if(%druidquest ! ^druid_spoken_sanfew) {
+    ~displaymessage(^dm_default);
+    return;
+}
 if($useitem = raw_rat_meat) {
     mes("You dip the raw rat meat in the cauldron.");
     inv_del(inv, raw_rat_meat, 1);

--- a/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
+++ b/scripts/quests/quest_itwatchtower/scripts/quest_itwatchtower.rs2
@@ -489,9 +489,10 @@ if ($pickaxe = null) {
 }
 // no inv space check on RS3
 anim(oc_param($pickaxe, mining_animation), 0); // no sound?
+// https://web.archive.org/web/20050118045713/http://img15.imageshack.us/img15/1109/crystalfour.jpg
 mes("You swing your pick at the rock...");
 p_delay(3);
-mes("A crack appears in the rock and you prise a crystal out.");
+mes("A crack appears in the rock and you prize a crystal out.");
 inv_add(inv, powering_crystal4, 1);
 
 [opheld1,shaman_robe]

--- a/scripts/quests/quest_itwatchtower/scripts/watchtower_wizard.rs2
+++ b/scripts/quests/quest_itwatchtower/scripts/watchtower_wizard.rs2
@@ -302,6 +302,9 @@ if(last_useitem = ogrerelic) {
     @make_magic_ogre_potion;
 } else if(last_useitem = magic_ogre_potion) {
     ~chatnpc("<p,confused>Yes, that is the potion I enchanted for you.|Go and use it now...");
+} else if (last_useitem = vial_water) {
+    inv_setslot(inv, last_useslot, vial_empty, 1);
+    ~chatnpc("<p,happy>Oh lovely, fresh water... Thanks!");
 } else {
     ~displaymessage(^dm_default);
 }

--- a/scripts/skill_prayer/configs/robes.obj
+++ b/scripts/skill_prayer/configs/robes.obj
@@ -35,7 +35,7 @@ womanwear=model_348_idk,0
 manwear2=model_292_idk
 womanwear2=model_456_idk
 weight=2lb
-param=prayerbonus,6
+param=prayerbonus,4
 
 [monkrobebottom]
 model=model_2521_obj

--- a/scripts/skill_prayer/configs/robes.obj
+++ b/scripts/skill_prayer/configs/robes.obj
@@ -35,7 +35,7 @@ womanwear=model_348_idk,0
 manwear2=model_292_idk
 womanwear2=model_456_idk
 weight=2lb
-param=prayerbonus,4
+param=prayerbonus,6
 
 [monkrobebottom]
 model=model_2521_obj
@@ -52,7 +52,7 @@ wearpos=legs
 manwear=model_265_obj_wear,0
 womanwear=model_428_idk,0
 weight=2lb
-param=prayerbonus,6
+param=prayerbonus,4
 
 [monkrobetop]
 model=model_2786_obj

--- a/scripts/skill_prayer/configs/robes.obj
+++ b/scripts/skill_prayer/configs/robes.obj
@@ -52,7 +52,7 @@ wearpos=legs
 manwear=model_265_obj_wear,0
 womanwear=model_428_idk,0
 weight=2lb
-param=prayerbonus,4
+param=prayerbonus,5
 
 [monkrobetop]
 model=model_2786_obj
@@ -72,7 +72,7 @@ womanwear=model_348_idk,0
 manwear2=model_292_idk
 womanwear2=model_456_idk
 weight=2lb
-param=prayerbonus,5
+param=prayerbonus,6
 
 [blackrobetop]
 model=model_2786_obj

--- a/scripts/skill_runecraft/scripts/runecraft.rs2
+++ b/scripts/skill_runecraft/scripts/runecraft.rs2
@@ -38,7 +38,8 @@ if (db_getfield($data, runecraft_table:members, 0) = ^true) {
 }
 anim(human_pickupfloor, 0);
 sound_synth(teleport_all, 0, 0);
-mes("You hold the <oc_name(last_useitem)> towards the mysterious ruins.");
+// https://www.youtube.com/watch?v=KIuXgWDMYbk
+mes("You hold the <db_getfield($data, runecraft_table:name, 0)> Talisman towards the mysterious ruins.");
 mes("You feel a powerful force take hold of you...");
 p_delay(1);
 p_telejump(map_findsquare(db_getfield($data, runecraft_table:enter_coord, random(db_getfieldcount($data, runecraft_table:enter_coord)))));


### PR DESCRIPTION
for 225+
- `prize` instead of `prise` when getting the last crystal in watch tower
- prayer bonus on monk robe pieces were swapped around
- `Talisman` is now capitalized when entering a runecraft altar
- NIH if using raw meats on the wrong stage for druidic ritual
- Sanfew should go straight into his dialogue when on the ingredients stage
- add missing water vial interaction to watchtower wizard