### PR TITLE
fix: Add cooking gauntlet successchance for swordfish

### DIFF
--- a/scripts/skill_cooking/configs/cooking_source/cooking_generic.dbrow
+++ b/scripts/skill_cooking/configs/cooking_source/cooking_generic.dbrow
@@ -340,6 +340,7 @@ data=levelrequired,45
 data=experience,1400
 data=successchance,18,292
 data=successchance_range,30,310
+data=successchance_gauntlets,30,310
 
 [cooking_generic_lobster]
 table=cooking_generic


### PR DESCRIPTION
For 225+

Same rate as range without gauntlets. This means cooking on a fire with gauntlets will now match range rate. This matches osrs.