### PR TITLE
fix: Plaque City quest fixes

### DIFF
--- a/scripts/doors/scripts/open_and_close_doors.rs2
+++ b/scripts/doors/scripts/open_and_close_doors.rs2
@@ -61,6 +61,28 @@ p_teleport($dest);
 loc_change(inviswall, 3);
 loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 3);
 
+// open_and_close_door2, but with 1 less tick of delay on closing the door, used for Plague City's plague house door
+[proc,open_and_close_door_fast](loc $replacement, boolean $entering, synth $sound)
+def_int $x;
+def_int $z;
+def_int $angle = loc_angle;
+def_locshape $shape = loc_shape;
+def_coord $loc_coord = loc_coord;
+$x, $z = ~door_open($angle, loc_shape);
+def_coord $dest = $loc_coord;
+sound_synth($sound, 0, 0);
+if ($entering = true) {
+    if (coord ! $loc_coord) {
+        p_teleport($loc_coord);
+        p_delay(1);
+    }
+    $dest = movecoord(loc_coord, $x, 0, $z);
+}
+p_teleport($dest);
+// Temp note: dur updated
+loc_change(inviswall, 2);
+loc_add(movecoord($loc_coord, $x, 0, $z), $replacement, modulo(add($angle, 1), 4), $shape, 2);
+
 // Same as other proc but uses delay of 0 for outside doors, example: https://youtu.be/n_ip_vEDbCA?si=6WmhtFdrgVyPhvNQ&t=1219
 [proc,open_and_close_door3](loc $replacement, boolean $entering, synth $sound)
 def_int $x;

--- a/scripts/quests/quest_elena/scripts/doors.rs2
+++ b/scripts/quests/quest_elena/scripts/doors.rs2
@@ -8,7 +8,7 @@
 
 [label,west_ardougne_plague_house_doors]
 if (~check_axis(coord, loc_coord, loc_angle) = false) {
-    ~open_and_close_door2(loc_2536, false, door_open);
+    ~open_and_close_door_fast(loc_2536, false, door_open);
     return;
 }
 switch_int(%elenaquest) {
@@ -19,10 +19,10 @@ switch_int(%elenaquest) {
             @multi3("But I think a kidnap victim is in here.", plague_house_but_i_think_a_kidnap_victim_is_in_here, "I fear not a mere plague.", plague_house_i_fear_not_a_mere_plague, "Thanks for the warning.", plague_house_thanks_for_the_warning);
         }
     case ^quest_elena_spoke_cured_bravek :
-        // Based on 2023 OSRS because some dialogue was missing about "sneaking into the building" on Apr 2004 RuneHQ
+        // Based on 2013 & 2023 OSRS because some dialogue was missing about "sneaking into the building" on Apr 2004 RuneHQ
         // https://web.archive.org/web/20040423204649/http://www.runehq.com/viewquest.php?id=00155
-        // https://www.youtube.com/watch?v=CCoUF_hIbU0
-        ~mesbox("The door won't open.|You notice a black cross on the door.");
+        // https://youtu.be/CCoUF_hIbU0?t=202
+        // https://youtu.be/lw1AzW2OoT0?t=882
         if (inv_total(inv, warrant) > 0 & npc_find(coord, mournertwb, 14, 0) = true) {
             .npc_findall(npc_coord, mournertwb, 14, 0);
             if (.npc_findnext = false) return;
@@ -34,21 +34,22 @@ switch_int(%elenaquest) {
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");
             ~chatplayer("<p,neutral>I have a warrant from <nc_name(bravek)> to enter here.");
             ~chatnpc("<p,neutral>This is highly irregular. Please wait...");
-            npc_setmode(null);
+            npc_setmode(none); .npc_setmode(none);
             if_close;
-            p_delay(0);
+            p_delay(1);
             npc_facesquare(.npc_coord);
             .npc_facesquare(npc_coord);
-            npc_say("Hey... I've got someone here with a warrant from Bravek, what shoud we do?");
-            p_delay(0);
+            npc_say("Hey... I've got someone here with a warrant from Bravek, what should we do?");
+            p_delay(2);
             .npc_say("Well you can't let them in...");
-            p_delay(0);
-            ~open_and_close_door2(loc_2536, ~check_axis(coord, loc_coord, loc_angle), door_open);;
+            ~open_and_close_door_fast(loc_2536, true, door_open);;
             ~mesbox("You wait until the mourner's back is turned and sneak into the building.");
+            npc_setmode(null); .npc_setmode(null);
         } else if (npc_find(coord, mournertwb, 14, 0) = true) {
+            ~mesbox("The door won't open.|You notice a black cross on the door.");
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");
         }
-    case ^quest_elena_freed_elena, ^elena_complete, ^elena_complete_read_scroll : ~open_and_close_door2(loc_2536, ~check_axis(coord, loc_coord, loc_angle), door_open);;
+    case ^quest_elena_freed_elena, ^elena_complete, ^elena_complete_read_scroll : ~open_and_close_door_fast(loc_2536, true, door_open);;
     case default :
         ~mesbox("The door won't open.|You notice a black cross on the door.");
         if (npc_find(coord, mournertwb, 14, 0) = true) {

--- a/scripts/quests/quest_elena/scripts/doors.rs2
+++ b/scripts/quests/quest_elena/scripts/doors.rs2
@@ -16,7 +16,9 @@ switch_int(%elenaquest) {
         ~mesbox("The door won't open.|You notice a black cross on the door.");
         if (npc_find(coord, mournertwb, 14, 0) = true) {
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");
-            @multi3("But I think a kidnap victim is in here.", plague_house_but_i_think_a_kidnap_victim_is_in_here, "I fear not a mere plague.", plague_house_i_fear_not_a_mere_plague, "Thanks for the warning.", plague_house_thanks_for_the_warning);
+            @multi3("But I think a kidnap victim is in here.", plague_house_but_i_think_a_kidnap_victim_is_in_here,
+                    "I fear not a mere plague.", plague_house_i_fear_not_a_mere_plague,
+                    "Thanks for the warning.", plague_house_thanks_for_the_warning);
         }
     case ^quest_elena_spoke_cured_bravek :
         // Based on 2013 & 2023 OSRS because some dialogue was missing about "sneaking into the building" on Apr 2004 RuneHQ
@@ -45,7 +47,7 @@ switch_int(%elenaquest) {
             // npc_say("Hey... I've got someone here with a warrant from Bravek, what should we do?");
             // p_delay(2);
             // .npc_say("Well you can't let them in...");
-            ~open_and_close_door_fast(loc_2536, true, door_open);;
+            ~open_and_close_door_fast(loc_2536, true, door_open);
             ~mesbox("You wait until the mourner's back is turned and sneak into the building.");
             npc_setmode(null);
             // .npc_setmode(null);
@@ -53,7 +55,8 @@ switch_int(%elenaquest) {
             ~mesbox("The door won't open.|You notice a black cross on the door.");
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");
         }
-    case ^quest_elena_freed_elena, ^elena_complete, ^elena_complete_read_scroll : ~open_and_close_door_fast(loc_2536, true, door_open);;
+    case ^quest_elena_freed_elena, ^elena_complete, ^elena_complete_read_scroll :
+        ~open_and_close_door_fast(loc_2536, true, door_open);
     case default :
         ~mesbox("The door won't open.|You notice a black cross on the door.");
         if (npc_find(coord, mournertwb, 14, 0) = true) {

--- a/scripts/quests/quest_elena/scripts/doors.rs2
+++ b/scripts/quests/quest_elena/scripts/doors.rs2
@@ -8,7 +8,7 @@
 
 [label,west_ardougne_plague_house_doors]
 if (~check_axis(coord, loc_coord, loc_angle) = false) {
-    ~open_plague_door;
+    ~open_and_close_door2(loc_2536, false, door_open);
     return;
 }
 switch_int(%elenaquest) {
@@ -23,43 +23,18 @@ switch_int(%elenaquest) {
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");
             ~chatplayer("<p,neutral>I have a warrant from <nc_name(bravek)> to enter here.");
             if_close;
-            ~open_plague_door;
+            ~open_and_close_door2(loc_2536, ~check_axis(coord, loc_coord, loc_angle), door_open);;
         } else if (npc_find(coord, mournertwb, 14, 0) = true) {
             ~mesbox("The door won't open.|You notice a black cross on the door.");
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");
         }
-    case ^quest_elena_freed_elena, ^elena_complete, ^elena_complete_read_scroll : ~open_plague_door;
+    case ^quest_elena_freed_elena, ^elena_complete, ^elena_complete_read_scroll : ~open_and_close_door2(loc_2536, ~check_axis(coord, loc_coord, loc_angle), door_open);;
     case default :
         ~mesbox("The door won't open.|You notice a black cross on the door.");
         if (npc_find(coord, mournertwb, 14, 0) = true) {
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");
         }
 }
-
-[proc,open_plague_door]
-def_int $x;
-def_int $z;
-def_int $angle = loc_angle;
-def_locshape $shape = loc_shape;
-def_coord $loc_coord = loc_coord;
-$x, $z = ~door_open($angle, loc_shape);
-def_coord $dest = $loc_coord;
-sound_synth(door_open, 0, 0);
-if (~check_axis(coord, loc_coord, loc_angle) = true) {
-    if (coord ! $loc_coord) {
-        p_teleport($loc_coord);
-        p_delay(1);
-    }
-    $dest = movecoord(loc_coord, $x, 0, $z);
-}
-p_teleport($dest);
-// Temp note: dur updated
-if(.loc_find(loc_coord, boardedupdoor) = true) {
-    .loc_del(3);
-    .loc_add(movecoord($loc_coord, $x, 0, $z), boardedupdoor, modulo(add($angle, 1), 4), .loc_shape, 3);
-}
-loc_change(inviswall, 3);
-loc_add(movecoord($loc_coord, $x, 0, $z), loc_2536, modulo(add($angle, 1), 4), $shape, 3);
 
 [label,plague_house_but_i_think_a_kidnap_victim_is_in_here]
 ~chatplayer("<p,neutral>But I think a kidnap victim is in here.");

--- a/scripts/quests/quest_elena/scripts/doors.rs2
+++ b/scripts/quests/quest_elena/scripts/doors.rs2
@@ -24,27 +24,31 @@ switch_int(%elenaquest) {
         // https://youtu.be/CCoUF_hIbU0?t=202
         // https://youtu.be/lw1AzW2OoT0?t=882
         if (inv_total(inv, warrant) > 0 & npc_find(coord, mournertwb, 14, 0) = true) {
-            .npc_findall(npc_coord, mournertwb, 14, 0);
-            if (.npc_findnext = false) return;
-            def_int $tries = 0;// precautionary
-            while (.npc_uid = npc_uid & $tries < 30) {
-                .npc_findnext;
-                $tries = add($tries, 1);
-            }            
+            // Uncomment below for Post-rework Feb 06 mini-cutscene (Matches videos above)
+            // .npc_findall(npc_coord, mournertwb, 14, 0);
+            // if (.npc_findnext = false) return;
+            // def_int $tries = 0;// precautionary
+            // while (.npc_uid = npc_uid & $tries < 30) {
+            //     .npc_findnext;
+            //     $tries = add($tries, 1);
+            // }
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");
             ~chatplayer("<p,neutral>I have a warrant from <nc_name(bravek)> to enter here.");
-            ~chatnpc("<p,neutral>This is highly irregular. Please wait...");
-            npc_setmode(none); .npc_setmode(none);
-            if_close;
-            p_delay(1);
-            npc_facesquare(.npc_coord);
-            .npc_facesquare(npc_coord);
-            npc_say("Hey... I've got someone here with a warrant from Bravek, what should we do?");
-            p_delay(2);
-            .npc_say("Well you can't let them in...");
+            // ~chatnpcrange("<p,neutral>This is highly irregular. Please wait...");
+            ~chatnpcrange("<p,neutral>This is highly irregular. Please wait while I speak to the Head Mourner.");
+            // npc_setmode(none);
+            // .npc_setmode(none);
+            // if_close;
+            // p_delay(1);
+            // npc_facesquare(.npc_coord);
+            // .npc_facesquare(npc_coord);
+            // npc_say("Hey... I've got someone here with a warrant from Bravek, what should we do?");
+            // p_delay(2);
+            // .npc_say("Well you can't let them in...");
             ~open_and_close_door_fast(loc_2536, true, door_open);;
             ~mesbox("You wait until the mourner's back is turned and sneak into the building.");
-            npc_setmode(null); .npc_setmode(null);
+            npc_setmode(null);
+            // .npc_setmode(null);
         } else if (npc_find(coord, mournertwb, 14, 0) = true) {
             ~mesbox("The door won't open.|You notice a black cross on the door.");
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");

--- a/scripts/quests/quest_elena/scripts/doors.rs2
+++ b/scripts/quests/quest_elena/scripts/doors.rs2
@@ -1,6 +1,10 @@
 [oploc1,rehnisondoorshut] @rehnissons_enter_house;
-[oploc1,loc_2534] @west_ardougne_plague_house_doors;
-[oploc1,loc_2535] mes("This door is locked."); // todo probs not right but yolo in 225 seems only 1 door is the correct one.
+
+// Should be the west door per old RuneHQ and Zybez
+// https://web.archive.org/web/20040423204649/http://www.runehq.com/viewquest.php?id=00155
+// https://web.archive.org/web/20060220020506/http://www.zybez.net/quests.php?id=38 (See Picture)
+[oploc1,loc_2534] mes("This door is locked."); // todo probs not right but yolo in 225 seems only 1 door is the correct one.
+[oploc1,loc_2535] @west_ardougne_plague_house_doors;
 
 [label,west_ardougne_plague_house_doors]
 if (~check_axis(coord, loc_coord, loc_angle) = false) {

--- a/scripts/quests/quest_elena/scripts/doors.rs2
+++ b/scripts/quests/quest_elena/scripts/doors.rs2
@@ -19,13 +19,33 @@ switch_int(%elenaquest) {
             @multi3("But I think a kidnap victim is in here.", plague_house_but_i_think_a_kidnap_victim_is_in_here, "I fear not a mere plague.", plague_house_i_fear_not_a_mere_plague, "Thanks for the warning.", plague_house_thanks_for_the_warning);
         }
     case ^quest_elena_spoke_cured_bravek :
+        // Based on 2023 OSRS because some dialogue was missing about "sneaking into the building" on Apr 2004 RuneHQ
+        // https://web.archive.org/web/20040423204649/http://www.runehq.com/viewquest.php?id=00155
+        // https://www.youtube.com/watch?v=CCoUF_hIbU0
+        ~mesbox("The door won't open.|You notice a black cross on the door.");
         if (inv_total(inv, warrant) > 0 & npc_find(coord, mournertwb, 14, 0) = true) {
+            .npc_findall(npc_coord, mournertwb, 14, 0);
+            if (.npc_findnext = false) return;
+            def_int $tries = 0;// precautionary
+            while (.npc_uid = npc_uid & $tries < 30) {
+                .npc_findnext;
+                $tries = add($tries, 1);
+            }            
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");
             ~chatplayer("<p,neutral>I have a warrant from <nc_name(bravek)> to enter here.");
+            ~chatnpc("<p,neutral>This is highly irregular. Please wait...");
+            npc_setmode(null);
             if_close;
+            p_delay(0);
+            npc_facesquare(.npc_coord);
+            .npc_facesquare(npc_coord);
+            npc_say("Hey... I've got someone here with a warrant from Bravek, what shoud we do?");
+            p_delay(0);
+            .npc_say("Well you can't let them in...");
+            p_delay(0);
             ~open_and_close_door2(loc_2536, ~check_axis(coord, loc_coord, loc_angle), door_open);;
+            ~mesbox("You wait until the mourner's back is turned and sneak into the building.");
         } else if (npc_find(coord, mournertwb, 14, 0) = true) {
-            ~mesbox("The door won't open.|You notice a black cross on the door.");
             ~chatnpcrange("<p,neutral>I'd stand away from there. That black cross means that house has been touched by the plague.");
         }
     case ^quest_elena_freed_elena, ^elena_complete, ^elena_complete_read_scroll : ~open_and_close_door2(loc_2536, ~check_axis(coord, loc_coord, loc_angle), door_open);;


### PR DESCRIPTION
**For 225+**

- Swap the east & west doors for the plague house in west ardougne
- Use `~open_and_close_door_fast` proc and remove `~open_plague_door` (also moved proc to `open_and_close_doors.rs2`)
- Added some additional dialogue when opening the door with a warrant source of 04 runehq missing dialogue, so matched a video from 2023 OSRS pretty well
- Added and tested cutscene for feb 06 rework, but commented it out