### PR TITLE
fix: Misc Tutorial island tweaks

### DIFF
--- a/scripts/skill_fishing/configs/fishing.npc
+++ b/scripts/skill_fishing/configs/fishing.npc
@@ -11,6 +11,7 @@ model1=model_loc_42_8
 defaultmode=none
 moverestrict=nomove
 timer=1
+category=category_453
 
 [0_41_53_sinisterfishspot]
 vislevel=hide
@@ -24,6 +25,7 @@ model1=model_loc_42_8
 defaultmode=none
 moverestrict=nomove
 timer=1
+category=category_453
 
 [0_41_53_bigdavefishspot]
 vislevel=hide
@@ -37,6 +39,7 @@ model1=model_loc_42_8
 defaultmode=none
 moverestrict=nomove
 timer=1
+category=category_453
 
 [0_41_53_joshuafishspot]
 vislevel=hide
@@ -50,6 +53,7 @@ model1=model_loc_42_8
 defaultmode=none
 moverestrict=nomove
 timer=1
+category=category_453
 //--- Fishing contest
 
 //--- (Lure/Bait) Gnome Stronghold

--- a/scripts/tutorial/configs/tutorial.npc
+++ b/scripts/tutorial/configs/tutorial.npc
@@ -276,11 +276,9 @@ wanderrange=6
 maxrange=8
 respawnrate=60
 hitpoints=3
-// param=attackbonus, TODO
-param=stabdefence,-100
-param=slashdefence,-100
-param=crushdefence,-100
-// param=rangedefence, TODO
+attack=3
+strength=3
+defence=3
 param=damagetype,^stab_style
 param=attack_anim,giantrat_attack
 param=defend_anim,giantrat_block
@@ -300,9 +298,9 @@ readyanim=chicken_ready
 op2=Attack
 model1=model_2849_npc
 hitpoints=3
-// param=attackbonus, TODO
-param=magicdefence,-100
-// param=rangedefence, TODO
+attack=3
+strength=3
+defence=3
 param=attack_anim,chicken_attack
 param=defend_anim,chicken_block
 param=death_anim,chicken_death
@@ -310,7 +308,6 @@ param=attack_sound,chicken_attack
 param=defend_sound,chicken_hit
 param=death_sound,chicken_death
 param=death_drop,newbiebones
-category=chicken
 // https://raw.githubusercontent.com/Joshua-F/osrs-dumps/refs/heads/master/config/dump.npc npc_3316
 
 [0_48_48_newbiefishing]
@@ -326,6 +323,7 @@ model1=model_loc_42_8
 defaultmode=none
 wanderrange=0
 moverestrict=nomove
+category=category_453
 
 [noobbanker]
 vislevel=hide

--- a/scripts/tutorial/scripts/guides/runescape_guide.rs2
+++ b/scripts/tutorial/scripts/guides/runescape_guide.rs2
@@ -20,7 +20,7 @@ if (map_live = false) {
 ~chatnpc("<p,neutral>Greetings! I see you are a new arrival to this land.|My job is to welcome all new visitors. So welcome!");
 ~chatnpc("<p,neutral>You have already learnt the first thing|needed to succeed in this world...|Talking to other people!");
 ~chatnpc("<p,neutral>You will find many inhabitants of this world|have useful things to say to you. By clicking|on them with your mouse you can talk to them.");
-// ~chatnpc("<p,neutral>I would also suggest reading through some of the|supporting information on the website. There you can|find maps, a bestiary, and much more.");
+~chatnpc("<p,neutral>I would also suggest reading through some of|the supporting information on the website.|There you can find maps, a bestiary, and much more.");
 ~chatnpc("<p,neutral>To continue the tutorial go through that door|over there, and speak to your first instructor!");
 %tutorial = ^newbie_basics_instructor_interact_with_scenery;
 ~set_tutorial_progress;

--- a/scripts/tutorial/scripts/npcs/tut_giant_rat.rs2
+++ b/scripts/tutorial/scripts/npcs/tut_giant_rat.rs2
@@ -5,7 +5,6 @@
 gosub(npc_death);
 if (npc_findhero = ^true) {
     obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
-    obj_add(npc_coord, raw_rat_meat, 1, ^lootdrop_duration);
     if (%tutorial =  ^newbie_combat_instructor_during_attacking_melee
         | %tutorial =  ^newbie_combat_instructor_before_attacking_ranged) {
         queue(set_rat_kill, 0, 0);


### PR DESCRIPTION
*Tutorial giant rat no longer drops raw rat meat.

*tutorial giant rat and chicken stats have been changed attack 3, str 3, def 3, hp 3 this should match vislevel. original can't be known because osrs data doesn't match at all. + including parameter attack bonuses and defense bonuses are set to 0 instead of -100..

*tutorial chicken category_chicken has now been completely removed from this npc. because it doesn't appear in osrs cache and now tutorial chicken also doesn't drop feather or raw chicken anymore.

*1 dialogue part from runescape guide npc fixed and added line breaks which pazaz forgot to fix earlier.
https://cdn.discordapp.com/attachments/1126857544523063367/1477462271436263596/image.png?ex=69a62af7&is=69a4d977&hm=b44ed766bdd1c031761e03535889c98aa09fb242fb0e3c2c769b41d75bfaf65c


*fishing contest fishing spot, and tutorial fishing spot added category_453 which also appears in osrs cache. no idea what this does but someone can figure it out this category is probably called some fishingspot_quest or something similar.



****Talking to the Survival Expert crashes the game at the point where she is about to give the player an axe.****