### PR TITLE
fix: genie random message fix

### DIFF
--- a/scripts/macro events/scripts/general/macro_event_genie.rs2
+++ b/scripts/macro events/scripts/general/macro_event_genie.rs2
@@ -62,7 +62,7 @@ if (uid ! %npc_macro_event_target) {
     return;
 }
 if (%npc_int = ^genie_happy) {
-    ~chatnpc("<p,neutral>Have a nice day, <text_gender("master", "mistress")>.");
+    ~chatnpc("<p,neutral>I hope you're happy with your wish. I must be leaving|now though.");
     return;
 }
 %npc_int = ^genie_happy;


### PR DESCRIPTION
225+

- Changed genie random event message based on old source

https://www.runescape.pc.pl/solucje/raporty-specjalne/41-umiejetnosci/thieving/320-random-events
<img width="487" height="230" alt="image" src="https://github.com/user-attachments/assets/d61eaa27-2512-47be-979d-e5c3550ad273" />
