### PR TITLE
fix: gnome baller npc_changetype mistimings

### DIFF
--- a/scripts/minigames/game_gnomeball/scripts/gnome_baller.rs2
+++ b/scripts/minigames/game_gnomeball/scripts/gnome_baller.rs2
@@ -17,8 +17,9 @@ if (p_finduid(uid) = true) {
 
 [proc,npc_gnomeball_tackle_fail]
 npc_anim(midget_human_tackle_fail, 0);
-npc_changetype_keepall(npc_param(gnome_fallen), 7);
+npc_changetype_keepall(npc_param(gnome_fallen), ^max_32bit_int);
 npc_delay(5);
+npc_changetype_keepall(npc_param(gnome_original), ^max_32bit_int);
 npc_anim(midget_human_tackle_fail_getup, 0);
 %npc_attacking_uid = null;
 
@@ -87,8 +88,9 @@ npc_delay(0);
 anim(human_gnome_tackle, 33);
 npc_anim(midget_tackled, 30);
 p_delay(0);
-npc_changetype_keepall(npc_param(gnome_tackled), 11);
+npc_changetype_keepall(npc_param(gnome_tackled), ^max_32bit_int);
 npc_delay(10);
+npc_changetype_keepall(npc_param(gnome_original), ^max_32bit_int);
 npc_anim(midget_getup, 0);
 %npc_attacking_uid = null;
 
@@ -127,7 +129,8 @@ npc_anim(midget_tackled, 30);
 p_delay(0);
 inv_setslot(worn, ^wearpos_rhand, ball_gnomeball_game, 1);
 ~update_all(null);
-npc_changetype_keepall(npc_param(gnome_tackled), 11);
+npc_changetype_keepall(npc_param(gnome_tackled), ^max_32bit_int);
 npc_delay(10);
+npc_changetype_keepall(npc_param(gnome_original), ^max_32bit_int);
 npc_anim(midget_getup, 0);
 %npc_attacking_uid = null;


### PR DESCRIPTION
for 225-274

Npc's reverting type will be paused during delays. Gnome ballers relied on reverting type to match up with the delay length. The reason why this is broken now is because of this engine change https://github.com/2004Scape/Server/pull/1712 (10 months ago ?!)

Seems like gnomeball is the only thing affected by this change

Todo: `npc_changetype_keepall(..., ^max_32bit_int);` subjected to change to -> `npc_changetype_keepall(..., 0);` at some point