### PR TITLE
fix: %tutorial < ^tutorial_complete -> ~in_tutorial_island, and misc tutorial island cases

### DIFF
--- a/scripts/player/scripts/equip.rs2
+++ b/scripts/player/scripts/equip.rs2
@@ -34,14 +34,12 @@ if (p_finduid(uid) = true) {
         return;
     }
     // todo: this needs a better home...
-    if (%tutorial < ^tutorial_complete) {
-     if (%tutorial = ^newbie_combat_instructor_unequipping_items) {
-            def_obj $shield = inv_getobj(worn, ^wearpos_lhand);
+    if (~in_tutorial_island(coord) = true & %tutorial = ^newbie_combat_instructor_unequipping_items) {
+        def_obj $shield = inv_getobj(worn, ^wearpos_lhand);
 
-            if ($previous = bronze_sword & $shield = wooden_shield) {
-                %tutorial = ^newbie_combat_instructor_open_combat_interface;
-                ~set_tutorial_progress;
-            }
+        if ($previous = bronze_sword & $shield = wooden_shield) {
+            %tutorial = ^newbie_combat_instructor_open_combat_interface;
+            ~set_tutorial_progress;
         }
     }
 

--- a/scripts/skill_combat/scripts/combat.rs2
+++ b/scripts/skill_combat/scripts/combat.rs2
@@ -115,8 +115,7 @@ if(npc_type = black_knight_titan) {
     }
     stat_advance(hitpoints, scale(133, 100, $base));
     return;
-}
-if (%tutorial < ^tutorial_complete) {
+} else if (npc_type = newbiegiantrat) { // on sailing release you could attack sailing npcs on tutorial island for xp... So its probably an npc type check
     switch_int($damagestyle) {
         case ^style_melee_accurate :
             ~tutorial_give_xp(attack, scale($multiplier, 1000, scale(400, 100, $base)));

--- a/scripts/skill_combat/scripts/player/player_magic.rs2
+++ b/scripts/skill_combat/scripts/player/player_magic.rs2
@@ -18,7 +18,7 @@ p_opnpct(db_getfield($spell_data, magic_spell_table:spellcom, 0));
 
 // osrs's opnpct triggers are unused
 [apnpct,magic:wind_strike]
-if (%tutorial < ^tutorial_complete) {
+if (~in_tutorial_island(coord) = true) {
    ~pvm_tutorial_spell(^wind_strike);
 } else {
    ~pvm_default_spell(^wind_strike);

--- a/scripts/skill_cooking/scripts/cooking.rs2
+++ b/scripts/skill_cooking/scripts/cooking.rs2
@@ -2,7 +2,7 @@
 [oplocu,_cooking_fire]
 if(oc_param(last_useitem, unlit_arrow) = ^true) { // might not work on every fire?
     @light_firearrow(last_useitem);
-} else if (%tutorial < ^tutorial_complete) {
+} else if (~in_tutorial_island(coord) = true) {
     @tut_attempt_cook_item(last_useitem);
 } else {
     @attempt_cook_item(last_useitem);

--- a/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -86,6 +86,10 @@ if(inv_total(inv, thanainabarrel) > 0) {
 }
 
 [proc,pre_tele_checks](coord $coord)(boolean)
+if (~in_tutorial_island(coord) = true) {
+    ~mesbox("You cannot teleport from Tutorial Island!"); // https://youtu.be/tt38tH6X30E?t=64
+    return(false);
+}
 if (~inzone_coord_pair_table(trawler_wreck_zones, $coord) = true) {
     ~mesbox("Water and magic don't mix!|You can't teleport whilst swimming."); // osrs
     return(false);

--- a/scripts/skill_smithing/scripts/smithing/smithing.rs2
+++ b/scripts/skill_smithing/scripts/smithing/smithing.rs2
@@ -40,7 +40,7 @@
 if (~in_tutorial_island(coord) = true) {
     // This happens with any item, not just bars.
     if (%tutorial < ^newbie_mining_instructor_before_smelt_bronze_bar) {
-        ~mesbox("This is an anvil used for smithing.|You'll lean how to use it soon.");
+        ~mesbox("This is an anvil used for smithing.|You'll learn how to use it soon.");
         return;
     }
 

--- a/scripts/skill_smithing/scripts/smithing/smithing.rs2
+++ b/scripts/skill_smithing/scripts/smithing/smithing.rs2
@@ -37,7 +37,7 @@
 
 
 [oplocu,anvil]
-if (%tutorial < ^tutorial_complete) {
+if (~in_tutorial_island(coord) = true) {
     // This happens with any item, not just bars.
     if (%tutorial < ^newbie_mining_instructor_before_smelt_bronze_bar) {
         ~mesbox("This is an anvil used for smithing.|You'll lean how to use it soon.");
@@ -126,7 +126,7 @@ if(%death_equiproom < ^death_complete) {
 switch_obj ($last_item)
 {
     case bronze_bar :
-        if (%tutorial < ^tutorial_complete) {
+        if (~in_tutorial_island(coord) = true) {
             %modified_smith = 1;
         } else {
             %modified_smith = calc($player_level + 1);
@@ -238,7 +238,7 @@ anim(human_smithing, 0);
 sound_synth(anvil_4, 0, 0);
 // delay player during whole smithing sesh
 // https://oldschool.runescape.wiki/w/Update:Dev_Blog:_Third_Old_School_RuneScape_Content_Poll
-if (%tutorial < ^tutorial_complete) {
+if (~in_tutorial_island(coord) = true) {
     ~tut_smithing_anvil($count);
 } else {
     ~smithing_anvil($data, $count);

--- a/scripts/tutorial/scripts/skills/tut_player_magic.rs2
+++ b/scripts/tutorial/scripts/skills/tut_player_magic.rs2
@@ -43,7 +43,7 @@ if (npc_type = newbiechicken & %tutorial < ^tutorial_successful_wind_strike) {
 
 [proc,tut_pvm_spell_cast](dbrow $spell_data)(int)
 ~delete_spell_runes($spell_data);
-~tut_give_spell_xp($spell_data);
+~tutorial_give_xp(magic, db_getfield($spell_data, magic_spell_table:experience, 0));
 // spell anim
 anim(db_getfield($spell_data, magic_spell_table:anim, 0), 0);
 // player spell visual effect
@@ -62,6 +62,3 @@ if (~player_autocast_enabled = true & db_getfield($spell_data, magic_spell_table
     p_opnpct(db_getfield(~get_spell_data(%autocast_spell), magic_spell_table:spellcom, 0));
 }
 return($duration);
-
-[proc,tut_give_spell_xp](dbrow $spell_data)
-~tutorial_give_xp(magic, db_getfield($spell_data, magic_spell_table:experience, 0));


### PR DESCRIPTION
for 225+

Recreated from https://github.com/LostCityRS/Content/pull/461

- A lot of the `%tutorial < ^tutorial_complete` checks are wrong, and are replaced with `~in_tutorial_island(coord)`. Having an incomplete %tutorial var after tutorial island, will prevent you from doing a lot of stuff (Doesnt match osrs!)
- fixes a typo during tutorial island smithing
- adds tutorial island check to pre_tele_checks to match [video](https://youtu.be/tt38tH6X30E?t=64)
![VS--YouTube-RuneScape-NoclipGlitch-TutorialIslandNovember2012-2012-1’03”](https://github.com/user-attachments/assets/6e5a0ef9-5d93-4b33-a04a-ee26c2749f74)
