### PR TITLE
refactor: tutorial island complete checks and tutorial island xp

### DIFF
--- a/scripts/player/scripts/equip.rs2
+++ b/scripts/player/scripts/equip.rs2
@@ -34,14 +34,12 @@ if (p_finduid(uid) = true) {
         return;
     }
     // todo: this needs a better home...
-    if (%tutorial < ^tutorial_complete) {
-     if (%tutorial = ^newbie_combat_instructor_unequipping_items) {
-            def_obj $shield = inv_getobj(worn, ^wearpos_lhand);
+    if (~in_tutorial_island(coord) = true & %tutorial = ^newbie_combat_instructor_unequipping_items) {
+        def_obj $shield = inv_getobj(worn, ^wearpos_lhand);
 
-            if ($previous = bronze_sword & $shield = wooden_shield) {
-                %tutorial = ^newbie_combat_instructor_open_combat_interface;
-                ~set_tutorial_progress;
-            }
+        if ($previous = bronze_sword & $shield = wooden_shield) {
+            %tutorial = ^newbie_combat_instructor_open_combat_interface;
+            ~set_tutorial_progress;
         }
     }
 

--- a/scripts/skill_combat/scripts/combat.rs2
+++ b/scripts/skill_combat/scripts/combat.rs2
@@ -116,57 +116,30 @@ if(npc_type = black_knight_titan) {
     stat_advance(hitpoints, scale(133, 100, $base));
     return;
 }
-if (%tutorial < ^tutorial_complete) {
-    switch_int($damagestyle) {
-        case ^style_melee_accurate :
-            ~tutorial_give_xp(attack, scale($multiplier, 1000, scale(400, 100, $base)));
-        case ^style_melee_aggressive :
-            ~tutorial_give_xp(strength, scale($multiplier, 1000, scale(400, 100, $base)));
-        case ^style_melee_defensive :
-            ~tutorial_give_xp(defence, scale($multiplier, 1000, scale(400, 100, $base)));
-        case ^style_melee_controlled :
-            ~tutorial_give_xp(attack, scale($multiplier, 1000, scale(133, 100, $base)));
-            ~tutorial_give_xp(strength, scale($multiplier, 1000, scale(133, 100, $base)));
-            ~tutorial_give_xp(defence, scale($multiplier, 1000, scale(133, 100, $base)));
-        case ^style_ranged_accurate, ^style_ranged_rapid :
-            ~tutorial_give_xp(ranged, scale($multiplier, 1000, scale(400, 100, $base)));
-        case ^style_ranged_longrange :
-            ~tutorial_give_xp(ranged, scale($multiplier, 1000, scale(200, 100, $base)));
-            ~tutorial_give_xp(defence, scale($multiplier, 1000, scale(200, 100, $base)));
-        case ^style_magic_normal :
-            ~tutorial_give_xp(magic, scale($multiplier, 1000, scale(200, 100, $base)));
-        case ^style_magic_defensive :
-            ~tutorial_give_xp(magic, scale($multiplier, 1000, scale(133, 100, $base)));
-            ~tutorial_give_xp(defence, scale($multiplier, 1000, scale(100, 100, $base)));
-        case default : return;
-    }
-    ~tutorial_give_xp(hitpoints, scale($multiplier, 1000, scale(133, 100, $base)));
-} else {
-    switch_int($damagestyle) {
-        case ^style_melee_accurate :
-            stat_advance(attack, scale($multiplier, 1000, scale(400, 100, $base)));
-        case ^style_melee_aggressive :
-            stat_advance(strength, scale($multiplier, 1000, scale(400, 100, $base)));
-        case ^style_melee_defensive :
-            stat_advance(defence, scale($multiplier, 1000, scale(400, 100, $base)));
-        case ^style_melee_controlled :
-            stat_advance(attack, scale($multiplier, 1000, scale(133, 100, $base)));
-            stat_advance(strength, scale($multiplier, 1000, scale(133, 100, $base)));
-            stat_advance(defence, scale($multiplier, 1000, scale(133, 100, $base)));
-        case ^style_ranged_accurate, ^style_ranged_rapid :
-            stat_advance(ranged, scale($multiplier, 1000, scale(400, 100, $base)));
-        case ^style_ranged_longrange :
-            stat_advance(ranged, scale($multiplier, 1000, scale(200, 100, $base)));
-            stat_advance(defence, scale($multiplier, 1000, scale(200, 100, $base)));
-        case ^style_magic_normal :
-            stat_advance(magic, scale($multiplier, 1000, scale(200, 100, $base)));
-        case ^style_magic_defensive :
-            stat_advance(magic, scale($multiplier, 1000, scale(133, 100, $base)));
-            stat_advance(defence, scale($multiplier, 1000, scale(100, 100, $base)));
-        case default : return;
-    }
-    stat_advance(hitpoints, scale($multiplier, 1000, scale(133, 100, $base)));
+switch_int($damagestyle) {
+    case ^style_melee_accurate :
+        stat_advance(attack, scale($multiplier, 1000, scale(400, 100, $base)));
+    case ^style_melee_aggressive :
+        stat_advance(strength, scale($multiplier, 1000, scale(400, 100, $base)));
+    case ^style_melee_defensive :
+        stat_advance(defence, scale($multiplier, 1000, scale(400, 100, $base)));
+    case ^style_melee_controlled :
+        stat_advance(attack, scale($multiplier, 1000, scale(133, 100, $base)));
+        stat_advance(strength, scale($multiplier, 1000, scale(133, 100, $base)));
+        stat_advance(defence, scale($multiplier, 1000, scale(133, 100, $base)));
+    case ^style_ranged_accurate, ^style_ranged_rapid :
+        stat_advance(ranged, scale($multiplier, 1000, scale(400, 100, $base)));
+    case ^style_ranged_longrange :
+        stat_advance(ranged, scale($multiplier, 1000, scale(200, 100, $base)));
+        stat_advance(defence, scale($multiplier, 1000, scale(200, 100, $base)));
+    case ^style_magic_normal :
+        stat_advance(magic, scale($multiplier, 1000, scale(200, 100, $base)));
+    case ^style_magic_defensive :
+        stat_advance(magic, scale($multiplier, 1000, scale(133, 100, $base)));
+        stat_advance(defence, scale($multiplier, 1000, scale(100, 100, $base)));
+    case default : return;
 }
+stat_advance(hitpoints, scale($multiplier, 1000, scale(133, 100, $base)));
 
 
 // returns the defend anim to use for this combat

--- a/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -18,7 +18,7 @@ p_opnpct(db_getfield($spell_data, magic_spell_table:spellcom, 0));
 
 // osrs's opnpct triggers are unused
 [apnpct,magic:wind_strike]
-if (%tutorial < ^tutorial_complete) {
+if (~in_tutorial_island(coord) = true) {
    ~pvm_tutorial_spell(^wind_strike);
 } else {
    ~pvm_default_spell(^wind_strike);

--- a/scripts/skill_cooking/scripts/cooking.rs2
+++ b/scripts/skill_cooking/scripts/cooking.rs2
@@ -2,7 +2,7 @@
 [oplocu,_cooking_fire]
 if(oc_param(last_useitem, unlit_arrow) = ^true) { // might not work on every fire?
     @light_firearrow(last_useitem);
-} else if (%tutorial < ^tutorial_complete) {
+} else if (~in_tutorial_island(coord) = true) {
     @tut_attempt_cook_item(last_useitem);
 } else {
     @attempt_cook_item(last_useitem);

--- a/scripts/skill_smithing/scripts/smithing/smithing.rs2
+++ b/scripts/skill_smithing/scripts/smithing/smithing.rs2
@@ -40,7 +40,7 @@
 if (~in_tutorial_island(coord) = true) {
     // This happens with any item, not just bars.
     if (%tutorial < ^newbie_mining_instructor_before_smelt_bronze_bar) {
-        ~mesbox("This is an anvil used for smithing.|You'll lean how to use it soon.");
+        ~mesbox("This is an anvil used for smithing.|You'll learn how to use it soon.");
         return;
     }
 

--- a/scripts/skill_smithing/scripts/smithing/smithing.rs2
+++ b/scripts/skill_smithing/scripts/smithing/smithing.rs2
@@ -37,7 +37,7 @@
 
 
 [oplocu,anvil]
-if (%tutorial < ^tutorial_complete) {
+if (~in_tutorial_island(coord) = true) {
     // This happens with any item, not just bars.
     if (%tutorial < ^newbie_mining_instructor_before_smelt_bronze_bar) {
         ~mesbox("This is an anvil used for smithing.|You'll lean how to use it soon.");
@@ -126,7 +126,7 @@ if(%death_equiproom < ^death_complete) {
 switch_obj ($last_item)
 {
     case bronze_bar :
-        if (%tutorial < ^tutorial_complete) {
+        if (~in_tutorial_island(coord) = true) {
             %modified_smith = 1;
         } else {
             %modified_smith = calc($player_level + 1);
@@ -238,7 +238,7 @@ anim(human_smithing, 0);
 sound_synth(anvil_4, 0, 0);
 // delay player during whole smithing sesh
 // https://oldschool.runescape.wiki/w/Update:Dev_Blog:_Third_Old_School_RuneScape_Content_Poll
-if (%tutorial < ^tutorial_complete) {
+if (~in_tutorial_island(coord) = true) {
     ~tut_smithing_anvil($count);
 } else {
     ~smithing_anvil($data, $count);

--- a/scripts/tutorial/scripts/skills/tut_bury_bone.rs2
+++ b/scripts/tutorial/scripts/skills/tut_bury_bone.rs2
@@ -15,9 +15,9 @@ p_delay(0);
 
 def_obj $last_item = inv_getobj(inv, $slot);
 inv_delslot(inv, $slot);
-~tutorial_give_xp(prayer, oc_param($last_item, bone_exp));
+stat_advance(prayer, oc_param($last_item, bone_exp));
 mes("You bury the bones.");
 
 // [queue,tut_finish_bury](obj $last_item)
-// ~tutorial_give_xp(prayer, oc_param($last_item, bone_exp));
+// stat_advance(prayer, oc_param($last_item, bone_exp));
 // mes("You bury the bones.");

--- a/scripts/tutorial/scripts/skills/tut_cooking.rs2
+++ b/scripts/tutorial/scripts/skills/tut_cooking.rs2
@@ -16,7 +16,7 @@ if (last_useitem = bread_dough) {
     if (%tutorial = ^newbie_cook_instructor_mixed_dough) {
         inv_del(inv, bread_dough, 1);
         inv_add(inv, bread, 1);
-        ~tutorial_give_xp(cooking, 400);
+        stat_advance(cooking, 400);
         %tutorial = ^newbie_cook_instructor_baked_bread;
         ~set_tutorial_progress;
     } else {
@@ -25,7 +25,7 @@ if (last_useitem = bread_dough) {
         if ($rand < calc(3 + stat_base(cooking))) {
             mes("You remove the bread from the oven.");
             inv_add(inv, bread, 1);
-            ~tutorial_give_xp(cooking, 400);
+            stat_advance(cooking, 400);
         } else {
             mes("You accidentally burn the bread.");
             inv_add(inv, burnt_bread, 1);
@@ -64,7 +64,7 @@ if ($uncooked_item = newbieraw_shrimp) {
         p_delay(2);
         inv_del(inv, newbieraw_shrimp, 1);
         inv_add(inv, shrimp, 1);
-        ~tutorial_give_xp(cooking, 300);
+        stat_advance(cooking, 300);
         %tutorial = ^newbie_survival_instructor_complete;
         ~tutorial_step_survival_recap;
     } else {
@@ -89,7 +89,7 @@ def_int $rand = random(10);
 if ($rand < calc(3 + stat_base(cooking))) {
     mes("The shrimps are now nicely cooked.");
     inv_add(inv, shrimp, 1);
-    ~tutorial_give_xp(cooking, 300);
+    stat_advance(cooking, 300);
 } else {
     mes("You accidentally burn the shrimps.");
     inv_add(inv, burntfish1, 1);
@@ -100,7 +100,7 @@ def_int $rand = random(10);
 if ($rand < calc(3 + stat_base(cooking))) {
     mes("The meat is now nicely cooked.");
     inv_add(inv, cooked_meat, 1);
-    ~tutorial_give_xp(cooking, 300);
+    stat_advance(cooking, 300);
 } else {
     mes("You accidentally burn the meat.");
     inv_add(inv, burnt_meat, 1);

--- a/scripts/tutorial/scripts/skills/tut_firemaking.rs2
+++ b/scripts/tutorial/scripts/skills/tut_firemaking.rs2
@@ -71,7 +71,7 @@ anim(null, 0);
 
 [proc,tut_firemaking_success](coord $fire_coord, obj $log)
 obj_del();
-~tutorial_give_xp(firemaking, 400);
+stat_advance(firemaking, 400);
 sound_synth(fire_lit, 0, 0);
 facesquare($fire_coord);
 if (%tutorial = ^newbie_survival_instructor_build_fire) {

--- a/scripts/tutorial/scripts/skills/tut_fishing.rs2
+++ b/scripts/tutorial/scripts/skills/tut_fishing.rs2
@@ -26,7 +26,7 @@ sound_synth(fishing_cast, 0, 15);
 p_delay(1);
 anim(null, 0);
 inv_add(inv, newbieraw_shrimp, 1);
-~tutorial_give_xp(fishing, 100);
+stat_advance(fishing, 100);
 if (%tutorial = ^newbie_survival_instructor_fish_shrimps) {
     hint_stop();
     %tutorial = ^newbie_survival_instructor_cook_shrimps;

--- a/scripts/tutorial/scripts/skills/tut_mining.rs2
+++ b/scripts/tutorial/scripts/skills/tut_mining.rs2
@@ -13,7 +13,7 @@ if (%tutorial = ^newbie_mining_instructor_mined_tin_first) {
 }
 ~set_tutorial_progress;
 inv_add(inv, copper_ore, 1);
-~tutorial_give_xp(mining, 175);
+stat_advance(mining, 175);
 ~mesbox("You manage to mine some copper.");
 
 // Tin Ore
@@ -31,7 +31,7 @@ if (%tutorial = ^newbie_mining_instructor_minted_copper_first) {
 }
 ~set_tutorial_progress;
 inv_add(inv, tin_ore, 1);
-~tutorial_give_xp(mining, 175);
+stat_advance(mining, 175);
 ~mesbox("You manage to mine some tin.");
 
 [proc,tut_mining](string $ore_name)(boolean)

--- a/scripts/tutorial/scripts/skills/tut_player_magic.rs2
+++ b/scripts/tutorial/scripts/skills/tut_player_magic.rs2
@@ -43,7 +43,7 @@ if (npc_type = newbiechicken & %tutorial < ^tutorial_successful_wind_strike) {
 
 [proc,tut_pvm_spell_cast](dbrow $spell_data)(int)
 ~delete_spell_runes($spell_data);
-~tut_give_spell_xp($spell_data);
+stat_advance(magic, db_getfield($spell_data, magic_spell_table:experience, 0));
 // spell anim
 anim(db_getfield($spell_data, magic_spell_table:anim, 0), 0);
 // player spell visual effect
@@ -62,6 +62,3 @@ if (~player_autocast_enabled = true & db_getfield($spell_data, magic_spell_table
     p_opnpct(db_getfield(~get_spell_data(%autocast_spell), magic_spell_table:spellcom, 0));
 }
 return($duration);
-
-[proc,tut_give_spell_xp](dbrow $spell_data)
-~tutorial_give_xp(magic, db_getfield($spell_data, magic_spell_table:experience, 0));

--- a/scripts/tutorial/scripts/skills/tut_smelting.rs2
+++ b/scripts/tutorial/scripts/skills/tut_smelting.rs2
@@ -41,7 +41,7 @@ if (%tutorial = ^newbie_mining_instructor_before_smelt_bronze_bar) {
 }
 inv_del(inv, copper_ore, 1);
 inv_del(inv, tin_ore, 1);
-~tutorial_give_xp(smithing, 62);
+stat_advance(smithing, 62);
 inv_add(inv, bronze_bar, 1);
 ~set_tutorial_progress;
 mes("You retreive a bar of bronze.");

--- a/scripts/tutorial/scripts/skills/tut_smithing.rs2
+++ b/scripts/tutorial/scripts/skills/tut_smithing.rs2
@@ -8,7 +8,7 @@ inv_del(inv, bronze_bar, 1);
 // add product
 inv_add(inv, bronze_dagger, 1);
 // add smithing xp
-~tutorial_give_xp(smithing, 125);
+stat_advance(smithing, 125);
 // display message
 mes("You hammer the bronze and make a dagger.");
 p_delay(1);

--- a/scripts/tutorial/scripts/skills/tut_woodcut.rs2
+++ b/scripts/tutorial/scripts/skills/tut_woodcut.rs2
@@ -80,7 +80,7 @@ loc_change($next_stage, $respawnrate);
 // set skill anim so it doesnt continue after depletion
 anim(null, $respawnrate);
 
-~tutorial_give_xp(woodcutting, 250);
+stat_advance(woodcutting, 250);
 if (%tutorial = ^newbie_survival_instructor_cut_tree) {
     @tut_advance_woodcutting;
 } else {

--- a/scripts/tutorial/scripts/tutorial.rs2
+++ b/scripts/tutorial/scripts/tutorial.rs2
@@ -287,12 +287,6 @@ if (inv_total(inv, $obj) > 0 | inv_total(worn, $obj) > 0) {
     return (false);
 }
 
-[proc,tutorial_give_xp](stat $skill, int $xp)
-if (stat_base($skill) >= 3) {
-    return;
-}
-stat_advance($skill, $xp);
-
 [label,tutorial_complete]
 tut_close();
 if_close;


### PR DESCRIPTION
for 225+

Same as https://github.com/LostCityRS/Content/pull/461 but without the ~givexp proc.

- tutorial island xp is moved to engine: https://github.com/LostCityRS/Engine-TS/pull/81
- A lot of the `%tutorial < ^tutorial_complete` checks are wrong, and are replaced with `~in_tutorial_island(coord)`. Having an incomplete %tutorial var after tutorial island, will prevent you from doing a lot of stuff (Doesnt match osrs!)
- fixes a typo during tutorial island smithing