### PR TITLE
fix: mime emote message fixes

### DIFF
--- a/scripts/interface_controls/scripts/player_controls.rs2
+++ b/scripts/interface_controls/scripts/player_controls.rs2
@@ -103,5 +103,5 @@ anim($anim, 20);
 
 [label,lockemote_mime_event]
 if (p_finduid(uid) = true) {
-    ~mesbox("This emote can be unlocked during the mime random event.");
+    ~mesbox("You can't use that emote yet."); // https://www.youtube.com/watch?v=Ke-iZF6aZ98&t=185s july 06 (https://www.youtube.com/watch?v=s083tB35i-8&t=80s changed late 06)
 }

--- a/scripts/macro events/scripts/general/macro_event_mime.rs2
+++ b/scripts/macro events/scripts/general/macro_event_mime.rs2
@@ -204,7 +204,7 @@ if (testbit(%emote_access, ^macro_mime_climb_rope) = ^false) {
 if (testbit(%emote_access, ^macro_mime_lean) = ^false) {
     if ($current = $pick) {
         %emote_access = setbit(%emote_access, ^macro_mime_lean);
-        ~mesbox("You can now use the Lean on air emote!");
+        ~mesbox("You can now use the Lean emote!"); // https://i.imgur.com/b7WvfEH.png (2005)
         return;
     }
     $current = add($current, 1);


### PR DESCRIPTION
254+

- Changed mime emote not unlocked message based on July 06 source
- Changed unlocked Lean on air message based on 2005 source

https://www.youtube.com/watch?v=Ke-iZF6aZ98&t=185s (july 06)
https://www.youtube.com/watch?v=s083tB35i-8&t=80s (late 06)
<img width="1122" height="739" alt="image" src="https://github.com/user-attachments/assets/b8a06535-8eb6-45f2-92fa-0a3ac9dfbd8c" />
<img width="1131" height="743" alt="image" src="https://github.com/user-attachments/assets/71704c2a-77d6-4b44-a54f-4f087fb72d37" />
2005 Lean message
<img width="781" height="573" alt="231231213123" src="https://github.com/user-attachments/assets/a345ddfd-41ff-42e0-90bf-4009a539a0a5" />

