### PR TITLE
fix: cannon msg, thread msg, watchtower tp msg

### DIFF
--- a/scripts/quests/quest_mcannon/scripts/cannon_setup.rs2
+++ b/scripts/quests/quest_mcannon/scripts/cannon_setup.rs2
@@ -4,7 +4,7 @@ if (%ownedmcannon = null) {
     return;
 }
 if (loc_find(%ownedmcannon, dwarf_multicannon1) = false) {
-    mes("Your cannon has decayed."); // https://runescape.wiki/w/Update:Patch_Notes_(6_May_2009)
+    mes("Your cannon has decayed!"); // https://i.imgur.com/Sw6twUP.png (2006) https://runescape.wiki/w/Update:Patch_Notes_(6_May_2009)
     cleartimer(cannon_decay);
 }
 

--- a/scripts/skill_crafting/scripts/leather/leather.rs2
+++ b/scripts/skill_crafting/scripts/leather/leather.rs2
@@ -125,10 +125,10 @@ if($product = hardleather_body) {
         inv_del(inv, thread, 1);
         %thread_used = 0;
         if(inv_total(inv, thread) = 0) {
-            mes("You use up your last reel of Thread.");
+            mes("You use up your last reel of thread"); // https://i.imgur.com/cpc8CJ0.png (2006)
             return;
         }
-        mes("You use up one of your reels of Thread.");
+        mes("You use up one of your reels of thread");
     }
     return;
 }
@@ -168,10 +168,10 @@ if (%thread_used > 4) {
     inv_del(inv, thread, 1);
     %thread_used = 0;
     if(inv_total(inv, thread) = 0) {
-        mes("You use up your last reel of Thread.");
+        mes("You use up your last reel of thread"); // https://i.imgur.com/cpc8CJ0.png (2006)
         return;
     }
-    mes("You use up one of your reels of Thread.");
+    mes("You use up one of your reels of thread");  
 }
 $count = sub($count, 1);
 if($count < 1) {

--- a/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -23,7 +23,7 @@ if (p_finduid(uid) = true) {
         return;
     }
     if($spell = ^watchtower_teleport & %itwatchtower < ^itwatchtower_complete) {
-        mes("You must have completed Watch Tower to use this spell.");
+        mes("You need to have completed the Watchtower Quest to use this spell."); // https://i.imgur.com/FelStNH.png (2006)
         return;
     }
     // https://www.reddit.com/r/2007scape/comments/b4vdki/watchtower_teleport_not_working_despite/, https://runescape.salmoneus.net/forums/topic/212538-cant-do-ardougne-tele-why-is-it-so/


### PR DESCRIPTION
225+

- Changed cannon decay message based on pre-september 2006 source
- Changed thread messages based on pre-september 2006 source
- Changed Watchtower TP message based on pre-september 2006 source (Pre rework of WT)

https://www.youtube.com/watch?t=505&v=_Q4g187iU5I
<img width="1080" height="606" alt="image" src="https://github.com/user-attachments/assets/16e62107-a5a8-449d-beb6-aa449dfbfd61" />
<img width="1084" height="603" alt="image" src="https://github.com/user-attachments/assets/d16c8ac3-fa02-47f2-925e-1c45c7c7a6d3" />
<img width="1078" height="601" alt="image" src="https://github.com/user-attachments/assets/c84349fa-6035-4c45-9b49-b2e1023aa429" />
