### PR TITLE
fix: drop untradeables on death, destroy certain items

### DIFF
--- a/scripts/areas/area_mage_arena/configs/mage_arena.obj
+++ b/scripts/areas/area_mage_arena/configs/mage_arena.obj
@@ -28,7 +28,7 @@ param=stabdefence,1
 param=slashdefence,1
 param=crushdefence,2
 param=magicdefence,10
-param=destroy_death,^true
+param=destroy_drop,^true
 param=lose_cape_message,Saradomin reclaims the cape as it touches the ground.
 tradeable=no
 
@@ -62,7 +62,7 @@ param=stabdefence,1
 param=slashdefence,1
 param=crushdefence,2
 param=magicdefence,10
-param=destroy_death,^true
+param=destroy_drop,^true
 param=lose_cape_message,Guthix reclaims the cape as it touches the ground.
 tradeable=no
 
@@ -94,7 +94,7 @@ param=stabdefence,1
 param=slashdefence,1
 param=crushdefence,2
 param=magicdefence,10
-param=destroy_death,^true
+param=destroy_drop,^true
 param=lose_cape_message,Zamorak reclaims the cape as it touches the ground.
 tradeable=no
 

--- a/scripts/macro events/scripts/macro_events.rs2
+++ b/scripts/macro events/scripts/macro_events.rs2
@@ -122,6 +122,7 @@ p_delay(1);
 // https://youtu.be/g5k3XuXxyYQ?list=PLn23LiLYLb1Y3P9S9qZbijcJihiD416jT&t=37
 spotanim_map(smokepuff, coord, 124, 0);
 sound_synth(smokepuff2, 0, 0);
+~tele_checks;
 //--
 ~p_telejump_safe($teleport_coord); // todo: Confirm this
 

--- a/scripts/player/configs/death.param
+++ b/scripts/player/configs/death.param
@@ -1,3 +1,7 @@
 [destroy_death]
 type=int
 default=0
+
+[destroy_drop]
+type=int
+default=0

--- a/scripts/player/scripts/death.rs2
+++ b/scripts/player/scripts/death.rs2
@@ -53,6 +53,8 @@ def_boolean $protecting_item = false;
 if (%prayer8 = ^true) { $protecting_item = true; }
 inv_clear(deathkeep);
 
+def_obj $currentitem;
+
 if($skulled = false) {
     ~move_priciest_item_on_hero_to_death;
     ~move_priciest_item_on_hero_to_death;
@@ -66,8 +68,12 @@ def_int $i = 0;
 def_int $size = inv_size(inv);
 while ($i < $size) {
     if (inv_getnum(inv, $i) > 0) {
-        if (oc_category(inv_getobj(inv, $i)) = armour_godcape) {
-            mes(oc_param(inv_getobj(inv, $i), lose_cape_message));
+        $currentitem = inv_getobj(inv, $i);
+        if (oc_category($currentitem) = armour_godcape) {
+            mes(oc_param($currentitem, lose_cape_message));
+        }
+        if (oc_param($currentitem, destroy_drop) = ^true | oc_param($currentitem, destroy_death) = ^true) {
+            inv_delslot(inv, $i);
         }
     }
     $i = calc($i + 1);
@@ -77,8 +83,12 @@ $i = 0;
 $size = inv_size(worn);
 while ($i < $size) {
     if (inv_getnum(worn, $i) > 0) {
-        if (oc_category(inv_getobj(worn, $i)) = armour_godcape) {
-            mes(oc_param(inv_getobj(worn, $i), lose_cape_message));
+        $currentitem = inv_getobj(worn, $i);
+        if (oc_category($currentitem) = armour_godcape) {
+            mes(oc_param($currentitem, lose_cape_message));
+        }
+        if (oc_param($currentitem, destroy_drop) = ^true | oc_param($currentitem, destroy_death) = ^true) {
+            inv_delslot(worn, $i);
         }
     }
     $i = calc($i + 1);
@@ -111,12 +121,16 @@ if($protecting_item = true) {
 
 def_int $i = 0;
 def_int $size = inv_size(inv);
+def_obj $currentitem;
 while ($i < $size) {
     if (inv_getnum(inv, $i) > 0) {
-        if (oc_category(inv_getobj(inv, $i)) = armour_godcape) {
-            mes(oc_param(inv_getobj(inv, $i), lose_cape_message));
+        $currentitem = inv_getobj(inv, $i);
+        if (oc_param($currentitem, destroy_drop) = ^true | oc_param($currentitem, destroy_death) = ^true) {
+            if (oc_category(inv_getobj(inv, $i)) = armour_godcape) {
+                mes(oc_param(inv_getobj(inv, $i), lose_cape_message));
+            }
             inv_delslot(inv, $i);
-        } else {
+        }  else {
             both_dropslot(inv, coord, $i, ^lootdrop_duration);
         }
     }
@@ -127,10 +141,13 @@ $i = 0;
 $size = inv_size(worn);
 while ($i < $size) {
     if (inv_getnum(worn, $i) > 0) {
-        if (oc_category(inv_getobj(worn, $i)) = armour_godcape) {
-            mes(oc_param(inv_getobj(worn, $i), lose_cape_message));
+        $currentitem = inv_getobj(worn, $i);
+        if (oc_param($currentitem, destroy_drop) = ^true | oc_param($currentitem, destroy_death) = ^true) {
+            if (oc_category(inv_getobj(worn, $i)) = armour_godcape) {
+                mes(oc_param(inv_getobj(worn, $i), lose_cape_message));
+            }
             inv_delslot(worn, $i);
-        } else {
+        }  else {
             both_dropslot(worn, coord, $i, ^lootdrop_duration);
         }
     }

--- a/scripts/quests/quest_chompybird/configs/quest_chompybird.obj
+++ b/scripts/quests/quest_chompybird/configs/quest_chompybird.obj
@@ -74,6 +74,7 @@ iop4=Release All
 iop5=Release
 tradeable=no
 param=unbankable,^true
+param=destroy_drop,^true
 
 [raw_chompy]
 name=Raw chompy

--- a/scripts/quests/quest_crest/configs/quest_crest.obj
+++ b/scripts/quests/quest_crest/configs/quest_crest.obj
@@ -65,6 +65,7 @@ param=slashdefence,9
 param=crushdefence,7
 param=strengthbonus,2
 tradeable=no
+param=destroy_drop,^true
 
 [gauntlets_of_goldsmithing]
 category=category_16
@@ -92,6 +93,7 @@ param=slashdefence,9
 param=crushdefence,7
 param=strengthbonus,2
 tradeable=no
+param=destroy_drop,^true
 
 [gauntlets_of_chaos]
 category=category_16
@@ -119,6 +121,7 @@ param=slashdefence,9
 param=crushdefence,7
 param=strengthbonus,2
 tradeable=no
+param=destroy_drop,^true
 
 [steel_gauntlets]
 category=category_16
@@ -146,6 +149,7 @@ param=slashdefence,9
 param=crushdefence,7
 param=strengthbonus,2
 tradeable=no
+param=destroy_drop,^true
 
 [avan_crest]
 model=model_2688_obj

--- a/scripts/quests/quest_fluffs/configs/quest_fluffs.obj
+++ b/scripts/quests/quest_fluffs/configs/quest_fluffs.obj
@@ -63,6 +63,7 @@ category=category_81
 members=yes
 op1=Use
 tradeable=no
+param=destroy_drop,^true
 
 [kittenobject]
 name=Pet kitten
@@ -79,7 +80,7 @@ weight=750g
 category=kitten
 param=follower_id,kittenpet1
 tradeable=no
-//https://chisel.weirdgloop.org/structs_rs3/index.html?type=items&id=1555
+param=destroy_drop,^true
 
 [kittenobject_light]
 name=Pet kitten
@@ -104,6 +105,7 @@ weight=750g
 category=kitten
 param=follower_id,kittenpet_light
 tradeable=no
+param=destroy_drop,^true
 
 [kittenobject_brown]
 name=Pet kitten
@@ -126,6 +128,7 @@ weight=750g
 category=kitten
 param=follower_id,kittenpet_brown
 tradeable=no
+param=destroy_drop,^true
 
 [kittenobject_black]
 name=Pet kitten
@@ -148,6 +151,7 @@ weight=750g
 category=kitten
 param=follower_id,kittenpet_black
 tradeable=no
+param=destroy_drop,^true
 
 [kittenobject_browngrey]
 name=Pet kitten
@@ -170,6 +174,7 @@ weight=750g
 category=kitten
 param=follower_id,kittenpet_browngrey
 tradeable=no
+param=destroy_drop,^true
 
 [kittenobject_bluegrey]
 name=Pet kitten
@@ -192,6 +197,7 @@ weight=750g
 category=kitten
 param=follower_id,kittenpet_bluegrey
 tradeable=no
+param=destroy_drop,^true
 
 [growncatobject]
 name=Pet cat
@@ -208,6 +214,7 @@ weight=1500g
 category=cat
 param=follower_id,growncat
 tradeable=no
+param=destroy_drop,^true
 
 [growncatobject_light]
 name=Pet cat
@@ -232,6 +239,7 @@ weight=1500g
 category=cat
 param=follower_id,growncat_light
 tradeable=no
+param=destroy_drop,^true
 
 [growncatobject_brown]
 name=Pet cat
@@ -254,6 +262,7 @@ weight=1500g
 category=cat
 param=follower_id,growncat_brown
 tradeable=no
+param=destroy_drop,^true
 
 [growncatobject_black]
 name=Pet cat
@@ -276,6 +285,7 @@ weight=1500g
 category=cat
 param=follower_id,growncat_black
 tradeable=no
+param=destroy_drop,^true
 
 [growncatobject_browngrey]
 name=Pet cat
@@ -298,6 +308,7 @@ weight=1500g
 category=cat
 param=follower_id,growncat_browngrey
 tradeable=no
+param=destroy_drop,^true
 
 [growncatobject_bluegrey]
 name=Pet cat
@@ -320,6 +331,7 @@ weight=1500g
 category=cat
 param=follower_id,growncat_bluegrey
 tradeable=no
+param=destroy_drop,^true
 
 [overgrowncatobject]
 name=Pet cat
@@ -336,6 +348,7 @@ weight=2500g
 category=overgrown
 param=follower_id,overgrowncat
 tradeable=no
+param=destroy_drop,^true
 
 [overgrowncatobject_light]
 name=Pet cat
@@ -360,6 +373,7 @@ weight=2500g
 category=overgrown
 param=follower_id,overgrowncat_light
 tradeable=no
+param=destroy_drop,^true
 
 [overgrowncatobject_brown]
 name=Pet cat
@@ -382,6 +396,7 @@ weight=2500g
 category=overgrown
 param=follower_id,overgrowncat_brown
 tradeable=no
+param=destroy_drop,^true
 
 [overgrowncatobject_black]
 name=Pet cat
@@ -404,6 +419,7 @@ weight=2500g
 category=overgrown
 param=follower_id,overgrowncat_black
 tradeable=no
+param=destroy_drop,^true
 
 [overgrowncatobject_browngrey]
 name=Pet cat
@@ -426,6 +442,7 @@ weight=2500g
 category=overgrown
 param=follower_id,overgrowncat_browngrey
 tradeable=no
+param=destroy_drop,^true
 
 [overgrowncatobject_bluegrey]
 name=Pet cat
@@ -448,3 +465,4 @@ weight=2500g
 category=overgrown
 param=follower_id,overgrowncat_bluegrey
 tradeable=no
+param=destroy_drop,^true

--- a/scripts/quests/quest_itexam/configs/quest_itexam.obj
+++ b/scripts/quests/quest_itexam/configs/quest_itexam.obj
@@ -446,6 +446,7 @@ recol1d=31201
 weight=25g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [nitroglycerin]
 name=Nitroglycerin
@@ -460,6 +461,7 @@ recol1d=31201
 weight=25g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [ground_charcoal]
 name=Ground charcoal
@@ -488,6 +490,7 @@ recol1d=20929
 weight=30g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [postcharcoalmixture]
 name=Mixed chemicals
@@ -502,6 +505,7 @@ recol1d=16577
 weight=35g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [digcompound]
 name=Chemical compound
@@ -516,6 +520,7 @@ recol1d=3171
 weight=35g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [arcenia_root]
 name=Arcenia root

--- a/scripts/quests/quest_priest/configs/quest_priest.obj
+++ b/scripts/quests/quest_priest/configs/quest_priest.obj
@@ -30,3 +30,4 @@ model=model_2388_obj
 weight=80g
 param=no_alchemy,1
 tradeable=no
+param=destroy_drop,^true

--- a/scripts/quests/quest_upass/configs/upass.obj
+++ b/scripts/quests/quest_upass/configs/upass.obj
@@ -168,6 +168,7 @@ recol1d=4228
 weight=1200g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [ibandoll]
 name=Doll of iban

--- a/scripts/quests/quest_zombiequeen/configs/quest_zombiequeen.obj
+++ b/scripts/quests/quest_zombiequeen/configs/quest_zombiequeen.obj
@@ -11,6 +11,7 @@ members=yes
 iop1=Inspect
 weight=10g
 tradeable=no
+param=destroy_drop,^true
 
 [zqbonekey]
 name=Bone key
@@ -26,6 +27,7 @@ recol1d=32767
 members=yes
 weight=10g
 tradeable=no
+param=destroy_drop,^true
 
 [zqplaque]
 name=Stone-plaque
@@ -40,6 +42,7 @@ iop1=Read
 weight=800g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [zqberviriusscroll]
 name=Tattered scroll
@@ -56,6 +59,7 @@ iop1=Read
 weight=20g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [zqrashiliyiascroll]
 name=Crumpled scroll
@@ -72,6 +76,7 @@ iop1=Read
 weight=20g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [zqcorpse]
 name=Rashiliya corpse
@@ -85,6 +90,7 @@ model=model_2595_obj
 weight=300g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [zqzadimusbones]
 name=Zadimus corpse
@@ -99,6 +105,7 @@ iop1=Bury
 weight=500g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [zqcrystal]
 name=Locating crystal
@@ -113,6 +120,7 @@ members=yes
 iop1=Activate
 weight=2lb
 tradeable=no
+param=destroy_drop,^true
 
 [zqcrystal_blue]
 name=Locating crystal
@@ -176,6 +184,7 @@ recol1d=32767
 weight=2lb
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [zqdeadbeads]
 name=Beads of the dead
@@ -207,6 +216,7 @@ param=rangedefence,1
 param=strengthbonus,1
 param=prayerbonus,1
 tradeable=no
+param=destroy_drop,^true
 
 [fake_coins]
 cost=1
@@ -232,6 +242,7 @@ model=model_2561_obj
 weight=1g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [zqbevsword]
 name=Sword pommel
@@ -246,6 +257,7 @@ cost=1
 weight=3oz
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [zqberviriusscroll2]
 name=Bervirius notes
@@ -263,6 +275,7 @@ iop1=Read
 weight=20g
 members=yes
 tradeable=no
+param=destroy_drop,^true
 
 [mosol_wampum_belt]
 name=Wampum belt

--- a/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -70,13 +70,15 @@ if ($rum > 0) {
 if(inv_total(inv, plaguesample) > 0) {
     inv_del(inv, plaguesample, ^max_32bit_int);
     mes("The plague sample is too delicate...it disintegrates in the crossing.");
-    return;
+}
+if(inv_total(inv, thanainabarrel) > 0) {
+    inv_del(inv, thanainabarrel, ^max_32bit_int);
+    mes("Your drop 'Ana in a barrel' before you teleport.");
 }
 
 [proc,pre_tele_checks](coord $coord)(boolean)
 if(inv_total(inv, thanainabarrel) > 0) {
     ~chatnpc_specific("Ana (in a Barrel)", anabarrel, "<p,idle>@dbl@-- You can't teleport while holding the barrel, it's just @dbl@too difficult to concentrate. --");
-    return(false);
 }
 if (~inzone_coord_pair_table(trawler_wreck_zones, $coord) = true) {
     ~mesbox("Water and magic don't mix!|You can't teleport whilst swimming."); // osrs

--- a/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -49,6 +49,7 @@ if (p_finduid(uid) = true) {
 [proc,player_teleport_normal](coord $coord)
 if_close;
 p_stopaction;
+~tele_checks;
 sound_synth(teleport_all, 0, 0);
 anim(human_castteleport, 0);
 spotanim_pl(teleport_casting, 92, 0);
@@ -71,15 +72,14 @@ if(inv_total(inv, plaguesample) > 0) {
     inv_del(inv, plaguesample, ^max_32bit_int);
     mes("The plague sample is too delicate...it disintegrates in the crossing.");
 }
+
+[proc,tele_checks]()
 if(inv_total(inv, thanainabarrel) > 0) {
     inv_del(inv, thanainabarrel, ^max_32bit_int);
     mes("Your drop 'Ana in a barrel' before you teleport.");
 }
 
 [proc,pre_tele_checks](coord $coord)(boolean)
-if(inv_total(inv, thanainabarrel) > 0) {
-    ~chatnpc_specific("Ana (in a Barrel)", anabarrel, "<p,idle>@dbl@-- You can't teleport while holding the barrel, it's just @dbl@too difficult to concentrate. --");
-}
 if (~inzone_coord_pair_table(trawler_wreck_zones, $coord) = true) {
     ~mesbox("Water and magic don't mix!|You can't teleport whilst swimming."); // osrs
     return(false);
@@ -100,5 +100,10 @@ if (~in_duel_arena($coord) = true) {
     mes("Coward! You can't teleport from a duel."); //RS3 message: https://archive.org/details/runelibris
     //Colored in #AB0908 in RS3, but was likely not colored in 2004
     return(false);
+}
+
+if(inv_total(inv, thanainabarrel) > 0) {
+    ~chatnpc_specific("Ana (in a Barrel)", anabarrel, "<p,idle>@dbl@-- You can't teleport while holding the barrel, it's just @dbl@too difficult to concentrate. --");
+    return (true);
 }
 return(true);


### PR DESCRIPTION
for 225+, relies on https://github.com/LostCityRS/Engine-TS/pull/80

untradeables should drop to the ground on death, with some exceptions of items that generally cant be on the ground, like cats, god capes, ana, etc.

this pr adds a param for items that will be destroyed if dropped to the ground on death, and changes god capes to use this. Ana will always be deleted on death, using the existing param for that. Death logic for standard and pvp deaths is updated to use this
