### PR TITLE
fix: typos in skillguides

### DIFF
--- a/scripts/player/configs/skill_guide.dbrow
+++ b/scripts/player/configs/skill_guide.dbrow
@@ -176,10 +176,10 @@ data=advancement,Access to:
 data=inv,skill_guide_agility
 data=unlock,1,Gnome Stronghold agility course.
 data=unlock,1,Gnomeball game.
-data=unlock,1,Low-level agility arena obstacles.
-data=unlock,20,Medium-level agility arena obstacles.
+data=unlock,1,Low level agility arena obstacles.
+data=unlock,20,Medium level agility arena obstacles.
 data=unlock,35,Barbarian Outpost agility course.
-data=unlock,40,High-level agility arena obstacles.
+data=unlock,40,High level agility arena obstacles.
 data=unlock,52,Wilderness course.
 
 // ----
@@ -213,35 +213,35 @@ data=unlock,67,Lantadyme.
 data=unlock,70,Dwarf weed.
 data=unlock,75,Torstol.
 
-// note: derived from 2007 clientscript
+// note: derived from 2007 clientscript + Jan 07 source for uppercase secondaries & tab order http://rune-scape.net/_fr/0/6845832.png
 [skill_guide_herblore_potions]
 table=skill_guides
 data=name,Herblore - Potions
 data=inv,skill_guide_herblore_potions
 data=unlock,-1,You must complete the Druidic Ritual\nquest before you can use Herblore.
-data=unlock,3,Attack potion\nGuam leaf & eye of newt.
-data=unlock,5,Anti-poison potion\nMarrentill & ground unicorn horn.
-data=unlock,12,Strength potion\nTarromin & limpwurt root.
-data=unlock,22,Stat restore potion\nHarralander & red spiders' eggs.
-data=unlock,26,Energy potion\nHarralander & chocolate dust.
-data=unlock,30,Defence potion\nRanarr weed & white berries.
-data=unlock,34,Agility potion\nToadflax & toad legs.
-data=unlock,38,Prayer restore potion\nRanarr weed & snape grass.
+data=unlock,3,Attack potion\nGuam leaf & Eye of newt.
+data=unlock,5,Anti-poison potion\nMarrentill & Ground unicorn horn.
+data=unlock,12,Strength potion\nTarromin & Limpwurt root.
+data=unlock,22,Stat restore potion\nHarralander & Red spiders' eggs.
+data=unlock,26,Energy potion\nHarralander & Chocolate dust.
+data=unlock,30,Defence potion\nRanarr weed & White berries.
+data=unlock,34,Agility potion\nToadflax & Toad legs.
+data=unlock,38,Prayer restore potion\nRanarr weed & Snape grass.
 // [sic] "Super Attack"
-data=unlock,45,Super Attack potion\nIrit leaf & eye of newt.
-data=unlock,48,Super anti-poison potion\nIrit leaf & ground unicorn horn.
-data=unlock,50,Fishing potion\nAvantoe & snape grass.
+data=unlock,45,Super Attack potion\nIrit leaf & Eye of newt.
+data=unlock,48,Super anti-poison potion\nIrit leaf & Ground unicorn horn.
+data=unlock,50,Fishing potion\nAvantoe & Snape grass.
 data=unlock,52,Super energy potion\nAvantoe & Mort Myre fungi.
 // [sic] "Super Strength"
-data=unlock,55,Super Strength potion\nKwuarm & limpwurt root.
-data=unlock,60,Weapon poison\nKwuarm & ground blue dragon scale.
-data=unlock,63,Super restore potion\nSnapdragon & red spiders' eggs.
+data=unlock,55,Super Strength potion\nKwuarm & Limpwurt root.
+data=unlock,60,Weapon poison\nKwuarm & Ground blue dragon scale.
+data=unlock,63,Super restore potion\nSnapdragon & Red spiders' eggs.
 // [sic] "Super Defence"
-data=unlock,66,Super Defence potion\nCadantine & white berries.
-data=unlock,69,Anti-firebreath potion\nLantadyme & ground blue dragon scale.
-data=unlock,72,Ranging potion\nDwarf weed & wine of Zamorak.
-data=unlock,76,Magic potion\nLantadyme & potato cactus.
-data=unlock,78,Zamorak brew\nTorstol & jangerberries.
+data=unlock,66,Super Defence potion\nCadantine & White berries.
+data=unlock,69,Anti-firebreath potion\nLantadyme & Ground blue dragon scale.
+data=unlock,72,Ranging potion\nDwarf weed & Wine of Zamorak.
+data=unlock,76,Magic potion\nLantadyme & Potato cactus.
+data=unlock,78,Zamorak brew\nTorstol & Jangerberries.
 
 // ----
 
@@ -275,7 +275,7 @@ data=inv,skill_guide_thieving_pickpocket
 data=unlock,1,Citizen.
 data=unlock,10,Farmer.
 data=unlock,25,Warrior.
-data=unlock,38,Rogue.
+data=unlock,32,Rogue.
 data=unlock,40,Guard.
 data=unlock,45,Fremennik.
 data=unlock,55,Knight.
@@ -430,7 +430,7 @@ data=op,Pickaxes,skill_guide_mining_pickaxes
 
 [skill_guide_mining_ores]
 table=skill_guides
-data=name,Mining - Ores
+data=name,Mining - Ore
 data=advancement,Able to mine:
 data=inv,skill_guide_mining_ores
 data=unlock,1,Rune essence (after completing Rune Mysteries).
@@ -486,7 +486,7 @@ data=unlock,40,Gold.
 data=unlock,50,Mithril
 // [sic] "Adamant" despite "Runite" below
 data=unlock,70,Adamant
-data=unlock,80,Runite
+data=unlock,85,Runite
 
 [skill_guide_smithing_bronze]
 table=skill_guides
@@ -776,7 +776,7 @@ data=unlock,-1,2. Use a pot to collect the flour you have made.
 // [sic] exact number of spaces
 data=unlock,-1,3. Fill a bucket or jug with water from a sink\n     or fountain.
 // [sic] exact number of spaces
-data=unlock,-1,4. Mix the dough and water to make some bread\n     dough.
+data=unlock,-1,4. Mix the flour and water to make some bread\n     dough.
 data=unlock,-1,5. Cook the dough by using it with a stove.
 
 [skill_guide_cooking_pies]
@@ -791,7 +791,7 @@ data=unlock,-1,To make a pie:
 data=unlock,-1,1. Mix flour and water to make pastry dough.
 data=unlock,-1,2. Place the dough in an empty pie dish.
 // [sic] exact number of spaces
-data=unlock,-1,"3. Use your choice of filling with the empty\n     pie (redberry, apple, or meat)."
+data=unlock,-1,"3. Use your choice of filling with the empty\n     pie (redberry, apple or meat)."
 data=unlock,-1,4. Cook the pie by using it with a stove.
 
 [skill_guide_cooking_stews]


### PR DESCRIPTION
274+
https://github.com/AmVoidGuy/skillGuides/tree/main

^ All changes have been made based of sources from within this git (besides rogue lvl, pulled that from wikis)



some stuff in skillguides im still unsure about:
- strength: we have halberds in 274, idk if we should have str guide because of that
- herblore: jan 07 source shows potions tab first, herbs 2nd
- crafting: silver sickle
- cooking: we have karambwan in fishing guide, but not in cooking
- cooking: we have a source showing lava eel in cooking guide
