### PR TITLE
feat: smelt-x

### DIFF
--- a/scripts/skill_smithing/configs/smelting/smelting.struct
+++ b/scripts/skill_smithing/configs/smelting/smelting.struct
@@ -11,9 +11,13 @@ param=ingredient,copper_ore
 param=bar_count,1
 param=ingredient_secondary,tin_ore
 param=ingredient_secondary_count,1
+param=queueore_primary,You have run out of ore to smelt into bronze.
+param=queueore_secondary,You have run out of ore to smelt into bronze.
 
 [smelting_iron_bar]
 param=levelfailure,You need a Smithing level of 15 to smelt an iron bar.
+// https://youtu.be/yPoPflxnUUY?si=hqyZRndBgQM1TWXS&t=245
+param=processfailure,You don't have any iron ore to smelt.
 param=processmessage,You smelt the iron in the furnace.
 param=productmessage,You retrieve a bar of iron.
 param=product,iron_bar
@@ -21,6 +25,7 @@ param=levelrequired,15
 param=productexp,125
 param=ingredient,iron_ore
 param=bar_count,1
+param=queueore_primary,You have run out of iron ore to smelt.
 
 [smelting_steel_bar]
 param=levelfailure,You need a Smithing level of 30 to smelt a steel bar.
@@ -34,9 +39,12 @@ param=ingredient,iron_ore
 param=bar_count,1
 param=ingredient_secondary,coal
 param=ingredient_secondary_count,2
+param=queueore_primary,You have run out of iron ore with which to make steel.
+param=queueore_secondary,You don't have enough coal to make any more steel.
 
 [smelting_silver_bar]
 param=levelfailure,You need a Smithing level of 20 to smelt a silver bar.
+param=processfailure,You don't have any silver ore to smelt.
 param=processmessage,You place a lump of silver in the furnace.
 param=productmessage,You retrieve a bar of silver from the furnace.
 param=product,silver_bar
@@ -44,9 +52,11 @@ param=levelrequired,20
 param=productexp,137
 param=ingredient,silver_ore
 param=bar_count,1
+param=queueore_primary,You have run out of silver ore to smelt.
 
 [smelting_gold_bar]
 param=levelfailure,You need a Smithing level of 40 to smelt a gold bar.
+param=processfailure,You don't have any gold ore to smelt.
 param=processmessage,You place a lump of gold in the furnace.
 param=productmessage,You retrieve a bar of gold from the furnace.
 param=product,gold_bar
@@ -54,6 +64,7 @@ param=levelrequired,40
 param=productexp,225
 param=ingredient,gold_ore
 param=bar_count,1
+param=queueore_primary,You have run out of gold ore to smelt.
 
 [smelting_mithril_bar]
 param=levelfailure,You need a Smithing level of 50 to smelt a mithril bar.
@@ -68,6 +79,8 @@ param=ingredient,mithril_ore
 param=bar_count,1
 param=ingredient_secondary,coal
 param=ingredient_secondary_count,4
+param=queueore_primary,You have run out of mithril ore to smelt.
+param=queueore_secondary,You don't have enough coal to make any more mithril.
 
 [smelting_adamantite_bar]
 param=levelfailure,You need a Smithing level of 70 to smelt an adamantite bar.
@@ -82,6 +95,8 @@ param=ingredient,adamantite_ore
 param=bar_count,1
 param=ingredient_secondary,coal
 param=ingredient_secondary_count,6
+param=queueore_primary,You have run out of adamantite ore to smelt.
+param=queueore_secondary,You don't have enough coal to make any more adamantite.
 
 [smelting_runite_bar]
 param=levelfailure,You need a Smithing level of 85 to smelt a runite bar.
@@ -96,9 +111,12 @@ param=ingredient,runite_ore
 param=bar_count,1
 param=ingredient_secondary,coal
 param=ingredient_secondary_count,8
+param=queueore_primary,You have run out of runite ore to smelt.
+param=queueore_secondary,You don't have enough coal to make any more runite.
 
 [smelting_perfect_gold_bar]
 param=levelfailure,You need a Smithing level of 40 to smelt a gold bar.
+param=processfailure,You don't have any gold ore to smelt.
 param=processmessage,You place a lump of gold in the furnace.
 param=productmessage,You retrieve a bar of gold from the furnace.
 param=product,perfect_gold_bar
@@ -106,3 +124,4 @@ param=levelrequired,40
 param=productexp,225
 param=ingredient,perfect_gold_ore
 param=bar_count,1
+param=queueore_primary,You have run out of gold ore to smelt.

--- a/scripts/skill_smithing/configs/smithing/smithing.param
+++ b/scripts/skill_smithing/configs/smithing/smithing.param
@@ -37,3 +37,11 @@ default=1
 [smithing_anvil_struct]
 type=struct
 default=null
+
+[queueore_primary]
+type=string
+default=null
+
+[queueore_secondary]
+type=string
+default=null

--- a/scripts/skill_smithing/scripts/smelting/smelting.rs2
+++ b/scripts/skill_smithing/scripts/smelting/smelting.rs2
@@ -76,7 +76,6 @@ def_int $entered_value = last_int;
 @smelt_ore($bar, $entered_value);
 
 [label,smelt_ore_single](obj $last)
-p_arrivedelay;
 def_namedobj $bar = oc_param($last, smeltsto);
 // using coal on furnace assumes steel bar. If using iron on furnace and player has 2 or more coal, then assume steel bar
 if (($last = iron_ore & inv_total(inv, coal) >= 2 & stat(smithing) >= 30) | $last = coal) {
@@ -90,6 +89,7 @@ if ($bar = null) {
 if(%action_delay < map_clock) {
     %action_delay = add(map_clock, 1); // sets action delay here as well
 }
+p_arrivedelay;
 @smelt_ore($bar, 1);
 
 [label,smelt_ore](obj $last, int $count)

--- a/scripts/skill_smithing/scripts/smelting/smelting.rs2
+++ b/scripts/skill_smithing/scripts/smelting/smelting.rs2
@@ -72,6 +72,7 @@ if_openchat(smelting);
 [label,smelt_ore_makex](obj $bar)
 p_countdialog;
 def_int $entered_value = last_int;
+if($entered_value <= 0) return;
 // https://youtu.be/C21cqhLHj98?si=Wa8Jf9T-fl7Xez_Q&t=68
 @smelt_ore($bar, $entered_value);
 

--- a/scripts/skill_smithing/scripts/smelting/smelting.rs2
+++ b/scripts/skill_smithing/scripts/smelting/smelting.rs2
@@ -11,15 +11,72 @@ switch_obj (last_useitem)
     case elemental_workshop_ore : mes("This furnace is not hot enough to smelt elemental ore.");
     case default :
         if (oc_category(last_useitem) = category_91) {
-            @smelt_ore(last_useitem);
+            @smelt_ore_single(last_useitem);
         }
         ~displaymessage(^dm_default);
 }
 
-//--- this is the code that uses p_delays instead of weakqueues
-[label,smelt_ore](obj $last)
-p_arrivedelay();
-// find the bar that the ore smelts to
+[oploc2,furnace1]
+// https://youtu.be/IKcLMkk50VU?si=9nCY28zLperwnJgM&t=62, interface was always brought up originally
+// osrs will auto make a single bar if you have ores for only 1 in inventory
+if_setobject(smelting:com_4, bronze_bar, 150);
+if_setobject(smelting:com_5, iron_bar, 150);
+if_setobject(smelting:com_6, silver_bar, 150);
+if_setobject(smelting:com_7, steel_bar, 150);
+if_setobject(smelting:com_8, gold_bar, 150);
+if_setobject(smelting:com_9, mithril_bar, 150);
+if_setobject(smelting:com_10, adamantite_bar, 150);
+if_setobject(smelting:com_11, runite_bar, 150);
+if_openchat(smelting);
+
+[if_button,smelting:com_15] @smelt_ore(bronze_bar, 1);
+[if_button,smelting:com_14] @smelt_ore(bronze_bar, 5);
+[if_button,smelting:com_13] @smelt_ore(bronze_bar, 10);
+[if_button,smelting:com_12] @smelt_ore_makex(bronze_bar);
+
+[if_button,smelting:com_19] @smelt_ore(iron_bar, 1);
+[if_button,smelting:com_18] @smelt_ore(iron_bar, 5);
+[if_button,smelting:com_17] @smelt_ore(iron_bar, 10);
+[if_button,smelting:com_16] @smelt_ore_makex(iron_bar);
+
+[if_button,smelting:com_23] @smelt_ore(silver_bar, 1);
+[if_button,smelting:com_22] @smelt_ore(silver_bar, 5);
+[if_button,smelting:com_21] @smelt_ore(silver_bar, 10);
+[if_button,smelting:com_20] @smelt_ore_makex(silver_bar);
+
+[if_button,smelting:com_27] @smelt_ore(steel_bar, 1);
+[if_button,smelting:com_26] @smelt_ore(steel_bar, 5);
+[if_button,smelting:com_25] @smelt_ore(steel_bar, 10);
+[if_button,smelting:com_24] @smelt_ore_makex(steel_bar);
+
+[if_button,smelting:com_31] @smelt_ore(gold_bar, 1);
+[if_button,smelting:com_30] @smelt_ore(gold_bar, 5);
+[if_button,smelting:com_29] @smelt_ore(gold_bar, 10);
+[if_button,smelting:com_28] @smelt_ore_makex(gold_bar);
+
+[if_button,smelting:com_35] @smelt_ore(mithril_bar, 1);
+[if_button,smelting:com_34] @smelt_ore(mithril_bar, 5);
+[if_button,smelting:com_33] @smelt_ore(mithril_bar, 10);
+[if_button,smelting:com_32] @smelt_ore_makex(mithril_bar);
+
+[if_button,smelting:com_39] @smelt_ore(adamantite_bar, 1);
+[if_button,smelting:com_38] @smelt_ore(adamantite_bar, 5);
+[if_button,smelting:com_37] @smelt_ore(adamantite_bar, 10);
+[if_button,smelting:com_36] @smelt_ore_makex(adamantite_bar);
+
+[if_button,smelting:com_43] @smelt_ore(runite_bar, 1);
+[if_button,smelting:com_42] @smelt_ore(runite_bar, 5);
+[if_button,smelting:com_41] @smelt_ore(runite_bar, 10);
+[if_button,smelting:com_40] @smelt_ore_makex(runite_bar);
+
+[label,smelt_ore_makex](obj $bar)
+p_countdialog;
+def_int $entered_value = last_int;
+// https://youtu.be/C21cqhLHj98?si=Wa8Jf9T-fl7Xez_Q&t=68
+@smelt_ore($bar, $entered_value);
+
+[label,smelt_ore_single](obj $last)
+p_arrivedelay;
 def_namedobj $bar = oc_param($last, smeltsto);
 // using coal on furnace assumes steel bar. If using iron on furnace and player has 2 or more coal, then assume steel bar
 if (($last = iron_ore & inv_total(inv, coal) >= 2 & stat(smithing) >= 30) | $last = coal) {
@@ -30,7 +87,19 @@ if ($bar = null) {
     ~displaymessage(^dm_default);
     return;
 }
-def_struct $struct = oc_param($bar, smelting_struct); 
+if(%action_delay < map_clock) {
+    %action_delay = add(map_clock, 1); // sets action delay here as well
+}
+@smelt_ore($bar, 1);
+
+[label,smelt_ore](obj $last, int $count)
+if_close;
+// https://youtu.be/mMQ1PmgpWtQ?si=2HE4hDPxhS7NlE1U&t=465
+// make x perfect gold works, if you have both ores it will prio regular gold
+if($last = gold_bar & inv_total(inv, gold_ore) = 0 & inv_total(inv, perfect_gold_ore) > 0) {
+    $last = perfect_gold_bar;
+}
+def_struct $struct = oc_param($last, smelting_struct); 
 // If smithing level isnt high enough, dislpay level fail message
 if (stat(smithing) < struct_param($struct, levelrequired)) {
     ~mesbox(struct_param($struct, levelfailure));
@@ -47,132 +116,88 @@ if ($secondary_total < struct_param($struct, ingredient_secondary_count)) {
     ~mesbox(struct_param($struct, processfailure));
     return;
 }
-// macro event
+@smelt_ore_weakqueue($last, $count);
+
+[label,smelt_ore_weakqueue](obj $bar, int $count)
+// https://youtu.be/mMQ1PmgpWtQ?si=2HE4hDPxhS7NlE1U&t=465
+// make x perfect gold works, if you have both ores it will prio regular gold and process both
+if($bar = gold_bar & inv_total(inv, gold_ore) = 0 & inv_total(inv, perfect_gold_ore) > 0) {
+    $bar = perfect_gold_bar;
+}
+def_struct $struct = oc_param($bar, smelting_struct);
 if (afk_event = ^true) {
     ~macro_event_general_spawn(~macro_event_set_random);
     return;
 }
-anim(human_furnace, 0);
+if (%action_delay < map_clock) {
+    %action_delay = calc(map_clock + 3);
+    anim(human_furnace, 0);
+    sound_synth(furnace, 0, 0);
+    mes(struct_param($struct, processmessage));
+    weakqueue*(smelting_ore, 4)($struct, $count);
+} else {
+    weakqueue*(start_smelt_ore, calc(%action_delay - map_clock - 1))($struct, $count);
+}
+
+[queue,start_smelt_ore](struct $struct, int $count)
+def_obj $primary_ore = struct_param($struct, ingredient);
+def_obj $secondary_ore = struct_param($struct, ingredient_secondary);
+def_int $primary_total = inv_total(inv, $primary_ore);
+def_int $secondary_total = inv_total(inv, $secondary_ore);
+// If not enough ores
+// https://youtu.be/Tb1oa7hMyhs?si=2IieUTMhp4kZ0A_K&t=141, https://youtu.be/m7lC4cTLHVA?si=Gt9Be615NpR7aCL8&t=32
+// https://youtu.be/4w2ppvPOJLQ?si=9rxW51dbPAdgST-y&t=8, https://youtu.be/Amv8nLOWrWw?si=Tej0TQRCMGkDXk_j&t=389
+// https://youtu.be/7wg_AeqK_2s?si=2XtMUAr9llPKR3CG&t=1330
+if ($primary_total < struct_param($struct, bar_count)) {
+    mes(struct_param($struct, queueore_primary));
+    return;
+}
+if ($secondary_total < struct_param($struct, ingredient_secondary_count)) {
+    mes(struct_param($struct, queueore_secondary));
+    return;
+}
+%action_delay = calc(map_clock + 3);
+anim(human_furnace, 0); // plays here for somereason
 sound_synth(furnace, 0, 0);
-
-// display process message
 mes(struct_param($struct, processmessage));
+weakqueue*(smelting_ore, 3)($struct, $count);
 
-p_delay(3);
-
+[queue,smelting_ore](struct $struct, int $count)
 // delete main ore
 inv_del(inv, struct_param($struct, ingredient), struct_param($struct, bar_count));
 // delete secondary ore
 if (struct_param($struct, ingredient_secondary) ! null) {
     inv_del(inv, struct_param($struct, ingredient_secondary), struct_param($struct, ingredient_secondary_count));
 }
-
-if ($bar = iron_bar) {
+def_namedobj $product = struct_param($struct, product);
+if ($product = iron_bar) {
     // if player is wearing ring of forging
     if (inv_total(worn, ring_of_forging) > 0 & map_members = ^true) {
         ~lose_charge_ring_of_forging;
     } else if (randominc(1) = 1) { // else assume 50% chance of success
         mes("The ore is too impure and you fail to refine it.");
+        if(sub($count,1) > 0) {
+            %action_delay = add(map_clock, 1);
+            @smelt_ore_weakqueue($product, sub($count,1));
+        }
         return;
     }
 }
-
-// If player is wearing gold smith gauntlets, 2.5x xp. The multiplier was 1.5x in RSC,
+// if player is wearing gold smith gauntlets, 2.5x xp. The multiplier was 1.5x in RSC,
 // earliest mention of 2.5x (56.2) xp is in aug 2004: https://web.archive.org/web/20040820223401/http://runevillage.net/ThePub/viewtopic.php?p=1257194&amp
 // No mentioned updates to Family Crest or the gauntlets in that period. 
 // Was likely changed when ported to rs2.
 def_int $xp = struct_param($struct, productexp);
-if ($bar = gold_bar & inv_total(worn, gauntlets_of_goldsmithing) > 0) {
+if ($product = gold_bar & inv_total(worn, gauntlets_of_goldsmithing) > 0) {
     $xp = scale(5, 2, $xp); // 2.5x
 }
-
-stat_advance(smithing, $xp);
-
-// add bar
-inv_add(inv, $bar, 1);
-// display product message
+// display ingame message
 mes(struct_param($struct, productmessage));
-//----------------------------
-
-//************* WEAKQUEUES DIDNT EXIST UNTIL SEPT 2004 *************
-// //--- This label is jumped to when ore -> furnace
-// [label,smelt_ore](obj $last)
-// p_arrivedelay();
-// // find the bar that the ore smelts to
-// def_namedobj $bar = oc_param($last, smeltsto);
-// // mes(oc_name($last));
-// // mes(oc_name($bar));
-// // for some reason jagex has blankrune and clay in the ores category
-// if ($bar = null) {
-//     ~displaymessage(^dm_default);
-//     return;
-// }
-// def_struct $struct = oc_param($bar, smelting_struct); 
-// // If smithing level isnt high enough, dislpay level fail message
-// if (stat(smithing) < struct_param($struct, levelrequired)) {
-//     ~mesbox(struct_param($struct, levelfailure));
-//     return;
-// }
-// def_int $primary_total = inv_total(inv, struct_param($struct, ingredient));
-// def_int $secondary_total = inv_total(inv, struct_param($struct, ingredient_secondary));
-// // If not enough ores
-// if ($primary_total < struct_param($struct, bar_count)) {
-//     ~mesbox(struct_param($struct, processfailure));
-//     return;
-// }
-// if ($secondary_total < struct_param($struct, ingredient_secondary_count)) {
-//     ~mesbox(struct_param($struct, processfailure));
-//     return;
-// }
-// if (%action_delay < map_clock) {
-//     %action_delay = calc(map_clock + 3);
-//     anim(human_furnace, 0); // plays here for somereason
-//     sound_synth(furnace, 0, 2);
-//     mes(struct_param($struct, processmessage));
-//     weakqueue(smelting_ore, 2, $struct);
-// } else {
-//     weakqueue(start_smelting_ore, calc(%action_delay - map_clock - 1), $struct);
-// }
-// //----------------------------
-
-// //----------------------------
-// [weakqueue,start_smelting_ore](struct $struct)
-// %action_delay = calc(map_clock + 3);
-// anim(human_furnace, 0); // plays here for somereason
-// sound_synth(furnace, 0, 2);
-// mes(struct_param($struct, processmessage));
-// weakqueue(smelting_ore, 4, $struct);
-// //----------------------------
-
-// //--- Weakqueue for smelting one ore
-// [weakqueue,smelting_ore](struct $struct)
-// anim(human_furnace, 0);
-// // delete main ore
-// inv_del(inv, struct_param($struct, ingredient), struct_param($struct, bar_count));
-// // delete secondary ore
-// inv_del(inv, struct_param($struct, ingredient_secondary), struct_param($struct, ingredient_secondary_count));
-// def_namedobj $product = struct_param($struct, product);
-// def_int $xp = struct_param($struct, productexp);
-// if ($product = iron_bar) {
-//     // if player is wearing ring of forging
-//     if (inv_total(worn, ring_of_forging) > 0) {
-//         ~lose_charge_ring_of_forging;
-//     } else if (randominc(1) = 1) { // else assume 50% chance of success
-//         mes("The ore is too impure and you fail to refine it.");
-//         return;
-//     }
-// }
-// // if player is wearing gold smith gauntlets, 1.5x
-// // osrs wiki says 56.2 xp, but the earliest confirmation of that is dec 2005. anything before that is unclear
-// // classic has it at 1.5x, no idea why it was changed to 2.5x after late 2005.
-// if ($product = gold_bar & inv_total(worn, gauntlets_of_goldsmithing) > 0) {
-//     $xp = scale(3, 2, $xp); // 1.5x
-// }
-// // display ingame message
-// mes(struct_param($struct, productmessage));
-// // add product
-// inv_add(inv, $product, 1);
-// // add exp
-// stat_advance(smithing, $xp);
-// //----------------------------
-//************* WEAKQUEUES DIDNT EXIST UNTIL SEPT 2004 *************
+// add product
+inv_add(inv, $product, 1);
+// add exp
+stat_advance(smithing, $xp);
+if(sub($count,1) > 0) {
+    %action_delay = add(map_clock, 1);
+    @smelt_ore_weakqueue($product, sub($count,1));
+}

--- a/scripts/skill_smithing/scripts/smelting/smelting.rs2
+++ b/scripts/skill_smithing/scripts/smelting/smelting.rs2
@@ -86,11 +86,31 @@ if ($bar = null) {
     ~displaymessage(^dm_default);
     return;
 }
-if(%action_delay < map_clock) {
-    %action_delay = add(map_clock, 1); // sets action delay here as well
-}
+// osrs sets action delay here, which delays the starting weakqueue by 1t, old videos
+// show this was instant originally : https://youtu.be/ser9EDJAhX8?si=t6vfx_yel5PmYvGN&t=379
+// smelting here is also 3t instead of 4t
 p_arrivedelay;
-@smelt_ore($bar, 1);
+if(~validate_first_smelt($bar) = true) @smelt_ore_weakqueue($bar, 1, 2);
+
+[proc,validate_first_smelt](obj $last)(boolean)
+def_struct $struct = oc_param($last, smelting_struct); 
+// If smithing level isnt high enough, dislpay level fail message
+if (stat(smithing) < struct_param($struct, levelrequired)) {
+    ~mesbox(struct_param($struct, levelfailure));
+    return (false);
+}
+def_int $primary_total = inv_total(inv, struct_param($struct, ingredient));
+def_int $secondary_total = inv_total(inv, struct_param($struct, ingredient_secondary));
+// If not enough ores
+if ($primary_total < struct_param($struct, bar_count)) {
+    ~mesbox(struct_param($struct, processfailure));
+    return (false);
+}
+if ($secondary_total < struct_param($struct, ingredient_secondary_count)) {
+    ~mesbox(struct_param($struct, processfailure));
+    return (false);
+}
+return (true);
 
 [label,smelt_ore](obj $last, int $count)
 if_close;
@@ -99,26 +119,9 @@ if_close;
 if($last = gold_bar & inv_total(inv, gold_ore) = 0 & inv_total(inv, perfect_gold_ore) > 0) {
     $last = perfect_gold_bar;
 }
-def_struct $struct = oc_param($last, smelting_struct); 
-// If smithing level isnt high enough, dislpay level fail message
-if (stat(smithing) < struct_param($struct, levelrequired)) {
-    ~mesbox(struct_param($struct, levelfailure));
-    return;
-}
-def_int $primary_total = inv_total(inv, struct_param($struct, ingredient));
-def_int $secondary_total = inv_total(inv, struct_param($struct, ingredient_secondary));
-// If not enough ores
-if ($primary_total < struct_param($struct, bar_count)) {
-    ~mesbox(struct_param($struct, processfailure));
-    return;
-}
-if ($secondary_total < struct_param($struct, ingredient_secondary_count)) {
-    ~mesbox(struct_param($struct, processfailure));
-    return;
-}
-@smelt_ore_weakqueue($last, $count);
+if(~validate_first_smelt($last) = true) @smelt_ore_weakqueue($last, $count, 4);
 
-[label,smelt_ore_weakqueue](obj $bar, int $count)
+[label,smelt_ore_weakqueue](obj $bar, int $count, int $delay)
 // https://youtu.be/mMQ1PmgpWtQ?si=2HE4hDPxhS7NlE1U&t=465
 // make x perfect gold works, if you have both ores it will prio regular gold and process both
 if($bar = gold_bar & inv_total(inv, gold_ore) = 0 & inv_total(inv, perfect_gold_ore) > 0) {
@@ -134,7 +137,7 @@ if (%action_delay < map_clock) {
     anim(human_furnace, 0);
     sound_synth(furnace, 0, 0);
     mes(struct_param($struct, processmessage));
-    weakqueue*(smelting_ore, 4)($struct, $count);
+    weakqueue*(smelting_ore, $delay)($struct, $count);
 } else {
     weakqueue*(start_smelt_ore, calc(%action_delay - map_clock - 1))($struct, $count);
 }
@@ -178,7 +181,7 @@ if ($product = iron_bar) {
         mes("The ore is too impure and you fail to refine it.");
         if(sub($count,1) > 0) {
             %action_delay = add(map_clock, 1);
-            @smelt_ore_weakqueue($product, sub($count,1));
+            @smelt_ore_weakqueue($product, sub($count,1), 4);
         }
         return;
     }
@@ -199,5 +202,5 @@ inv_add(inv, $product, 1);
 stat_advance(smithing, $xp);
 if(sub($count,1) > 0) {
     %action_delay = add(map_clock, 1);
-    @smelt_ore_weakqueue($product, sub($count,1));
+    @smelt_ore_weakqueue($product, sub($count,1), 4);
 }


### PR DESCRIPTION
Implements weakqueue smelting for regular metal bars, also applies to perfect gold (which is done through the gold option, it worked this way on OSRS release)

The primary difference here compared to osrs is with single bar smelting through opu,  in osrs this will set action_delay to run the starting queue 1t later, which then takes 4t to smelt the ore. On OSRS release this was instant instead (still has arrivedelay though) and the queue only took 3t to smelt the ore rather than 4 (ore smelted through smelt-x still took 4t), this video shows both back to back for a good comparison: https://youtu.be/JQnX6AW7sZQ?si=4ny9X-LLmCGw-KCU&t=168