### PR TITLE
chore: 377 - Remove a unreferenced syntactically off proc. Re-instate lumbridge cook treasure trail step. Change erroneous pass by value labels in dialogue. Fixed wilderness obelisks

### DIFF
--- a/scripts/_unpack/377/all.npc
+++ b/scripts/_unpack/377/all.npc
@@ -3225,6 +3225,7 @@ param=death_sound,giant_death
 param=death_drop,big_bones
 huntmode=cowardly
 huntrange=2
+param=slayer_category,^slayer_mossgiant
 
 [jogre]
 name=Jogre
@@ -37065,6 +37066,7 @@ param=death_sound,giant_death
 param=death_drop,big_bones
 huntmode=cowardly
 huntrange=2
+param=slayer_category,^slayer_mossgiant
 
 [mossgiant3]
 name=Moss giant
@@ -37106,6 +37108,7 @@ param=death_sound,giant_death
 param=death_drop,big_bones
 huntmode=cowardly
 huntrange=2
+param=slayer_category,^slayer_mossgiant
 
 [dog_wild]
 name=Wild dog

--- a/scripts/_unpack/377/all.varp
+++ b/scripts/_unpack/377/all.varp
@@ -912,9 +912,11 @@ transmit=yes
 
 [varp_511]
 transmit=yes
+scope=perm
 
 [varp_512]
 transmit=yes
+scope=perm
 
 [varp_513]
 scope=perm

--- a/scripts/areas/area_lumbridge/scripts/cook.rs2
+++ b/scripts/areas/area_lumbridge/scripts/cook.rs2
@@ -1,9 +1,8 @@
 [opnpc1,cook]
 // https://www.youtube.com/watch?v=mtPhS3n2dAo
-/*if(map_members = ^true &inv_total(inv, trail_clue_medium_anagram002) > 0) {
+if(map_members = ^true &inv_total(inv, trail_clue_medium_anagram002) > 0) {
     @trail_cook;
-}*/
-// TODO enable when treasure trails is ported
+}
 
 if(%cookquest = 0) {
     ~chatnpc("<p,sad>What am I to do?");
@@ -31,12 +30,11 @@ if(%cookquest = 0) {
 
 }
 
-/*[label,trail_cook]
+[label,trail_cook]
 if(inv_total(inv, trail_clue_medium_anagram002_challenge) > 0) {
     @trail_challengenpc_prompt("<p,neutral>Please tell me how many cannons there are.", "<p,happy>Cheers!", "<p,angry>Hmm, I don't think that's right.",
     "The cook has given you another clue scroll!", trail_clue_medium_anagram002, trail_clue_medium_anagram002_challenge);
 }
 ~chatnpc("<p,confused>I've always wondered how many cannons the castle has. Could you find out for me?");
 inv_add(inv, trail_clue_medium_anagram002_challenge, 1);
-~objbox(trail_clue_medium_anagram002_challenge, "The cook has given you a challenge scroll!", 250, 0, 0);*/
-// TODO enable when treasure trails is ported
+~objbox(trail_clue_medium_anagram002_challenge, "The cook has given you a challenge scroll!", 250, 0, 0);

--- a/scripts/areas/area_wilderness/scripts/obelisks.rs2
+++ b/scripts/areas/area_wilderness/scripts/obelisks.rs2
@@ -19,9 +19,6 @@ while (loc_findnext = true & $locsChanged < 4) {
         $locsChanged = calc($locsChanged + 1);
     }
 }
-//world_delay(5); //doesn't work with the p_ scripts required until the engine lets you get players in an area
-//get all players within 3 squares of the center
-//teleport them to a random obelisk
 switch_int(random(6))
 {
     case 0 : $destination = ^obelisk_one;
@@ -32,24 +29,18 @@ switch_int(random(6))
     case 5 : $destination = ^obelisk_six;
 }
 
-//player_findallzone doesn't actually work, so for now this is using player only
-// player_findallzone($center_coord);
-// while (player_findnext = true & $locsChanged < 4) {
-//     if(distance(coord, $center_coord) <= 2) {
-//         anim(teleport_other_casting, 0);
-//         anim(human_castteleport, 0);
-//         spotanim_pl(teleport_other_impact, 92, 0);
-//         p_delay(2);
-//         p_telejump($destination);
-//         anim(null, 0);
-//     }
-// }
+world_delay(5);
+huntall($center_coord, 2, 0);
+while (huntnext = true) {
+    if (finduid(uid) = true) {
+        queue*(wilderness_obelisk_teleport_after_timer, 0)(map_findsquare($destination, 0, 2, ^map_findsquare_lineofwalk));
+    }
+}
 
+[queue,wilderness_obelisk_teleport_after_timer](coord $destination)
 anim(teleport_other_casting, 0);
 anim(human_castteleport, 0);
 spotanim_pl(teleport_other_impact, 92, 0);
 p_delay(2);
 p_telejump($destination);
-
 anim(null, 0);
-

--- a/scripts/areas/area_wizard_tower/scripts/sedridor.rs2
+++ b/scripts/areas/area_wizard_tower/scripts/sedridor.rs2
@@ -2,7 +2,7 @@
 ~chatnpc("<p,neutral>Welcome adventurer, to the world renowned|Wizards' Tower. How may I help you?");
 // we don't support teleporting until the quest is complete
 if(%runemysteries = ^runemysteries_not_started) {
-    @multi2("Nothing thanks, I'm just looking around.", @head_wizard_nothing, "What are you doing down here?", @head_wizard_2);
+    @multi2("Nothing thanks, I'm just looking around.", head_wizard_nothing, "What are you doing down here?", head_wizard_2);
 } else if(%runemysteries = ^runemysteries_started) {
     @rune_mysteries;
 } else if(%runemysteries = ^runemysteries_given_talisman) {

--- a/scripts/areas/area_wizard_tower/scripts/sedridor.rs2
+++ b/scripts/areas/area_wizard_tower/scripts/sedridor.rs2
@@ -2,7 +2,7 @@
 ~chatnpc("<p,neutral>Welcome adventurer, to the world renowned|Wizards' Tower. How may I help you?");
 // we don't support teleporting until the quest is complete
 if(%runemysteries = ^runemysteries_not_started) {
-    @multi2("Nothing thanks, I'm just looking around.", head_wizard_nothing, "What are you doing down here?", head_wizard_2);
+    @multi2("Nothing thanks, I'm just looking around.", @head_wizard_nothing, "What are you doing down here?", @head_wizard_2);
 } else if(%runemysteries = ^runemysteries_started) {
     @rune_mysteries;
 } else if(%runemysteries = ^runemysteries_given_talisman) {

--- a/scripts/drop_tables/scripts/moss_giant.rs2
+++ b/scripts/drop_tables/scripts/moss_giant.rs2
@@ -1,4 +1,8 @@
-[ai_queue3,mossgiant]
+[ai_queue3,mossgiant] @moss_giant_death;
+[ai_queue3,mossgiant2] @moss_giant_death;
+[ai_queue3,mossgiant3] @moss_giant_death;
+
+[label,moss_giant_death]
 gosub(npc_death);
 if (npc_findhero = ^false) {
     return;

--- a/scripts/general/scripts/enchanted_jewellry/necklace_of_minigames.rs2
+++ b/scripts/general/scripts/enchanted_jewellry/necklace_of_minigames.rs2
@@ -1,0 +1,29 @@
+[opheld4,_necklace_of_minigames]
+// https://youtu.be/sB2oqPgruaM?si=7EKqWR-U07U1ncoR&t=272
+mes("You rub the necklace...");
+def_obj $item = last_item;
+def_int $slot = last_slot;
+p_delay(1);
+def_int $choice = ~p_choice2_header("Burthorpe Games Rooms.", 1, "Nowhere.", 2, "Where would you like to teleport to?");
+if($choice = 2) {
+    mes("You remain where you were.");
+    return;
+}
+if (~wilderness_level(coord) > 20) {
+    // yes it actually says this in osrs
+    mes("A mysterious force blocks your teleport spell!");
+    mes("You can't use this teleport after level 20 wilderness.");
+    return;
+}
+if (~pre_tele_checks(coord) = false) {
+    return;
+}
+~player_teleport_normal(map_findsquare(0_34_77_31_12, 0, 2, ^map_findsquare_lineofwalk));
+def_namedobj $new_necklace = oc_param($item, next_obj_stage);
+if ($new_necklace = null) {
+    inv_delslot(inv, $slot);
+    mes("Your Games Necklace crumbles to dust.");
+} else {
+    inv_setslot(inv, $slot, $new_necklace, 1);
+    mes("Your Games Necklace has <~pluralise(oc_param($new_necklace, charges), "use")> left.");
+}

--- a/scripts/npc/configs/dragons.npc
+++ b/scripts/npc/configs/dragons.npc
@@ -31,6 +31,7 @@ param=death_sound,dragon_death
 maxrange=7
 huntmode=elvarg_hunt
 huntrange=7
+attackrange=1
 
 [king_dragon]
 name=King black dragon
@@ -114,6 +115,7 @@ param=death_drop,dragon_bones
 param=slayer_category,^slayer_greendragon
 huntmode=cowardly
 huntrange=4
+attackrange=1
 
 [red_dragon]
 name=Red dragon
@@ -150,6 +152,7 @@ param=death_drop,dragon_bones
 param=slayer_category,^slayer_reddragon
 huntmode=cowardly
 huntrange=4
+attackrange=1
 
 [black_dragon]
 name=Black dragon
@@ -186,6 +189,7 @@ param=death_drop,dragon_bones
 param=slayer_category,^slayer_blackdragon
 huntmode=cowardly
 huntrange=4
+attackrange=1
 
 [blue_dragon]
 name=Blue dragon
@@ -222,6 +226,7 @@ param=death_drop,dragon_bones
 param=slayer_category,^slayer_bluedragon
 huntmode=cowardly
 huntrange=4
+attackrange=1
 
 [babydragon]
 name=Baby dragon
@@ -254,6 +259,7 @@ param=death_sound,babydragon_death
 param=death_drop,babydragon_bones
 huntmode=cowardly
 huntrange=2
+attackrange=1
 
 [babybluedragon]
 name=Baby blue dragon
@@ -295,6 +301,7 @@ param=death_drop,babydragon_bones
 param=slayer_category,^slayer_bluedragon
 huntmode=cowardly
 huntrange=2
+attackrange=1
 
 [babyreddragon]
 name=Baby red dragon

--- a/scripts/player/configs/player.inv
+++ b/scripts/player/configs/player.inv
@@ -8,6 +8,7 @@ runweight=yes
 scope=perm
 size=14
 protect=no
+runweight=yes
 
 [tradeoffer]
 size=28

--- a/scripts/player/scripts/appearance.rs2
+++ b/scripts/player/scripts/appearance.rs2
@@ -113,7 +113,7 @@ if (p_finduid(uid) = true) {
 ~update_bas; // update appearance
 ~update_bonuses; // update bonuses if
 ~update_weight; // update weight
-if (%tutorial_progress > ^newbie_combat_instructor_unequipping_items) {
+if (%tutorial > ^newbie_combat_instructor_unequipping_items) {
 ~update_weapon_category($previous_weapon); // the attack tab weapon category
 }
 ~player_combat_stat; // update combat varps

--- a/scripts/player/scripts/appearance.rs2
+++ b/scripts/player/scripts/appearance.rs2
@@ -113,9 +113,9 @@ if (p_finduid(uid) = true) {
 ~update_bas; // update appearance
 ~update_bonuses; // update bonuses if
 ~update_weight; // update weight
-// if (%tutorial_progress > ^newbie_combat_instructor_unequipping_items) { re-enable later
+if (%tutorial_progress > ^newbie_combat_instructor_unequipping_items) {
 ~update_weapon_category($previous_weapon); // the attack tab weapon category
-// }
+}
 ~player_combat_stat; // update combat varps
 
 [proc,.update_all](obj $previous_weapon)

--- a/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
+++ b/scripts/quests/quest_chompybird/scripts/raw_chompy.rs2
@@ -11,7 +11,7 @@ switch_obj (last_useitem)
 // message taken from OSRS
 ~mesbox("You can only add ingredients when you're cooking a chompy bird. Ensure you have the seasonings you want to use in your inventory when cooking the chompy bird and you will use them automatically when cooking.");
 
-[oplocu,chompybird_spitroast_empty]
+[oplocu,multi_chompybird_spitroast_entity]
 if (stat(cooking) < 30) { // before obj check
     mes("You need a cooking level of 30 to use the spit roast.");
     return;

--- a/scripts/quests/quest_death/scripts/quest_death.rs2
+++ b/scripts/quests/quest_death/scripts/quest_death.rs2
@@ -173,9 +173,6 @@ if(add($val, ~death_get_haroldgold) >= 10000) {
     %death_bits = setbit_range_toint(%death_bits, $val, ^harold_money_lower, ^harold_money_upper);
 }
 
-[proc,death_clear_dicegame]()(int)
-clearbit_range(%death_bits, ^death_haroldroll_lower, ^death_goldclaimed);
-
 [proc,death_get_map]()(int)
 return (getbit_range(%death_map, ^death_map_lower, ^death_map_upper));
 

--- a/scripts/quests/quest_ikov/scripts/ikov_dungeon.rs2
+++ b/scripts/quests/quest_ikov/scripts/ikov_dungeon.rs2
@@ -33,6 +33,10 @@ if($entering = false | testbit(%ikov_dungeon, ^ikov_lever) = ^true) {
 }
 ~mesbox("The door won't open!");
 
+[mapzone,0_41_153]
+settimer(move_ikovtrigger, 1);
+@music_playbyregion(coord);
+
 [mapzoneexit,0_41_153] 
 cleartimer(move_ikovtrigger);
 %ikov_dungeon = clearbit(%ikov_dungeon, ^ikov_bridge);

--- a/scripts/quests/quest_waterfall/scripts/hadley.rs2
+++ b/scripts/quests/quest_waterfall/scripts/hadley.rs2
@@ -11,7 +11,7 @@ switch_int (%waterfall_quest) {
         ~chatnpc("<p,neutral>People come from miles around to fish in the clear lakes or to wander the beautiful hill sides");
         ~chatplayer("<p,neutral>It is quite pretty.");
         ~chatnpc("<p,neutral>Surely pretty is an understatement kind <text_gender("Sir", "Lady")>. Beautiful, amazing or possibly life-changing would be more suitable wording. Have you seen the Baxtorian Waterfall? Named after the elf king who was buried beneath.");
-        @multi4("What happened to the elf king?", waterfall_hadley_elf_king, "Where else is worth visiting around here?", waterfall_hadley_worth_visiting,  "I don't like nature, it gives me a rash!", @waterfall_hadley_nature, "Thanks then, goodbye.", waterfall_hadley_bye);
+        @multi4("What happened to the elf king?", waterfall_hadley_elf_king, "Where else is worth visiting around here?", waterfall_hadley_worth_visiting,  "I don't like nature, it gives me a rash!", waterfall_hadley_nature, "Thanks then, goodbye.", waterfall_hadley_bye);
     case default :
         ~chatnpc("<p,neutral>Are you on holiday? If so you've come to the right place. I'm Hadley the tourist guide, anything you need to know just ask me. We have some of the most unspoilt wildlife and scenery in RuneScape.");
         ~chatnpc("<p,neutral>People come from miles around to fish in the clear lakes or to wander the beautiful hill sides");

--- a/scripts/quests/quest_waterfall/scripts/hadley.rs2
+++ b/scripts/quests/quest_waterfall/scripts/hadley.rs2
@@ -11,7 +11,7 @@ switch_int (%waterfall_quest) {
         ~chatnpc("<p,neutral>People come from miles around to fish in the clear lakes or to wander the beautiful hill sides");
         ~chatplayer("<p,neutral>It is quite pretty.");
         ~chatnpc("<p,neutral>Surely pretty is an understatement kind <text_gender("Sir", "Lady")>. Beautiful, amazing or possibly life-changing would be more suitable wording. Have you seen the Baxtorian Waterfall? Named after the elf king who was buried beneath.");
-        @multi4("What happened to the elf king?", waterfall_hadley_elf_king, "Where else is worth visiting around here?", waterfall_hadley_worth_visiting,  "I don't like nature, it gives me a rash!", waterfall_hadley_nature, "Thanks then, goodbye.", waterfall_hadley_bye);
+        @multi4("What happened to the elf king?", waterfall_hadley_elf_king, "Where else is worth visiting around here?", waterfall_hadley_worth_visiting,  "I don't like nature, it gives me a rash!", @waterfall_hadley_nature, "Thanks then, goodbye.", waterfall_hadley_bye);
     case default :
         ~chatnpc("<p,neutral>Are you on holiday? If so you've come to the right place. I'm Hadley the tourist guide, anything you need to know just ask me. We have some of the most unspoilt wildlife and scenery in RuneScape.");
         ~chatnpc("<p,neutral>People come from miles around to fish in the clear lakes or to wander the beautiful hill sides");

--- a/scripts/skill_combat/configs/magic/magic_combat_spells.dbrow
+++ b/scripts/skill_combat/configs/magic/magic_combat_spells.dbrow
@@ -102,8 +102,8 @@ data=anim,human_caststrike
 data=spotanim_origin,waterbolt_casting
 data=spotanim_proj,waterbolt_travel,43,31,51,16,-5,64,10
 data=spotanim_target,waterbolt_impact,124
-data=sound_success,water_bolt_all
-data=sound_fail,water_bolt_fail
+data=sound_cast,waterbolt_cast_and_fire
+data=sound_hit,waterbolt_hit
 data=continue_by_autocast,true
 
 [magic_spell_earth_bolt]
@@ -120,8 +120,8 @@ data=anim,human_caststrike
 data=spotanim_origin,earthbolt_casting
 data=spotanim_proj,earthbolt_travel,43,31,51,16,-5,64,10
 data=spotanim_target,earthbolt_impact,124
-data=sound_success,earth_bolt_all
-data=sound_fail,earth_bolt_fail
+data=sound_cast,earthbolt_cast_and_fire
+data=sound_hit,earthbolt_hit
 data=continue_by_autocast,true
 
 [magic_spell_fire_bolt]
@@ -138,8 +138,8 @@ data=anim,human_caststrike
 data=spotanim_origin,firebolt_casting
 data=spotanim_proj,firebolt_travel,43,31,51,16,-5,64,10
 data=spotanim_target,firebolt_impact,124
-data=sound_success,fire_bolt_all
-data=sound_fail,fire_bolt_fail
+data=sound_cast,firebolt_cast_and_fire
+data=sound_hit,firebolt_hit
 data=continue_by_autocast,true
 
 [magic_spell_wind_blast]
@@ -156,8 +156,8 @@ data=anim,human_caststrike
 data=spotanim_origin,windblast_casting
 data=spotanim_proj,windblast_travel,43,31,51,16,-5,64,10
 data=spotanim_target,windblast_impact,124
-data=sound_success,wind_blast_all
-data=sound_fail,wind_blast_fail
+data=sound_cast,windblast_cast_and_fire
+data=sound_hit,windblast_hit
 data=continue_by_autocast,true
 
 [magic_spell_water_blast]
@@ -174,8 +174,8 @@ data=anim,human_caststrike
 data=spotanim_origin,waterblast_casting
 data=spotanim_proj,waterblast_travel,43,31,51,16,-5,64,10
 data=spotanim_target,waterblast_impact,124
-data=sound_success,water_blast_all
-data=sound_fail,water_blast_fail
+data=sound_cast,waterblast_cast_and_fire
+data=sound_hit,waterblast_hit
 data=continue_by_autocast,true
 
 [magic_spell_earth_blast]
@@ -192,8 +192,8 @@ data=anim,human_caststrike
 data=spotanim_origin,earthblast_casting
 data=spotanim_proj,earthblast_travel,43,31,51,16,-5,64,10
 data=spotanim_target,earthblast_impact,124
-data=sound_success,earth_blast_all
-data=sound_fail,earth_blast_fail
+data=sound_cast,earthblast_cast_and_fire
+data=sound_hit,earthblast_hit
 data=continue_by_autocast,true
 
 [magic_spell_fire_blast]
@@ -228,8 +228,8 @@ data=anim,human_castwave
 data=spotanim_origin,windwave_casting
 data=spotanim_proj,windwave_travel,43,31,51,16,-5,64,10
 data=spotanim_target,windwave_impact,124
-data=sound_success,wind_wave_all
-data=sound_fail,wind_wave_fail
+data=sound_cast,windwave_cast_and_fire
+data=sound_hit,windwave_hit
 data=continue_by_autocast,true
 
 [magic_spell_water_wave]
@@ -246,8 +246,8 @@ data=anim,human_castwave
 data=spotanim_origin,waterwave_casting
 data=spotanim_proj,waterwave_travel,43,31,51,16,-5,64,10
 data=spotanim_target,waterwave_impact,124
-data=sound_success,water_wave_all
-data=sound_fail,water_wave_fail
+data=sound_cast,waterwave_cast_and_fire
+data=sound_hit,waterwave_hit
 data=continue_by_autocast,true
 
 [magic_spell_earth_wave]
@@ -264,8 +264,8 @@ data=anim,human_castwave
 data=spotanim_origin,earthwave_casting
 data=spotanim_proj,earthwave_travel,43,31,51,16,-5,64,10
 data=spotanim_target,earthwave_impact,124
-data=sound_success,earth_wave_all
-data=sound_fail,earth_wave_fail
+data=sound_cast,earthwave_cast_and_fire
+data=sound_hit,earthwave_hit
 data=continue_by_autocast,true
 
 [magic_spell_fire_wave]
@@ -282,8 +282,8 @@ data=anim,human_castwave
 data=spotanim_origin,firewave_casting
 data=spotanim_proj,firewave_travel,43,31,51,16,-5,64,10
 data=spotanim_target,firewave_impact,124
-data=sound_success,fire_wave_all
-data=sound_fail,fire_wave_fail
+data=sound_cast,firewave_cast_and_fire
+data=sound_hit,firewave_hit
 data=continue_by_autocast,true
 
 [magic_spell_bind]
@@ -298,7 +298,8 @@ data=anim,human_castentangle
 data=spotanim_origin,entangle_casting
 data=spotanim_proj,entangle_travel,45,0,75,16,-24,64,10
 data=spotanim_target,bind_impact,124
-data=sound_success,bind_all
+data=sound_cast,bind_cast
+data=sound_hit,bind_impact
 data=freeze_time,8
 data=continue_by_autocast,false
 
@@ -314,7 +315,8 @@ data=anim,human_castentangle
 data=spotanim_origin,entangle_casting
 data=spotanim_proj,entangle_travel,45,0,75,16,-24,64,10
 data=spotanim_target,snare_impact,124
-data=sound_success,snare_all
+data=sound_cast,bind_cast
+data=sound_hit,bind_impact
 data=freeze_time,16
 data=maxhit,2
 data=continue_by_autocast,false
@@ -331,7 +333,8 @@ data=anim,human_castentangle
 data=spotanim_origin,entangle_casting
 data=spotanim_proj,entangle_travel,45,0,75,16,-24,64,10
 data=spotanim_target,entangle_impact,124
-data=sound_success,entangle_all
+data=sound_cast,bind_cast
+data=sound_hit,bind_impact
 data=freeze_time,24
 data=maxhit,5
 data=continue_by_autocast,false
@@ -348,7 +351,8 @@ data=anim,human_castconfuse
 data=spotanim_origin,confuse_casting
 data=spotanim_proj,confuse_travel,36,31,51,16,-5,64,10
 data=spotanim_target,confuse_impact,124
-data=sound_success,confuse_all
+data=sound_cast,confuse_cast_and_fire
+data=sound_hit,confuse_hit
 data=stat_change,attack,-1,-5
 data=continue_by_autocast,false
 
@@ -364,7 +368,8 @@ data=anim,human_castweaken
 data=spotanim_origin,weaken_casting
 data=spotanim_proj,weaken_travel,36,31,51,16,-5,64,10
 data=spotanim_target,weaken_impact,124
-data=sound_success,weaken_all
+data=sound_cast,confuse_cast_and_fire
+data=sound_hit,confuse_hit
 data=stat_change,strength,-1,-5
 data=continue_by_autocast,false
 
@@ -380,7 +385,8 @@ data=anim,human_castcurse
 data=spotanim_origin,curse_casting
 data=spotanim_proj,curse_travel,43,31,51,16,-5,64,10
 data=spotanim_target,curse_impact,124
-data=sound_success,curse_all
+data=sound_cast,confuse_cast_and_fire
+data=sound_hit,confuse_hit
 data=stat_change,defence,-1,-5
 data=continue_by_autocast,false
 
@@ -396,7 +402,8 @@ data=anim,human_castcurse
 data=spotanim_origin,vulnerability_casting
 data=spotanim_proj,vulnerability_travel,36,31,51,16,-5,64,10
 data=spotanim_target,vulnerability_impact,124
-data=sound_success,vulnerability_all
+data=sound_cast,confuse_cast_and_fire
+data=sound_hit,confuse_hit
 data=stat_change,defence,-1,-10
 data=continue_by_autocast,false
 
@@ -412,7 +419,8 @@ data=anim,human_castenfeeble
 data=spotanim_origin,enfeeble_casting
 data=spotanim_proj,enfeeble_travel,36,31,51,16,-5,64,10
 data=spotanim_target,enfeeble_impact,124
-data=sound_success,enfeeble_all
+data=sound_cast,enfeeble_cast_and_fire
+data=sound_hit,enfeeble_hit
 data=stat_change,strength,-1,-10
 data=continue_by_autocast,false
 
@@ -429,7 +437,8 @@ data=spotanim_origin,stun_casting
 data=spotanim_proj,stun_travel,36,31,51,16,-5,64,10
 data=spotanim_target,stun_impact,124
 // data=spotanim_target,stunned,124
-data=sound_success,stun_all
+data=sound_cast,enfeeble_cast_and_fire
+data=sound_hit,enfeeble_hit
 data=stat_change,attack,-1,-10
 data=continue_by_autocast,false
 
@@ -446,7 +455,8 @@ data=anim,human_castcrumbleundead
 data=spotanim_origin,crumbleundead_casting
 data=spotanim_proj,crumbleundead_travel,31,31,46,16,0,64,5
 data=spotanim_target,crumbleundead_impact,124
-data=sound_success,crumble_all
+data=sound_cast,crumble_cast_and_fire
+data=sound_hit,crumble_hit
 data=continue_by_autocast,true
 data=maxhit,15
 
@@ -463,8 +473,8 @@ data=worn_reqmessage,"You must be wielding the Staff of Saradomin to cast this s
 data=experience,350
 data=anim,human_casting
 data=spotanim_target,saradomin_lightning,128
-data=sound_success,saradomin_strike
-data=sound_fail,saradomin_strike_fail
+data=sound_cast,firewave_cast_and_fire
+data=sound_hit,saradomin_strike
 data=continue_by_autocast,true
 data=maxhit,20
 data=stat_change,prayer,-1,0
@@ -482,8 +492,8 @@ data=worn_reqmessage,"You must be wielding the Staff of Guthix to cast this spel
 data=experience,350
 data=anim,human_casting
 data=spotanim_target,gunthix_claw,96
-data=sound_success,claws_of_guthix
-data=sound_fail,claws_of_guthix_fail
+data=sound_cast,firewave_cast_and_fire
+data=sound_hit,claws_of_guthix
 data=continue_by_autocast,true
 data=maxhit,20
 data=stat_change,defence,-1,-5
@@ -501,8 +511,8 @@ data=worn_reqmessage,"You must be wielding the Staff of Zamorak to cast this spe
 data=experience,350
 data=anim,human_casting
 data=spotanim_target,zamorak_flame,0
-data=sound_success,flames_of_zamorak
-data=sound_fail,flames_of_zamorak_fail
+data=sound_cast,firewave_cast_and_fire
+data=sound_hit,flames_of_zamorak
 data=continue_by_autocast,true
 data=maxhit,20
 data=stat_change,magic,-1,-5
@@ -522,8 +532,8 @@ data=anim,human_castibanblast
 data=spotanim_origin,ibanblast_casting
 data=spotanim_proj,ibanblast_travel,36,31,51,16,-5,64,10
 data=spotanim_target,ibanblast_impact,124
-data=sound_success,fire_wave_all
-data=sound_fail,fire_wave_fail
+data=sound_cast,firewave_cast_and_fire
+data=sound_hit,firewave_hit
 data=continue_by_autocast,true
 data=maxhit,25
 


### PR DESCRIPTION
Finally updated Content and Engine in my local 377 (haven't updated anything from the github besides my work since January or so) so fixing things that don't build