### PR TITLE
fix: chompybird fixes

### DIFF
--- a/scripts/quests/quest_chompybird/configs/quest_chompybird.npc
+++ b/scripts/quests/quest_chompybird/configs/quest_chompybird.npc
@@ -10,7 +10,6 @@ model1=model_2878_npc
 model2=model_3442_npc
 head1=model_141_npc_head
 wanderrange=2
-timer=1
 param=damagetype,^crush_style
 param=death_anim,ogre_death
 param=death_sound,giant_death
@@ -67,6 +66,7 @@ desc=A green skinned croaker, loves the swamp.
 readyanim=chompy_toad_ready
 walkanim=chompy_toad_walk
 model1=model_3447_obj
+timer=30
 
 [bloated_toad]
 vislevel=hide

--- a/scripts/quests/quest_chompybird/configs/quest_chompybird.varn
+++ b/scripts/quests/quest_chompybird/configs/quest_chompybird.varn
@@ -3,3 +3,6 @@ type=player_uid
 
 [rantz_attacking_chompy]
 type=npc_uid
+
+[chompy_attacking_toad]
+type=npc_uid

--- a/scripts/quests/quest_chompybird/configs/quest_chompybird.varn
+++ b/scripts/quests/quest_chompybird/configs/quest_chompybird.varn
@@ -1,6 +1,3 @@
-[quest_chompybird_baiter]
-type=player_uid
-
 [rantz_attacking_chompy]
 type=npc_uid
 

--- a/scripts/quests/quest_chompybird/scripts/bloated_toad.rs2
+++ b/scripts/quests/quest_chompybird/scripts/bloated_toad.rs2
@@ -70,7 +70,7 @@ if (%chompybird = ^chompybird_shown_toad) {
 
 if (p_finduid(uid) = true) {
     npc_add(coord, bloated_toad, 101);
-    %quest_chompybird_baiter = uid;
+    %npc_attacking_uid = uid;
     npc_queue(4, 0, 25);
 
     mes("You carefully place the bloated toad bait.");
@@ -113,7 +113,7 @@ if ($toad_should_explode = true) {
 }
 
 if ($should_spawn_chompy = true) {
-    ~spawn_chompy_bird(npc_coord, %quest_chompybird_baiter);
+    ~spawn_chompy_bird(npc_coord, %npc_attacking_uid);
 }
 
 [proc,toad_explode]()

--- a/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -8,7 +8,7 @@
     npc_say("Sqwirk!");
     if(finduid(%npc_attacking_uid) = true) {
         if (%chompybird >= ^chompybird_chompy_ate_toad & %chompybird < ^chompybird_rantz_gave_player_bow) {
-            npc_queue(11, 0, ~random_range(15, 30));
+            npc_queue(11, 0, add(15, random(10)));
         }
         hint_npc;
     }

--- a/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -3,10 +3,10 @@
     def_coord $spawn_coord = map_findsquare($coord, 3, 10, ^map_findsquare_lineofsight);
     
     npc_add($spawn_coord, chompy_bird, 100); // no seq for flying away at end, prob just despawned?
-    %quest_chompybird_baiter = $baiter_uid;
+    %npc_attacking_uid = $baiter_uid;
     npc_anim(chompy_landing, 0);
     npc_say("Sqwirk!");
-    if(finduid(%quest_chompybird_baiter) = true) {
+    if(finduid(%npc_attacking_uid) = true) {
         if (%chompybird >= ^chompybird_chompy_ate_toad & %chompybird < ^chompybird_rantz_gave_player_bow) {
             npc_queue(11, 0, ~random_range(15, 30));
         }
@@ -50,7 +50,7 @@ if (.npc_finduid(%chompy_attacking_toad) = true & distance(npc_coord, .npc_coord
     .npc_delay(1);
     .npc_del;
     npc_setmode(null);
-    if (p_finduid(%quest_chompybird_baiter) = true) {
+    if (p_finduid(%npc_attacking_uid) = true) {
         if (%chompybird = ^chompybird_dropped_toad) {
             %chompybird = ^chompybird_chompy_ate_toad;
         }
@@ -107,7 +107,7 @@ if ($rhand ! ogre_bow) {
     return;
 }
 
-if(%quest_chompybird_baiter ! uid) {
+if(%npc_attacking_uid ! uid) {
     mes("This is not your Chompy Bird to shoot.");
     return;
 }
@@ -216,7 +216,7 @@ if(%chompybird_kills = 4000) {
 
 [ai_queue11,chompy_bird]
 if (.npc_find(0_41_46_6_37, rantz, 5, 0) = true) {
-    if (finduid(%quest_chompybird_baiter) = true & distance(coord, .npc_coord) < 20) {
+    if (finduid(%npc_attacking_uid) = true & distance(coord, .npc_coord) < 20) {
         %rantz_attacking_chompy = .npc_uid;
         mes("Rantz: Hey, dere's da chompy, I's gonna shoot it.");
         .npc_say("Hey, dere's da chompy, I's gonna shoot it.");
@@ -239,7 +239,7 @@ if (.npc_finduid(%rantz_attacking_chompy) = true) {
 
 [ai_queue13,chompy_bird]
 if (.npc_finduid(%rantz_attacking_chompy) = true) {
-    if (finduid(%quest_chompybird_baiter) = true & distance(coord, .npc_coord) < 20) {
+    if (finduid(%npc_attacking_uid) = true & distance(coord, .npc_coord) < 20) {
         .npc_setmode(null);
         queue(rantz_shot_chompy, 0, 0);
         mes("Rantz keeps missing the chompy bird...");

--- a/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -7,6 +7,9 @@
     npc_anim(chompy_landing, 0);
     npc_say("Sqwirk!");
     if(finduid(%quest_chompybird_baiter) = true) {
+        if (%chompybird >= ^chompybird_chompy_ate_toad & %chompybird < ^chompybird_rantz_gave_player_bow) {
+            npc_queue(11, 0, ~random_range(15, 30));
+        }
         hint_npc;
     }
 
@@ -22,7 +25,7 @@ if (%npc_aggressive_player ! null) {
 def_int $dist;
 def_coord $dest;
 if (.npc_find(npc_coord, bloated_toad, 7, ^vis_lineofwalk) = true) {
-    %rantz_attacking_chompy = .npc_uid;
+    %chompy_attacking_toad = .npc_uid;
     $dest = map_findsquare(.npc_coord, 1, 1, ^vis_lineofwalk);
     $dist = add(distance(npc_coord, $dest), 1);
     npc_walk($dest);
@@ -32,7 +35,7 @@ if (.npc_find(npc_coord, bloated_toad, 7, ^vis_lineofwalk) = true) {
 }
 
 [ai_queue5,chompy_bird]
-if (.npc_finduid(%rantz_attacking_chompy) = true & distance(npc_coord, .npc_coord) = 1 & %npc_aggressive_player = null) {
+if (.npc_finduid(%chompy_attacking_toad) = true & distance(npc_coord, .npc_coord) = 1 & %npc_aggressive_player = null) {
     %npc_int = ^true;
     npc_walk(npc_coord);
     npc_facesquare(.npc_coord);
@@ -209,4 +212,38 @@ if(%chompybird_kills = 4000) {
     mes("You've been awarded ranged experience for your relentless pursuit of chompies!");
     // https://youtu.be/cQ_HQgUodI0?si=NMThWxkpJozNbe57&t=121
     ~objbox(chompy_bird_obj, "@blu@**** Congratulations! 4000 Chompies! ****|@dre@~ You're an Expert Dragon Archer! ~|This is the highest honour that can be bestowed on any chompy bird hunter.", 250, 0, ^objbox_height); 
+}
+
+[ai_queue11,chompy_bird]
+if (.npc_find(0_41_46_6_37, rantz, 5, 0) = true) {
+    if (finduid(%quest_chompybird_baiter) = true & distance(coord, .npc_coord) < 20) {
+        %rantz_attacking_chompy = .npc_uid;
+        mes("Rantz: Hey, dere's da chompy, I's gonna shoot it.");
+        .npc_say("Hey, dere's da chompy, I's gonna shoot it.");
+        .npc_facesquare(npc_coord);
+        .npc_setmode(none);
+        .npc_walk(.npc_coord);
+        npc_queue(12, 0, 2);
+        return;
+    }
+}
+
+[ai_queue12,chompy_bird]
+if (.npc_finduid(%rantz_attacking_chompy) = true) {
+    .npc_anim(ogre_longbow, 0);
+    ~sound_area(ogre_bow, 0, .npc_coord, 10);
+    .spotanim_npc(ogre_arrow_launch, 50, 0);
+    ~.npc_to_npc_projectile(npc_uid, ogre_arrow_travel, 38, 36, 41, 15, 5, 11, 5);
+    npc_queue(13, 0, 3);
+}
+
+[ai_queue13,chompy_bird]
+if (.npc_finduid(%rantz_attacking_chompy) = true) {
+    if (finduid(%quest_chompybird_baiter) = true & distance(coord, .npc_coord) < 20) {
+        .npc_setmode(null);
+        queue(rantz_shot_chompy, 0, 0);
+        mes("Rantz keeps missing the chompy bird...");
+        mes("Rantz: Grrr...de'ese arrows are rubbish.");
+        .npc_say("Grrr...de'ese arrows are rubbish.");
+    }
 }

--- a/scripts/quests/quest_chompybird/scripts/ogre_chest.rs2
+++ b/scripts/quests/quest_chompybird/scripts/ogre_chest.rs2
@@ -9,8 +9,7 @@ anim(human_pickuptable, 0);
 
 p_delay(0);
 
-// todo confirm chance
-if (random(3) = 0) {
+if (stat_random(strength, 30, 254) = false) {
     mes("You strain to lift the huge rock off the chest...");
     p_delay(1);
     mes("... but it's just too heavy for you.");

--- a/scripts/quests/quest_chompybird/scripts/rantz.rs2
+++ b/scripts/quests/quest_chompybird/scripts/rantz.rs2
@@ -751,43 +751,5 @@ if($hat18 = ^true) {
 [label,rantz_ok]
 ~chatplayer("<p,neutral>Ok, thanks.");
 
-// look for any chompy birds to shoot
-[ai_timer,rantz]
-if(random(20) ! 0 | npc_getmode = none) return;
-if (.npc_find(0_41_46_11_22, chompy_bird, 12, ^vis_lineofsight) = true) {
-    if(%rantz_attacking_chompy = .npc_uid) return;
-    if (p_finduid(.%quest_chompybird_baiter) = true & inzone(0_41_46_0_0, 0_41_46_63_63, coord) = true) {
-        // we only run this logic for players in the right quest state
-        if (%chompybird >= ^chompybird_chompy_ate_toad & %chompybird < ^chompybird_rantz_gave_player_bow) {
-            %rantz_attacking_chompy = .npc_uid;
-            %quest_chompybird_baiter = uid;
-            mes("Rantz: Hey, dere's da chompy, I's gonna shoot it.");
-            npc_say("Hey, dere's da chompy, I's gonna shoot it.");
-            npc_facesquare(.npc_coord);
-            npc_setmode(none);
-            npc_walk(npc_coord);
-            npc_queue(11, 0, 2);
-            return;
-        }
-    }
-}
-
-[ai_queue11,rantz]
-if(.npc_finduid(%rantz_attacking_chompy) = true) {
-    npc_anim(ogre_longbow, 0);
-    spotanim_npc(ogre_arrow_launch, 50, 0);
-    def_int $duration = ~npc_to_npc_projectile(.npc_uid, ogre_arrow_travel, 38, 36, 41, 15, 5, 11, 5);
-    def_int $delay = add(sub(divide($duration, 30), 1), 2);
-    npc_queue(12, 0, calc($delay + 1));
-}
-
-[ai_queue12,rantz]
-npc_setmode(null);
-if(.npc_finduid(%rantz_attacking_chompy) = true) {
-    if (p_finduid(%quest_chompybird_baiter) = true) {
-        %chompybird = ^chompybird_rantz_tried_to_shoot_chompy;
-        mes("Rantz keeps missing the chompy bird...");
-        mes("Rantz: Grrr...de'ese arrows are rubbish.");
-        npc_say("Grrr...de'ese arrows are rubbish.");
-    }
-}
+[queue,rantz_shot_chompy]
+if(%chompybird < ^chompybird_rantz_tried_to_shoot_chompy) %chompybird = ^chompybird_rantz_tried_to_shoot_chompy;

--- a/scripts/quests/quest_chompybird/scripts/swamp_toad.rs2
+++ b/scripts/quests/quest_chompybird/scripts/swamp_toad.rs2
@@ -15,7 +15,6 @@
 [proc,come_here_toady]()
 {
     say("Come here toady!");
-    npc_setmode(playerfaceclose);
     anim(human_chompybird_ogrebellows, 30);
     sound_synth(ogre_bellows, 0, 30);
     spotanim_pl(ogre_bellows_use, 64, 30);
@@ -23,23 +22,22 @@
 }
 
 [opnpcu,toad]
+// always does this regardless of item used
+facesquare(npc_coord);
+npc_setmode(playerface);
+npc_anim(null, 0);
 switch_obj(last_useitem) {
     case empty_ogre_bellows :
-
         ~come_here_toady();
+        p_delay(2);
+        npc_anim(null, 0);
+        npc_setmode(null);
+        npc_say("Hissss....");
+        ~sound_area(toad_hiss, 0, npc_coord, 5);
+        p_delay(0);
+        mes("The air seems too thin to stay in the toad.");
+        mes("Perhaps you need something thicker than air.");
 
-        p_delay(1);
-
-        if (p_finduid(uid) = true) {
-            npc_say("Hissss....");
-            
-            p_delay(1);
-
-            if (p_finduid(uid) = true) {
-                mes("The air seems too thin to stay in the toad.");
-                mes("Perhaps you need something thicker than air.");
-            }
-        }        
     case filled_ogre_bellow3, filled_ogre_bellow2, filled_ogre_bellow1 :
         if (inv_freespace(inv) < 1) {
             mes("You don't have space to carry that.");
@@ -49,6 +47,8 @@ switch_obj(last_useitem) {
         def_obj $used_bellow = last_useitem;
 
         if (inv_total(inv, bloated_toad) >= 3) {
+            npc_setmode(playerfaceclose);
+            p_delay(1);
             mes("One of your bloated toads manages to escape.");
 
             npc_add(map_findsquare(coord, 1, 1, ^map_findsquare_lineofwalk), toad, 100);
@@ -56,24 +56,6 @@ switch_obj(last_useitem) {
             inv_del(inv, bloated_toad, 1);
 
             p_delay(1);
-
-            if (p_finduid(uid) = true) {
-                mes("You manage to catch the toad and inflate it with the swamp gas.");
-                ~come_here_toady();
-
-                p_delay(3);
-
-                if (p_finduid(uid) = true) {
-                    mes("You add the bloated toad to your inventory.");
-                    inv_add(inv, bloated_toad, 1);
-
-                    ~reduce_ogre_bellows($used_bellow);
-
-                    npc_del;
-                }
-            }
-
-            return;
         }
         
         mes("You manage to catch the toad and inflate it with the swamp gas.");
@@ -89,3 +71,10 @@ switch_obj(last_useitem) {
     case default :
         mes("Nothing interesting happens.");
 }
+
+// 116 samples, low = 75, high = 99
+[ai_timer,toad]
+npc_settimer(add(75, random(25)));
+~sound_area(toad_croak, 0, npc_coord, 5);
+if(random(2) = 0) npc_say("Ribbit");
+else npc_say("Croak");

--- a/scripts/skill_combat/scripts/projectile.rs2
+++ b/scripts/skill_combat/scripts/projectile.rs2
@@ -16,6 +16,12 @@ def_int $duration = calc($delay + $flight);
 projanim_npc(npc_coord, $uid, $spotanim, $startheight, $endheight, $delay, $duration, $angle, $offset);
 return($duration);
 
+[proc,.npc_to_npc_projectile](npc_uid $uid, spotanim $spotanim, int $startheight, int $endheight, int $delay, int $angle, int $length, int $offset, int $step)(int)
+def_int $flight = calc($length + (npc_range(.npc_coord) * $step));
+def_int $duration = calc($delay + $flight);
+projanim_npc(.npc_coord, $uid, $spotanim, $startheight, $endheight, $delay, $duration, $angle, $offset);
+return($duration);
+
 [proc,player_projectile](coord $coord, coord $coord2, player_uid $uid, spotanim $spotanim, int $startheight, int $endheight, int $delay, int $angle, int $length, int $offset, int $step)(int)
 def_int $flight = calc($length + (distance($coord, $coord2) * $step));
 def_int $duration = calc($delay + $flight);


### PR DESCRIPTION
for 225+
- change rantz shooting logic to queue from chompy after the chompy spawns, remove prot access checks aside from var increase, remove timer from rantz
- use stat_random for the chest during the quest
- cleanup and slight adjustments to opu logic on toads
- add timer for toads to ribbit/croak periodically