### PR TITLE
fix: corrected stat_random values, locked door fixes

### DIFF
--- a/scripts/areas/area_desert/scripts/kharidian_cactus.rs2
+++ b/scripts/areas/area_desert/scripts/kharidian_cactus.rs2
@@ -35,7 +35,7 @@ if ($item = knife) {
 sound_synth(hacksword_slash, 0, 15);
 sound_synth(liquid, 0, 0);
 
-if (stat_random(woodcutting, 30, 252) = true) {
+if (stat_random(woodcutting, 30, 253) = true) {
     if (inv_total(inv, water_skin0) > 0 | inv_total(inv, water_skin1) > 0 | inv_total(inv, water_skin2) > 0 | inv_total(inv, water_skin3) > 0) {
         mes("You top up your skin with water from the cactus.");
 

--- a/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
@@ -92,7 +92,7 @@ if(loc_angle = ^loc_east) {
 ~set_readywalk_bas(human_walk_logbalance_ready, human_walk_logbalance);
 sound_synth(tightrope, 2, 0);
 ~forcemove(movecoord(coord, 0, 0, multiply($z_dist, 2)));
-if(stat_random(agility, 100, 310) = false) {
+if(stat_random(agility, 200, 440) = false) {
     ~update_bas;
     anim(human_walk_logbalance_stumble, 0);
     facesquare(movecoord(coord, 0, 0, -1)); // face south

--- a/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
@@ -264,7 +264,7 @@ if (.loc_find(movecoord(coord, 0, 0, 1), agilityarena_handholds_middle) = true) 
 // https://youtu.be/fu3V6gn4WWM?si=JsMRX4S23YvvD-Ev&t=355 2t delay instead of 1t (OSRS is 1t)
 sound_synth(handholds_grab_to_second, 0, 0);
 ~agility_exactmove($start_seq, 0, 1, loc_coord, movecoord(loc_coord, $dx, 0, $dz), 46, 60, $dir, false);
-if(stat_random(agility, 180, 280) = false) {
+if(stat_random(agility, 80, 280) = false) {
     ~update_bas;
     ~agility_exactmove($fall_seq, 0, 2, movecoord(loc_coord, $dx, 0, $dz), movecoord(loc_coord, multiply(2, $dx), 0, multiply(2, $dz)), 26, 44, $dir, false);
     p_teleport(movecoord(coord, 0, -3, 0));

--- a/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena.rs2
@@ -92,7 +92,7 @@ if(loc_angle = ^loc_east) {
 ~set_readywalk_bas(human_walk_logbalance_ready, human_walk_logbalance);
 sound_synth(tightrope, 2, 0);
 ~forcemove(movecoord(coord, 0, 0, multiply($z_dist, 2)));
-if(stat_random(agility, 230, 280) = false) {
+if(stat_random(agility, 100, 310) = false) {
     ~update_bas;
     anim(human_walk_logbalance_stumble, 0);
     facesquare(movecoord(coord, 0, 0, -1)); // face south
@@ -157,7 +157,7 @@ switch_int(loc_angle) {
 p_delay(0);
 ~playerwalk3($start_pos);
 p_arrivedelay;
-if(stat_random(agility, 225, 285) = false) {
+if(stat_random(agility, 100, 310) = false) {
     sound_synth(stumble_loop, 6, 10);
     ~agility_exactmove(human_ropeswing_long_miss, 30, 2, $start_pos, movecoord($start_pos, divide($dx, 5), 0, divide($dz, 5)), 30, 76, $dir, false);
     mes("You missed the rope!");
@@ -193,7 +193,7 @@ sound_synth(jump_no_land, 0, 0);
 ~agility_exactmove(human_spot_jump, 0, 1, coord, loc_coord, 15, 30, $dir, false);
 sound_synth(jump_no_land, 0, 0);
 ~agility_exactmove(human_spot_jump, 0, 1, loc_coord, movecoord(loc_coord, $dx, 0, $dz), 15, 30, $dir, false);
-if(stat_random(agility, 230, 280) = false) {
+if(stat_random(agility, 120, 340) = false) {
     anim(human_walk_logbalance_stumble, 0);
     p_delay(0);
     p_teleport(movecoord(coord, multiply($dz, -1), -3, multiply($dx, 1)));
@@ -311,7 +311,7 @@ if ($dx = 0 & $dz >= 1) {
     $dir = ^exact_east;
     $dx = 1;
 }
-if(stat_random(agility, 240, 290) = false) {
+if(stat_random(agility, 220, 460) = false) {
     ~forcemove(movecoord(coord, $dx, 0, $dz));
     mes("You stumbled!");
     anim(human_lowwall_fail, 0);
@@ -354,7 +354,7 @@ sound_synth(monkeybars_on, 0, 0);
 p_delay(0);
 sound_synth(monkeybars_loop, 6, 0);
 ~forcemove(movecoord(coord, calc($dx * 2), 0, calc($dz * 2)));
-if(stat_random(agility, 230, 280) = false) {
+if(stat_random(agility, 160, 400) = false) {
     ~update_bas;
     anim(human_monkeybars_off, 0);
     sound_synth(monkeybars_off, 0, 0);
@@ -400,7 +400,7 @@ if(coordx(coord) < coordx(loc_coord)) {
 ~set_forcemove_bas($walk_seq);
 sound_synth(balancing_ledge, 3, 10);
 ~forcemove(movecoord(coord, multiply($x_dist, 2), 0, 0));
-if(stat_random(agility, 230, 280) = false) {
+if(stat_random(agility, 140, 370) = false) {
     ~update_bas;
     anim(human_walk_logbalance_stumble, 0);
     facesquare(movecoord(coord, -1, 0, 0)); // face west
@@ -446,7 +446,7 @@ if(coordz(coord) > coordz(loc_coord)) {
 ~set_readywalk_bas(human_walk_logbalance_ready, human_walk_logbalance);
 sound_synth(log_balance, 2, 0);
 ~forcemove(movecoord(coord, multiply($x_dist, 2), 0, multiply($z_dist, 2)));
-if(stat_random(agility, 230, 280) = false) {
+if(stat_random(agility, 180, 420) = false) {
     ~update_bas;
     anim(human_walk_logbalance_stumble, 0);
     p_delay(0);

--- a/scripts/minigames/game_agilityarena/scripts/agilityarena_zones.rs2
+++ b/scripts/minigames/game_agilityarena/scripts/agilityarena_zones.rs2
@@ -114,7 +114,7 @@ if(loc_find(coord, agilityarena_floorspikes) = true) {
     // https://youtu.be/eHMW2KRp9_Q?si=H8uk_KvSW2zFNcIQ&t=119 1t delay before activating, which osrs doesnt seem to have
     p_stopaction;
     p_delay(0);
-    if(stat_random(agility, 150, 250) = false | stat(agility) < 20) {
+    if(stat_random(agility, 60, 250) = false | stat(agility) < 20) {
         if(stat(agility) < 20) mes("You need an agility level of at least 20 to get past this trap!");
         mes("You were hit by some floor spikes!");
         sound_synth(floor_spikes, 0, 0);
@@ -151,7 +151,7 @@ if(loc_find(coord, agilityarena_pressurepad) = true) {
     // https://youtu.be/eHMW2KRp9_Q?si=4o0WDWs9VMAxXitO&t=137 1t delay before activating, which osrs doesnt seem to have (same as floor spikes bascially)
     p_stopaction;
     p_delay(0);
-    if(stat_random(agility, 135, 235) = false | stat(agility) < 20) {
+    if(stat_random(agility, 40, 230) = false | stat(agility) < 20) {
         if(stat(agility) < 20) mes("You need an agility level of at least 20 to get past this trap!");
         mes("You were hit by some falling rocks!");
         sound_synth(roof_collapse, 0, 0);
@@ -202,7 +202,7 @@ if((inzone(3_43_149_25_43, 3_43_149_27_43, coord) = true | inzone(3_43_149_31_37
     & loc_find(~get_sawblades_coord, agilityarena_sawblades) = true) {
     p_stopaction;
     p_delay(0);
-    if(stat_random(agility, 91, 191) = false | stat(agility) < 40) {
+    if(stat_random(agility, 30, 210) = false | stat(agility) < 40) {
         if(stat(agility) < 40) mes("You need an agility level of at least 40 to get past this trap!");
         if(~total_distance(coord, loc_coord) > 1) {
             // these could just be coord checks, theres only 3 of them and they all have different angles
@@ -262,7 +262,7 @@ if(coord = 3_43_149_42_38 | coord = 3_43_149_42_37 | coord = 3_43_149_37_21 | co
     p_stopaction;
     p_delay(0);
     $pillar_coord, $cam2, $cam3, $dart_target, $dest, $fail, $dir = ~get_poisondart_vals(coord);
-    if(stat_random(agility, 80, 180) = false | stat(agility) < 40) {
+    if(stat_random(agility, 20, 190) = false | stat(agility) < 40) {
         if(stat(agility) < 40) mes("You need an agility level of at least 40 to get past this trap!");
         sound_synth(dart_fire_hit, 0, 0);
         ~coord_projectile($pillar_coord, coord, bullettime_dart, 0, 10, 0, 2, 25, 40, 0);

--- a/scripts/quests/quest_desertrescue/scripts/mining_slave.rs2
+++ b/scripts/quests/quest_desertrescue/scripts/mining_slave.rs2
@@ -108,7 +108,7 @@ switch_int(~p_choice2("It's funny you should say that...", 1, "That sounds awful
 [label,mining_slave_male_picklock]
 ~mesbox("You use some nearby bits of wood and wire to try and pick the lock.");
 def_int $attempts = getbit_range(%desertrescue_map_mechanisms, ^desertrescue_lock_attempts1, ^desertrescue_lock_attempts2); // OSRS has this mechanic stored as varb in varp 907, might be rework exclusive?
-if(stat_random(thieving, 111, 250) = false) {
+if(stat_random(thieving, 20, 250) = false) { // RS3 rate
     %desertrescue_map_mechanisms = setbit_range_toint(%desertrescue_map_mechanisms, add($attempts, 1), ^desertrescue_lock_attempts1, ^desertrescue_lock_attempts2);
     mes("You fail!");
     // you can get caught by guards first time in osrs, in rsc (at least openrsc) its always on 2nd attempt

--- a/scripts/quests/quest_itexam/scripts/digsite_workman.rs2
+++ b/scripts/quests/quest_itexam/scripts/digsite_workman.rs2
@@ -64,7 +64,6 @@ if (stat(thieving) < 25) {
     return;
 }
 
-// TODO: we need to investigate this success rate a bit, for now this is the warrior woman success rate
 if(stat_random(thieving, 100, 240) = false) {
     npc_say("What do you think you're doing?");
     mes("You fail to pick the workman's pocket.");

--- a/scripts/quests/quest_legends/scripts/quest_legends.rs2
+++ b/scripts/quests/quest_legends/scripts/quest_legends.rs2
@@ -97,7 +97,7 @@ if (~p_choice2_header("Yes please!", 1, "No thanks!", 2, "Would you like to sque
     p_delay(1);
     ~agility_exactmove(human_crawling, 0, 0, coord, 0_43_145_43_60, 6, 20, ^exact_east, false);
     // guess
-    if (stat_random(agility, 125, 250) = false) {
+    if (stat_random(agility, 60, 254) = false) {
         mes("You get stuck as you try to squeeze into the crevice.");
         p_delay(5);
         mes("It takes you a while to get back out again.");
@@ -1578,7 +1578,7 @@ if_close;
 mes("You prepare to climb down the rope.");
 p_delay(2);
 if(testbit(%legends_bits, ^legends_drank_bravery_potion) = ^true) {
-    if(stat_random(agility, 120, 250) = false) {
+    if(stat_random(agility, 60, 253) = false) {
         mes("Fear stabs at your heart....");
         say("Gulp!");
         p_delay(1);

--- a/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
+++ b/scripts/quests/quest_seaslug/scripts/quest_seaslug.rs2
@@ -42,7 +42,7 @@ if(stat(firemaking) < 30) {
     mes("You need a Firemaking level of 30 or above.");
     return;
 }
-if(stat_random(firemaking, 210, 250) = false) {
+if(stat_random(firemaking, 64, 512) = false) {
     mes("You rub together the dry sticks and the sticks smoke momentarily then die out.");
     return;
 }

--- a/scripts/quests/quest_troll/scripts/quest_troll.rs2
+++ b/scripts/quests/quest_troll/scripts/quest_troll.rs2
@@ -27,7 +27,7 @@ if(coordx(coord) > coordx(loc_coord)) {
 }
 p_delay(0);
 ~agility_exactmove(human_climbing_down, 15, 0, coord, movecoord(coord, $dx, 0, 0), 0, 90, $dir, false);
-if(stat_random(agility, 125, 250) = false) {
+if(stat_random(agility, 170, 253) = false) {
     sound_synth(stumble_loop, 10, 0);
     anim(human_climbing_fall, 0);
     p_delay(1);
@@ -56,7 +56,7 @@ if(coordx(coord) < coordx(loc_coord)) {
 p_delay(0);
 ~set_forcemove_bas(human_climbing);
 ~forcemove(movecoord(coord, multiply(2, $dx), 0, 0));
-if(stat_random(agility, 125, 250) = false) {
+if(stat_random(agility, 170, 253) = false) {
     sound_synth(stumble_loop, 10, 0);
     ~agility_exactmove(human_climbing_fall, 0, 1, coord, movecoord(coord, multiply(-2, $dx), 0, 0), 0, 50, $dir, false);
     anim(null, 0);
@@ -145,7 +145,7 @@ def_int $dx = -2;
 def_int $dir = ^exact_east;
 p_delay(0);
 ~agility_exactmove(human_climbing_down, 15, 0, coord, movecoord(coord, $dx, 0, 0), 0, 50, $dir, false);
-if(stat_random(agility, 125, 250) = false) {
+if(stat_random(agility, 170, 253) = false) {
     sound_synth(stumble_loop, 10, 0);
     anim(human_climbing_fall, 0);
     p_delay(1);
@@ -173,7 +173,7 @@ def_int $dir = ^exact_east;
 p_delay(0);
 ~set_forcemove_bas(human_climbing);
 ~forcemove(movecoord(coord, $dx, 0, 0));
-if(stat_random(agility, 125, 250) = false) {
+if(stat_random(agility, 170, 253) = false) {
     sound_synth(stumble_loop, 10, 0);
     ~agility_exactmove(human_climbing_fall, 0, 1, coord, movecoord(coord, multiply(-1, $dx), 0, 0), 0, 25, $dir, false);
     anim(null, 0);

--- a/scripts/quests/quest_troll/scripts/troll_stronghold_camp_guard.rs2
+++ b/scripts/quests/quest_troll/scripts/troll_stronghold_camp_guard.rs2
@@ -55,7 +55,7 @@ if(npc_stat(hitpoints) = 0) {
     mes("Too late, they're dead.");
     return;
 }
-if(stat_random(thieving, 100, 240) = false) {
+if(stat_random(thieving, 60, 300) = false) {
     npc_say("What do you think you're doing?");
     mes("You fail to pick the guard's pocket.");
     npc_changetype_keepall($next_type, 500);

--- a/scripts/quests/quest_upass/scripts/quest_upass.rs2
+++ b/scripts/quests/quest_upass/scripts/quest_upass.rs2
@@ -226,7 +226,7 @@ if(last_useitem = spade) {
 [oploc1,cave_railings2]
 mes("You attempt to pick the lock...");
 def_int $roll = random(100);
-if ($roll < 50) { // Some arbitrary rng.
+if (stat_random(thieving, 128, 400) = false) {
     mes("You fail to pick the lock.");
     return;
 }
@@ -251,7 +251,7 @@ if(stat(thieving) < 50) {
 }
 mes("You attempt to pick the lock...");
 def_int $roll = random(100);
-if ($roll < 50) { // Some arbitrary rng.
+if (stat_random(thieving, 128, 400) = false) {
     mes("You fail to pick the lock.");
     return;
 }

--- a/scripts/quests/quest_upass/scripts/upass_bridge.rs2
+++ b/scripts/quests/quest_upass/scripts/upass_bridge.rs2
@@ -65,7 +65,7 @@ mes("You fire your arrow at the rope supporting the bridge...");
 anim(human_bow, 0);
 ~coord_projectile(coord, loc_coord, oc_param($worn_ammo, proj_travel), 40, 36, 41, 15, 5, 11, 5);
 p_delay(0);
-if(stat_random(ranged, 90, 300) = false) {
+if(stat_random(ranged, 160, 300) = false) {
     mes("The arrow just misses the rope.");
     return;
 }

--- a/scripts/quests/quest_upass/scripts/upass_obstacles.rs2
+++ b/scripts/quests/quest_upass/scripts/upass_obstacles.rs2
@@ -19,7 +19,7 @@ if(coordz(coord) > coordz(loc_coord)) {
 p_arrivedelay;
 mes("You climb onto the rock...");
 facesquare(loc_coord);
-if(stat_random(agility, 95, 305) = false) {
+if(stat_random(agility, 160, 300) = false) {
     p_delay(0);
     anim(human_stumble_back, 0);
     mes("...but you slip back down.");
@@ -159,8 +159,7 @@ mes("You try to disarm the trap...");
 anim(human_pickpocket, 0);
 sound_synth(lockeddoor, 0, 0);
 p_delay(1); // 2 ticks
-// TODO: check these numbers
-if(stat_random(thieving, 110, 320) = false) {
+if(stat_random(thieving, 160, 300) = false) {
     mes("...and fail, activating the trap!");
     loc_anim(speartrap_release);
     say("Ouch!");
@@ -231,8 +230,7 @@ mes("You try to disarm the trap...");
 anim(human_pickpocket, 0);
 sound_synth(lockeddoor, 0, 0);
 p_delay(1); // 2 ticks
-// TODO: check these numbers
-if(stat_random(thieving, 110, 320) = false) {
+if(stat_random(thieving, 160, 300) = false) {
     mes("...and fail, activating the trap!");
     @upass_orboflight_trap;
 }
@@ -272,7 +270,7 @@ if(coordz(coord) >= coordz(loc_coord)) {
     ~forcemove(0_37_150_6_42);
 }
 // https://youtu.be/n_ip_vEDbCA?si=0_EUH-TcBp6oAAZL&t=547
-if(stat_random(agility, 90, 300) = false) {
+if(stat_random(agility, 200, 260) = false) {
     anim(human_walk_logbalance_stumble, 0);
     mes("You fall in to the rat pit.");
     p_exactmove(coord, movecoord(coord, -1, 0, 0), 18, 30, ^exact_south);
@@ -306,7 +304,7 @@ if(coordx(coord) > coordx(loc_coord)) {
 sound_synth(log_balance, 2, 0);
 ~agility_force_move(0, human_walk_logbalance, movecoord(coord, calc((coordx($end) - coordx(coord)) / 2), 0, calc((coordz($end) - coordz(coord)) / 2)));
 // https://youtu.be/n_ip_vEDbCA?si=0_EUH-TcBp6oAAZL&t=547
-if(stat_random(agility, 90, 300) = false) {
+if(stat_random(agility, 160, 300) = false) {
     // no actual difference in terms of angle or anything so guess these are hardcoded
     // (guessing all destinations are but w/e)
     def_int $dz = -1;
@@ -373,7 +371,7 @@ stat_advance(agility, 30);
 [label,upass_cross_bridge]
 mes("You attempt to walk over the remaining bridge...");
 p_delay(1);
-if(stat_random(agility, 90, 300) = false) {
+if(stat_random(agility, 160, 300) = false) {
     if(random(2) = 0) p_teleport(0_36_153_31_29);
     else p_teleport(0_36_154_29_10);
     sound_synth(fall_land, 0, 0);

--- a/scripts/quests/quest_zombiequeen/scripts/quest_zombiequeen.rs2
+++ b/scripts/quests/quest_zombiequeen/scripts/quest_zombiequeen.rs2
@@ -530,7 +530,7 @@ if(coordx(coord) > coordx(loc_coord)) {
     }
     p_delay(0);
     ~agility_force_move(0, human_climbing, movecoord(coord, -2, 0, 0));
-    if(stat_random(agility, 125, 250) = false) {
+    if(stat_random(agility, 170, 253) = false) {
         sound_synth(stumble_loop, 10, 0);
         ~agility_exactmove(human_climbing_fall, 0, 1, coord, movecoord(coord, 2, 0, 0), 0, 50, ^exact_west, false);
         anim(null, 0);
@@ -543,7 +543,7 @@ if(coordx(coord) > coordx(loc_coord)) {
     ~agility_force_move(0, human_climbing, movecoord(coord, -2, 0, 0));
 } else if (coordx(coord) < coordx(loc_coord)) {
     ~agility_exactmove(human_climbing_down, 15, 0, coord, movecoord(coord, 4, 0, 0), 0, 120, ^exact_west, false);
-    if(stat_random(agility, 125, 250) = false) {
+    if(stat_random(agility, 170, 253) = false) {
         anim(human_climbing_fall, 0);
         sound_synth(stumble_loop, 10, 0);
         p_delay(1);
@@ -563,7 +563,7 @@ if(coordx(coord) > coordx(loc_coord)) {
 
 [timer,cairn_island_bridge]
 if(inzone(0_43_46_24_35, 0_43_46_29_35, coord) = true) {
-    if(stat_random(agility, 125, 250) = false) {
+    if(stat_random(agility, 75, 250) = false) {
         // fall
         mes("You fall!");
         p_stopaction;
@@ -622,7 +622,7 @@ if(testbit(%zq_map_mechanisms, ^zq_read_tattered_scroll) = ^true) {
             }
             ~mesbox("You contort your body and prepare to squirm worm like into the hole.");
             anim(human_pickupfloor, 5);
-            if(stat_random(agility, 125, 250) = false) {
+            if(stat_random(agility, 170, 253) = false) {
                 ~set_walkbas(human_drowning);
                 ~forcemove(loc_coord);
                 mes("You manage to get yourself stuck.");
@@ -847,7 +847,7 @@ if(~obj_gettotal(zqberviriusscroll) > 0) {
 def_int $choice = ~p_choice2("Yes, I'm quite sure.", 1, "No, I think I'll keep it.", 2);
 if ($choice = 1) {
     ~mesbox("You start to slowly move the rocks to one side.");
-    if(stat_random(agility, 125, 250) = false) {
+    if(stat_random(agility, 75, 250) = false) {
         queue(damage_player, 0, calc(((stat_base(hitpoints) * 10) / 100) + 1)); // assuming regular queue, strongqueue in OSRS
         ~mesbox("You accidentally knock some rocks and the ceiling starts to cave in.|Some rocks fall on you."); // this wont show up cause of damage in OSRS
         return;
@@ -991,7 +991,7 @@ switch_int(~p_choice2_header("Yes, I'll follow the path.", 1, "No, I'll look for
         }
         ~forcemove(movecoord(coord, 2, 0, 0));
         p_delay(0);
-        if(stat_random(agility, 125, 250) = false) {
+        if(stat_random(agility, 75, 250) = false) {
             mes("You fall!");
             ~set_walkbas(human_drowning);
             sound_synth(pool_plop, 0, 0);
@@ -1315,7 +1315,7 @@ p_arrivedelay;
 mes("You attempt to climb the granite rock.");
 ~set_readywalkturn_bas(human_climbing_ready, human_climbing, human_climbing);
 ~forcemove(movecoord(loc_coord, 1, 0, 0));
-if(stat_random(agility, 125, 250) = false) {
+if(stat_random(agility, 70, 250) = false) {
     mes("You fall!");
     ~update_bas;
     say("Arrggghhhhhh!");
@@ -1453,7 +1453,7 @@ return (getbit_range(%zq_map_mechanisms, 7, 8));
 [oploc1,zq_rashrocks]
 ~rash_summon;
 def_boolean $failed = false;
-if(stat_random(agility, 125, 250) = false) {
+if(stat_random(agility, 150, 252) = false) {
     $failed = true;
 }
 if(coordz(coord) > 9512) {

--- a/scripts/skill_agility/scripts/barbarian_course.rs2
+++ b/scripts/skill_agility/scripts/barbarian_course.rs2
@@ -10,7 +10,7 @@ if(coordz(coord) < coordz($start_pos)) {
     return;
 }
 p_delay(0);
-if(stat_random(agility, 200, 260) = false) {
+if(stat_random(agility, 200, 280) = false) {
     // todo: actual rates (same for every other fail on this course)
     ~agility_instant_fail(0_39_155_54_29, calc(((stat(hitpoints) * 15) / 100) + 1), "You slip and fall to the pit below.");
     p_teleport(movecoord(coord, 1, 0, -1));
@@ -38,7 +38,7 @@ mes("You walk carefully across the slippery log...");
 ~forcemove(movecoord(coord, -2, 0, 0));
 sound_synth(log_balance, 4, 0);
 ~forcemove(movecoord(coord, -4, 0, 0));
-if(stat_random(agility, 185, 260) = false) {
+if(stat_random(agility, 180, 260) = false) {
     mes("...You lose your footing and fall into the water.");
     anim(human_walk_logbalance_stumble, 0);
     sound_synth(stumble_loop, 10, 0);
@@ -81,7 +81,7 @@ anim(human_into_sidestepl, 0);
 ~forcemove(movecoord(coord, -1, 0, 0));
 sound_synth(balancing_ledge, 2, 10);
 ~forcemove(movecoord(coord, -1, 0, 0));
-if(stat_random(agility, 210, 260) = false) {
+if(stat_random(agility, 200, 280) = false) {
     anim(human_walk_logbalance_stumble, 0);
     sound_synth(stumble_loop, 10, 0);
     mes("You slip and fall onto the spikes below.");

--- a/scripts/skill_agility/scripts/shortcuts.rs2
+++ b/scripts/skill_agility/scripts/shortcuts.rs2
@@ -238,7 +238,7 @@ mes("You attempt to balance on the stepping stone.");
 sound_synth(jump_no_land, 0, 20);
 // 1t longer delay than osrs for now, otherwise the fall seq won't play on fails 
 ~agility_exactmove(human_steppingstonejump, 20, 2, coord, movecoord(coord, 0, 0, $dz), 48, 60, $dir, false);
-if(stat_random(agility, 140, 250) = false) {
+if(stat_random(agility, 50, 253) = false) {
     // slip and fall, exact move when falling but force walk afterwards
     def_coord $fail_coord = 0_45_46_48_5;
     def_int $damage_bound = calc(stat(hitpoints) * 10 / 100);

--- a/scripts/skill_thieving/configs/doors/locked_door.dbrow
+++ b/scripts/skill_thieving/configs/doors/locked_door.dbrow
@@ -1,7 +1,7 @@
 [locked_door_loc_2550]
 table=locked_door
 data=loc,loc_2550
-data=replacement,elenadoor2open
+data=replacement,desertdoor_inactive
 data=level,1
 data=experience,38
 data=door_successchance,32,250
@@ -9,7 +9,7 @@ data=door_successchance,32,250
 [locked_door_loc_2551]
 table=locked_door
 data=loc,loc_2551
-data=replacement,elenadoor2open
+data=replacement,desertdoor_inactive
 data=level,16
 data=experience,150
 data=door_successchance,32,250
@@ -36,7 +36,7 @@ data=door_successchance,16,100
 [locked_door_loc_2554]
 table=locked_door
 data=loc,loc_2554
-data=replacement,elenadoor2open
+data=replacement,desertdoor_inactive
 data=level,46
 data=experience,375
 data=door_successchance,8,75
@@ -45,7 +45,7 @@ data=trap_successchance,220,280
 [locked_door_loc_2555]
 table=locked_door
 data=loc,loc_2555
-data=replacement,baxtorian_door_open_waterfall_quest
+data=replacement,poordoor_crossopen
 data=level,61
 data=experience,500
 data=door_successchance,4,40
@@ -54,7 +54,7 @@ data=trap_successchance,200,270
 [locked_door_loc_2556]
 table=locked_door
 data=loc,loc_2556
-data=replacement,baxtorian_door_open_waterfall_quest
+data=replacement,poordoor_crossopen
 data=level,13
 data=experience,150
 data=door_successchance,4,40
@@ -72,7 +72,7 @@ data=door_successchance,24,175
 [locked_door_loc_2558]
 table=locked_door
 data=loc,loc_2558
-data=replacement,elenadoor2open
+data=replacement,desertdoor_inactive
 data=level,39
 data=experience,350
 data=tool,lockpick,lockpick
@@ -82,7 +82,7 @@ data=door_successchance,12,87
 [locked_door_loc_2559]
 table=locked_door
 data=loc,loc_2559
-data=replacement,wydindooropen
+data=replacement,poordoor
 data=level,82
 data=experience,500
 data=tool,lockpick,lockpick

--- a/scripts/skill_thieving/configs/doors/locked_door.dbrow
+++ b/scripts/skill_thieving/configs/doors/locked_door.dbrow
@@ -4,6 +4,7 @@ data=loc,loc_2550
 data=replacement,elenadoor2open
 data=level,1
 data=experience,38
+data=door_successchance,32,250
 
 [locked_door_loc_2551]
 table=locked_door
@@ -11,6 +12,7 @@ data=loc,loc_2551
 data=replacement,elenadoor2open
 data=level,16
 data=experience,150
+data=door_successchance,32,250
 
 [locked_door_east_ardy_sewer_gate_north]
 table=locked_door
@@ -20,6 +22,7 @@ data=level,31
 data=experience,250
 data=mirror,true
 data=gate,true
+data=door_successchance,16,100
 
 [locked_door_east_ardy_sewer_gate_south]
 table=locked_door
@@ -28,6 +31,7 @@ data=replacement,loc_1563
 data=level,31
 data=experience,250
 data=gate,true
+data=door_successchance,16,100
 
 [locked_door_loc_2554]
 table=locked_door
@@ -35,6 +39,8 @@ data=loc,loc_2554
 data=replacement,elenadoor2open
 data=level,46
 data=experience,375
+data=door_successchance,8,75
+data=trap_successchance,220,280
 
 [locked_door_loc_2555]
 table=locked_door
@@ -42,6 +48,8 @@ data=loc,loc_2555
 data=replacement,baxtorian_door_open_waterfall_quest
 data=level,61
 data=experience,500
+data=door_successchance,4,40
+data=trap_successchance,200,270
 
 [locked_door_loc_2556]
 table=locked_door
@@ -49,6 +57,8 @@ data=loc,loc_2556
 data=replacement,baxtorian_door_open_waterfall_quest
 data=level,13
 data=experience,150
+data=door_successchance,4,40
+data=trap_successchance,32,250
 
 [locked_door_loc_2557]
 table=locked_door
@@ -57,6 +67,7 @@ data=replacement,poshdooropen
 data=level,23
 data=experience,250
 data=tool,lockpick,lockpick
+data=door_successchance,24,175
 
 [locked_door_loc_2558]
 table=locked_door
@@ -66,6 +77,7 @@ data=level,39
 data=experience,350
 data=tool,lockpick,lockpick
 data=lock_inversed,true
+data=door_successchance,12,87
 
 [locked_door_loc_2559]
 table=locked_door
@@ -75,3 +87,4 @@ data=level,82
 data=experience,500
 data=tool,lockpick,lockpick
 data=lock_inversed,true
+data=door_successchance,40,82

--- a/scripts/skill_thieving/configs/doors/locked_door.dbtable
+++ b/scripts/skill_thieving/configs/doors/locked_door.dbtable
@@ -7,3 +7,5 @@ column=tool,namedobj,string
 column=mirror,boolean
 column=gate,boolean
 column=lock_inversed,boolean
+column=door_successchance,int,int
+column=trap_successchance,int,int

--- a/scripts/skill_thieving/scripts/doors/locked_door.rs2
+++ b/scripts/skill_thieving/scripts/doors/locked_door.rs2
@@ -152,16 +152,24 @@ if ($locked = true) {
     def_int $current_level = stat(thieving);
     def_int $thieving_level = db_getfield($data, locked_door:level, 0);
 
+    if(db_getfieldcount($data, locked_door:trap_successchance) > 0) {
+        if (stat_random(thieving, db_getfield($data, locked_door:trap_successchance, 0)) = false) {
+            mes("You have activated a trap on the lock.");
+            queue(damage_player, 0, divide(stat(hitpoints), 10));
+            return;
+        }
+    }
+
     if ($current_level < $thieving_level) {
         ~mesbox("You need level <tostring($thieving_level)> Thieving to pick this lock.");
         return;
     }
 
-    def_int $roll = random(100);
-    if ($roll < 50) { // Some arbitrary rng.
+    if (stat_random(thieving, db_getfield($data, locked_door:door_successchance, 0)) = false) {
         mes("You fail to pick the lock.");
         return;
     }
+
     mes("You manage to pick the lock.");
 
     def_int $experience = db_getfield($data, locked_door:experience, 0);

--- a/scripts/skill_thieving/scripts/doors/locked_door.rs2
+++ b/scripts/skill_thieving/scripts/doors/locked_door.rs2
@@ -137,15 +137,6 @@ def_loc $replacement = db_getfield($data, locked_door:replacement, 0);
 def_boolean $gate = db_getfield($data, locked_door:gate, 0);
 def_boolean $mirror = db_getfield($data, locked_door:mirror, 0);
 if ($locked = true) {
-    if (db_getfieldcount($data, locked_door:tool) > 0) {
-        def_namedobj $tool;
-        def_string $name;
-        $tool, $name = db_getfield($data, locked_door:tool, 0);
-        if (inv_total(inv, $tool) = 0) {
-            mes("You need a <$name> for this lock.");
-            return;
-        }
-    }
 
     mes("You attempt to pick the lock.");
 
@@ -163,6 +154,16 @@ if ($locked = true) {
     if ($current_level < $thieving_level) {
         ~mesbox("You need level <tostring($thieving_level)> Thieving to pick this lock.");
         return;
+    }
+
+    if (db_getfieldcount($data, locked_door:tool) > 0) {
+        def_namedobj $tool;
+        def_string $name;
+        $tool, $name = db_getfield($data, locked_door:tool, 0);
+        if (inv_total(inv, $tool) = 0) {
+            mes("You need a <$name> for this lock.");
+            return;
+        }
     }
 
     if (stat_random(thieving, db_getfield($data, locked_door:door_successchance, 0)) = false) {


### PR DESCRIPTION
For 225+
updated various stat_random calls that were using estimated/guessed values using values from RS3
- Brimhaven agility arena
- Barbarian outpost course
- skill checks in various quests, including tourist trap, shilo vilage, underground pass, legends quest (most are still missing), death plateau, troll stronghold

also rewrote locked doors to use a stat_random check instead of the arbitrary 50/50, also added the trap check + damage to certain doors, and changed them to use the correct replacement locs + updated lockpick order check