### PR TITLE
fix: Applied category=chicken to Rooster

### DIFF
--- a/scripts/_unpack/244/all.npc
+++ b/scripts/_unpack/244/all.npc
@@ -72,6 +72,6 @@ param=attack_sound,chicken_attack
 param=defend_sound,chicken_hit
 param=death_sound,chicken_death
 param=retreat,1
-// category=chicken
+category=chicken
 // Stats match osrs version but our version Vislvl is different.
 // https://raw.githubusercontent.com/Joshua-F/osrs-dumps/refs/heads/master/config/dump.npc npc_1175


### PR DESCRIPTION
https://oldschool.runescape.wiki/w/Rooster
Rooster now has exactly the same functions as chicken + including drops.