### PR TITLE
feat: gnomeball rework

### DIFF
--- a/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
+++ b/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
@@ -1,4 +1,15 @@
+[applayer1,_]
+if (~inzone_coord_pair_table(gnomeball_zones, coord) = true) {
+    @pvp_gnomeball_pass;
+    return;
+}
+p_aprange(0);
+
 [opplayer1,_]
+if (~inzone_coord_pair_table(gnomeball_zones, coord) = true) {
+    @pvp_gnomeball_pass;
+    return;
+}
 if (.busy = true) {
     mes("Other player is busy at the moment."); // https://youtu.be/YkJQDvB14-U?t=26
     return;

--- a/scripts/minigames/game_gnomeball/scripts/gnome_baller.rs2
+++ b/scripts/minigames/game_gnomeball/scripts/gnome_baller.rs2
@@ -41,16 +41,6 @@ npc_sethuntmode(null); // none
 [opnpc1,gnomeballer_red] @player_gnomeball_tackle(30, 200);
 [opnpc1,gnomeballer_orange] @player_gnomeball_tackle(30, 200);
 [opnpc1,gnomeballer_yellow] @player_gnomeball_tackle(30, 220);
-// [opnpct,gnomeball:com_5] 
-// switch_npc (npc_type) {
-//     case gnomeballer_red, gnomeballer_orange : @player_gnomeball_tackle(30, 200);
-//     case gnomeballer_yellow : @player_gnomeball_tackle(30, 220);
-//     case gnomeballer_red_withball, gnomeballer_orange_withball, gnomeballer_yellow_withball : @player_gnomeball_tackle_carrier;
-//     case default : mes("You can only tackle gnome ballers."); // complete guess
-// }
-
-// [opplayert,gnomeball:com_5] 
-// mes("You can only tackle gnome ballers."); // complete guess
 
 [label,player_gnomeball_tackle](int $low, int $high)
 if (inv_getobj(worn, ^wearpos_rhand) = ball_gnomeball_game) {

--- a/scripts/minigames/game_gnomeball/scripts/gnome_winger.rs2
+++ b/scripts/minigames/game_gnomeball/scripts/gnome_winger.rs2
@@ -1,5 +1,4 @@
-[opnpc1,gnomeballer_green]
-mes("The gnome is not interested in chatting."); // osrs
+[apnpc1,gnomeballer_green] @player_gnomeball_pass;
 [opnpc1,gnomeballer_green_withball]
 mes("The gnome is not interested in chatting."); // osrs
 
@@ -7,6 +6,10 @@ mes("The gnome is not interested in chatting."); // osrs
 // [apnpct,gnomeball:com_7] @player_gnomeball_pass;
 
 [label,player_gnomeball_pass]
+if (~inzone_coord_pair_table(gnomeball_zones, coord) = false) {
+    mes("You cannot pass to a player from off the pitch."); // osrs
+    return;
+}
 if (inv_getobj(worn, ^wearpos_rhand) ! ball_gnomeball_game) {
     mes("You need a ball in your hand to throw."); // osrs
     return;

--- a/scripts/minigames/game_gnomeball/scripts/gnome_winger.rs2
+++ b/scripts/minigames/game_gnomeball/scripts/gnome_winger.rs2
@@ -2,9 +2,6 @@
 [opnpc1,gnomeballer_green_withball]
 mes("The gnome is not interested in chatting."); // osrs
 
-// [opnpct,gnomeball:com_7] @player_gnomeball_pass;
-// [apnpct,gnomeball:com_7] @player_gnomeball_pass;
-
 [label,player_gnomeball_pass]
 if (~inzone_coord_pair_table(gnomeball_zones, coord) = false) {
     mes("You cannot pass to a player from off the pitch."); // osrs

--- a/scripts/minigames/game_gnomeball/scripts/gnomeball.rs2
+++ b/scripts/minigames/game_gnomeball/scripts/gnomeball.rs2
@@ -37,7 +37,7 @@ if ($exiting = false) {
         inv_del(inv, ball_gnomeball_game, inv_total(inv, ball_gnomeball_game));
         %gnomeball_owedball = ^true;
     }
-    // if_settab(gnomeball, 0);
+    set_player_op("Pass", 1, ^true);
 } else {
     ~open_and_close_door(loc_param(next_loc_stage), $exiting, false);
     if (%gnomeball_owedball = ^true) {
@@ -71,6 +71,7 @@ if (inv_getobj(worn, ^wearpos_rhand) = ball_gnomeball_game) {
     inv_delslot(worn, ^wearpos_rhand);
 }
 ~initalltabs;
+set_player_op(null, 1, ^false);
 %gnomeball_owedball = ^false;
 %score_gnomeball_game = 0;
 npc_findallany(^gnomeball_centre_coord, 14, ^vis_off);

--- a/scripts/minigames/game_gnomeball/scripts/gnomeball_pass.rs2
+++ b/scripts/minigames/game_gnomeball/scripts/gnomeball_pass.rs2
@@ -6,14 +6,6 @@
 [label,pvp_gnomeball_pass]
 def_boolean $player1_ingame = ~inzone_coord_pair_table(gnomeball_zones, coord);
 def_boolean $player2_ingame = ~.inzone_coord_pair_table(gnomeball_zones, .coord);
-if (inv_total(worn, ball_gnomeball_game) < 1 & $player1_ingame = true) {
-    mes("You need a ball in your hand to throw.");
-    return;
-}
-if (inv_getobj(worn, ^wearpos_rhand) ! null & $player1_ingame = false) {
-    mes("You need your right hand free to pass a ball."); // osrs
-    return;
-}
 // https://oldschool.runescape.wiki/w/Update:Patch_Notes_(3_October_2013)
 // if close early: "Players can no longer use a gnomeball to interrupt other players' Make-X actions without the gnomeball being thrown."
 .if_close;
@@ -23,6 +15,14 @@ if (.p_finduid(.uid) = false) {
 }
 if ($player1_ingame = true & $player2_ingame = false) {
     mes("<.displayname> is not playing gnomeball.");
+    return;
+}
+if (inv_total(worn, ball_gnomeball_game) < 1 & $player1_ingame = true) {
+    mes("You need a ball in your hand to throw.");
+    return;
+}
+if (inv_getobj(worn, ^wearpos_rhand) ! null & $player1_ingame = false) {
+    mes("You need your right hand free to pass a ball."); // osrs
     return;
 }
 if ($player1_ingame = false & $player2_ingame = true) {

--- a/scripts/minigames/game_gnomeball/scripts/gnomeball_pass.rs2
+++ b/scripts/minigames/game_gnomeball/scripts/gnomeball_pass.rs2
@@ -1,7 +1,5 @@
 [opplayeru,ball_gnomeball_game] @pvp_gnomeball_pass;
 [applayeru,ball_gnomeball_game] @pvp_gnomeball_pass;
-// [opplayert,gnomeball:com_7] @pvp_gnomeball_pass;
-// [applayert,gnomeball:com_7] @pvp_gnomeball_pass;
 
 [label,pvp_gnomeball_pass]
 def_boolean $player1_ingame = ~inzone_coord_pair_table(gnomeball_zones, coord);

--- a/scripts/minigames/game_gnomeball/scripts/gnomeball_shoot.rs2
+++ b/scripts/minigames/game_gnomeball/scripts/gnomeball_shoot.rs2
@@ -1,15 +1,6 @@
-// [if_button,gnomeball:com_6]
-// if_close;
-// if (p_finduid(uid) = true) {
-//     if (loc_find(^gnomeball_goal_coord, goal_gnomeball_game) = true) {
-//         @gnomeball_shoot;
-//     }
-// }
+[aploc1,goal_gnomeball_game] @gnomeball_shoot;
 
 [label,gnomeball_shoot]
-if (lineofsight(coord, loc_coord) = false) {
-    return;
-}
 if (~inzone_coord_pair_table(gnomeball_zones, coord) = false) {
     mes("You may only score while on the pitch.");
     return;
@@ -22,12 +13,7 @@ if (coordx(coord) >= coordx(loc_coord)) {
     mes("You must be in front of the goal.");
     return;
 }
-if (distance(loc_coord, coord) > 10) {
-    mes("The goal is too far away from here."); // complete guess
-    return;
-}
 // pos: 2404 3488
-p_stopaction; // doesnt do this in osrs but its an aploc interaction so maybe they removed this?
 // https://youtu.be/LWfcA_C2bJY?si=1xvGzgrQ53VgBsAx&t=50
 mes("You throw the ball at the goal.");
 cam_moveto(movecoord(loc_coord, 3, 0, 0), 300, 100, 100);
@@ -43,7 +29,11 @@ inv_delslot(worn, ^wearpos_rhand);
 ~update_all(ball_gnomeball_game);
 p_delay(divide($duration, 30));
 if ($land_coord = loc_coord) {
-    mes("and score!"); // aug 2004, https://youtu.be/LWfcA_C2bJY?si=1xvGzgrQ53VgBsAx&t=50
+    // aug 2004, https://youtu.be/LWfcA_C2bJY?si=1xvGzgrQ53VgBsAx&t=50
+    // june 2006, https://youtu.be/1ITDFFB7aiI?t=158
+    // - probably changed during the gnomeball rework
+    mes("... and score!");
+    
     %score_gnomeball_game = min(add(max(%score_gnomeball_game, 0), 1), 5);
     if (%score_gnomeball_game = 5) {
         mes("You win!");
@@ -64,7 +54,7 @@ if ($land_coord = loc_coord) {
         npc_say("GOAL");
     }  
 } else {
-    mes("and miss."); // guess based off score mes
+    mes("... and miss."); // https://youtu.be/1ITDFFB7aiI?t=441
 }
 p_delay(3);
 // cam_lookat(movecoord(loc_coord, -68, 0, -40), 0, 0, 0);


### PR DESCRIPTION
for 274

- From https://oldschool.runescape.wiki/w/Update:Morytania_Expansion:
`Gnomeball has been given a much needed polish. We have gotten rid of the old interface and replaced it with a much more intuitive system. Now you can shoot by just clicking the goal net, pass by clicking on another player or gnomeballer, and tackle is now an option on other gnomeballers too.`

- [fix: gnomeball player pass mes order](https://github.com/LostCityRS/Content/commit/1710e01aecdf10eab493709146ee3fe382ade552) needs to be applied for 225-274