### PR TITLE
fix: chaos druid drop table

### DIFF
--- a/scripts/drop tables/scripts/chaos_druid.rs2
+++ b/scripts/drop tables/scripts/chaos_druid.rs2
@@ -40,8 +40,10 @@ if ($random < 7)  {
     obj_add(npc_coord, bronze_longsword, 1, ^lootdrop_duration);
 } else if ($random < 89) {
     obj_add(npc_coord, snape_grass, 1, ^lootdrop_duration);
-} else if ($random < 90 & %itgronigen >= ^itgronigen_complete) {
-    obj_add(npc_coord, unholy_symbol_mould, 1, ^lootdrop_duration);
+} else if ($random < 90) {
+    if (%itgronigen >= ^itgronigen_complete) {
+        obj_add(npc_coord, unholy_symbol_mould, 1, ^lootdrop_duration);
+    }
 } else if ($random < 91) {
     obj_add(npc_coord, ~randomjewel, ^lootdrop_duration);
 }


### PR DESCRIPTION
For 225+

If Observatory quest is not complete, drop nothing when `unholy_symbol_mould` is rolled instead of an additional `~randomjewel`