### PR TITLE
fix: Shades of Mortton fixes

### DIFF
--- a/scripts/minigames/game_mortton/configs/mortton_shades.hunt
+++ b/scripts/minigames/game_mortton/configs/mortton_shades.hunt
@@ -1,0 +1,10 @@
+[shades]
+type=player
+check_vis=off
+check_nottoostrong=outside_wilderness
+check_notcombat=%lastcombat
+check_notcombat_self=%npc_lastcombat
+check_notbusy=off
+extracheck_var=%morttonmulti,&16
+find_keephunting=off
+find_newmode=opplayer2

--- a/scripts/minigames/game_mortton/configs/mortton_shades.npc
+++ b/scripts/minigames/game_mortton/configs/mortton_shades.npc
@@ -27,11 +27,11 @@ param=defend_sound,shade_hit
 param=death_sound,shade_death
 param=death_drop,shade_bones1
 param=undead,^true
-huntmode=cowardly
+huntmode=shades
 timer=1
 param=next_npc_type,shade_level1
-// huntrange= TODO
-// TODO immune to poison
+// guess
+huntrange=3
 
 [shade_level1]
 name=Loar Shade
@@ -67,7 +67,6 @@ param=death_drop,shade_bones1
 param=undead,^true
 timer=1
 // huntrange= TODO
-// TODO immune to poison
 
 [shade_heaven]
 name=Shade Spirit
@@ -113,8 +112,9 @@ param=defend_sound,shade_hit
 param=death_sound,shade_death
 param=death_drop,shade_bones2
 param=undead,^true
-huntmode=cowardly
-// huntrange= TODO
+huntmode=shades
+// guess
+huntrange=3
 // TODO immune to poison
 
 [shade_level2]
@@ -180,8 +180,9 @@ param=defend_sound,shade_hit
 param=death_sound,shade_death
 param=death_drop,shade_bones3
 param=undead,^true
-huntmode=cowardly
-// huntrange= TODO
+huntmode=shades
+// guess
+huntrange=3
 // immune to poison
 
 [shade_level3]
@@ -247,8 +248,9 @@ param=defend_sound,shade_hit
 param=death_sound,shade_death
 param=death_drop,shade_bones4
 param=undead,^true
-huntmode=cowardly
-// huntrange= TODO
+huntmode=shades
+// guess
+huntrange=3
 // immune to poison
 
 [shade_level4]
@@ -312,8 +314,9 @@ param=defend_sound,shade_hit
 param=death_sound,shade_death
 param=death_drop,shade_bones5
 param=undead,^true
-huntmode=cowardly
-// huntrange= TODO
+huntmode=shades
+// guess
+huntrange=3
 // immune to poison
 
 [shade_level5]

--- a/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
+++ b/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
@@ -133,21 +133,23 @@ if(%temple_sanctity_p < 100) {
 }
 
 //1 exp per 2 resources spent
-stat_advance(crafting, divide($resource_amount,2));
+stat_advance(crafting, divide(multiply($resource_amount,10),2));
 
 def_int $current_wall_state = loc_param(temple_wall_level);
 //todo: Find better breakpoints
-switch_int($current_wall_state) {
-    case 0 : if(%current_temple_build > 300) loc_change(loc_param(next_loc_stage), 9000);
-    case 1 : if(%current_temple_build > 700) loc_change(loc_param(next_loc_stage), 9000);
-    case 2 : if(%current_temple_build > 1100) loc_change(loc_param(next_loc_stage), 9000);
-    case 3 : if(%current_temple_build > 1500) loc_change(loc_param(next_loc_stage), 9000);
-    case 4 : if(%current_temple_build > 1900) loc_change(loc_param(next_loc_stage), 9000);
-    case 5 : if(%current_temple_build > 2300) loc_change(loc_param(next_loc_stage), 9000);
-    case 6 : if(%current_temple_build > 2700) loc_change(loc_param(next_loc_stage), 9000);
-    case 7 : if(%current_temple_build > 3100) loc_change(loc_param(next_loc_stage), 9000);
-    case 8 : if(%current_temple_build > 3500) loc_change(loc_param(next_loc_stage), 9000);
-    case 9 : if(%current_temple_build > 3900) loc_change(loc_param(next_loc_stage), 9000);
+if(loc_param(next_loc_stage) ! null) {
+    switch_int($current_wall_state) {
+        case 0 : if(%current_temple_build > 300) loc_change(loc_param(next_loc_stage), 9000);
+        case 1 : if(%current_temple_build > 700) loc_change(loc_param(next_loc_stage), 9000);
+        case 2 : if(%current_temple_build > 1100) loc_change(loc_param(next_loc_stage), 9000);
+        case 3 : if(%current_temple_build > 1500) loc_change(loc_param(next_loc_stage), 9000);
+        case 4 : if(%current_temple_build > 1900) loc_change(loc_param(next_loc_stage), 9000);
+        case 5 : if(%current_temple_build > 2300) loc_change(loc_param(next_loc_stage), 9000);
+        case 6 : if(%current_temple_build > 2700) loc_change(loc_param(next_loc_stage), 9000);
+        case 7 : if(%current_temple_build > 3100) loc_change(loc_param(next_loc_stage), 9000);
+        case 8 : if(%current_temple_build > 3500) loc_change(loc_param(next_loc_stage), 9000);
+        case 9 : if(%current_temple_build > 3900) loc_change(loc_param(next_loc_stage), 9000);
+    }
 }
 
 anim(human_pickuptable, 0);
@@ -167,28 +169,69 @@ if (inv_total(inv, tinderbox) < 1) {
     mes("You need a tinderbox to light the fire altar.");
     return;
 }
-@try_light_altar;
 
-[oplocu,templefire_altar_nofire]
-if(last_useitem = tinderbox) {
-    @try_light_altar;
-} else {
-    ~displaymessage(^dm_default);
+if (%morttonquest < ^mortton_can_light_altar) {
+    ~mesbox("You need to have repaired or reinforced the walls of the temple|before you can light the sacred flame.");
+    return;
 }
 
-[label,try_light_altar]
 if(%temple_sanctity_p < 10) {
     ~mesbox("You haven't sanctified enough of the temple to allow you to light the|fire. Repair or reinforce the wall to increase your sanctity. You|need at least 10% Sanctity to attempt to light the fire.");
     return;
 }
-//todo: light temple logic
-//action delay check
-mes("You attempt to light the fire altar.");
-//stat random mes fail
-mes("You don't manage to light the fire this time.");
-//stat random mes success
-mes("You light the temple fire.");
-loc_change(templefire_altar, 99);
+
+if (%action_delay < map_clock) {
+    %action_delay = calc(map_clock + 3);
+    mes("You attempt to light the fire altar.");
+} else if (%action_delay = map_clock) {
+    @try_light_altar;
+}
+anim(human_pickuptable, 0);
+p_oploc(3);
+
+[oplocu,templefire_altar_nofire]
+if(last_useitem = tinderbox) {
+    if (%morttonquest < ^mortton_can_light_altar) {
+        ~mesbox("You need to have repaired or reinforced the walls of the temple|before you can light the sacred flame.");
+        return;
+    }
+
+    if(%temple_sanctity_p < 10) {
+        ~mesbox("You haven't sanctified enough of the temple to allow you to light the|fire. Repair or reinforce the wall to increase your sanctity. You|need at least 10% Sanctity to attempt to light the fire.");
+        return;
+    }
+
+    if (%action_delay < map_clock) {
+        %action_delay = calc(map_clock + 3);
+        mes("You attempt to light the fire altar.");
+    } else if (%action_delay = map_clock) {
+        @try_light_altar;
+    }
+    anim(human_pickuptable, 0);
+    p_oploc(3);
+} else {
+    ~displaymessage(^dm_default);
+}
+
+[oploc3,templefire_altar_nofire]
+if (%action_delay < map_clock) {
+    %action_delay = calc(map_clock + 3);
+    anim(human_pickuptable, 0);
+} else if (%action_delay = map_clock) {
+    @try_light_altar;
+}
+p_oploc(3);
+
+[label,try_light_altar]
+// Guess
+if(stat_random(firemaking, 100, 250) = false) {
+    mes("You don't manage to light the fire this time.");
+    p_oploc(3);
+} else {
+    mes("You light the temple fire.");
+    loc_change(templefire_altar, 99);
+    stat_advance(firemaking, 1600);
+}
 
 [queue,update_flamtaer_overlay]
 %temple_resources_p = divide(%temple_resources, 150);
@@ -236,6 +279,11 @@ inv_del(inv, woodplank, 1);
 
 [oplocu,templefire_altar]
 if (oc_category(last_useitem) = category_110) {
+    if (%morttonquest < ^mortton_can_light_altar) {
+        ~mesbox("You need to have repaired or reinforced the walls of the temple|before you can use the sacred flame.");
+        return;
+    }
+
     if(%temple_sanctity_p < 10) {
         ~mesbox("You need to increase your sanctity to at least 10% before you can|use the sacred flame. Using the sacred flame reduces your sanctity.");
         return;
@@ -246,12 +294,20 @@ if (oc_category(last_useitem) = category_110) {
     def_int $sanc_drain = divide(multiply(multiply(9, $doses), 30), 1000);
     %temple_sanctity = sub(%temple_sanctity, $sanc_drain);
 
-    inv_setslot(inv, $slot, oc_param($obj, next_obj_stage_temple), 1);
+    inv_setslot(inv, $slot, oc_param($obj, next_obj_stage), 1);
     sound_synth(oil_pour, 0, 0);
     anim(human_pickuptable, 0);
     mes("You carefully sanctify the oil in the sacred flame.");
+    if (%morttonquest = ^mortton_can_light_altar) {
+        %morttonquest = ^mortton_created_sacred_oil;
+    }
     return;
 } else if (oc_category(last_useitem) = category_108) {
+    if (%morttonquest < ^mortton_can_light_altar) {
+        ~mesbox("You need to have repaired or reinforced the walls of the temple|before you can use the sacred flame.");
+        return;
+    }
+
     if(%temple_sanctity_p < 20) {
         //Was fixed to be 20% later
         ~mesbox("You need to increase your sanctity to %20 before you can use the|sacred flame for this purpose.  Using the sacred flame reduces your|sanctity.");
@@ -275,5 +331,3 @@ if (oc_category(last_useitem) = category_110) {
     return;
 }
 ~displaymessage(^dm_default);
-
-//todo finished temple midi

--- a/scripts/minigames/game_mortton/scripts/mortton_catacombs.rs2
+++ b/scripts/minigames/game_mortton/scripts/mortton_catacombs.rs2
@@ -1,6 +1,6 @@
 [oploc1,shadelairentrancel]
 p_arrivedelay;
-if(testbit(%morttonmulti, ^mortton_unlocked_shade_lair) = ^false & ~get_shadekeys_total = 0) {
+if(testbit(%morttonmulti, ^mortton_unlocked_shade_lair) = ^false | ~get_shadekeys_total = 0) {
     mes("The door seems locked. Perhaps you need a key.");
     sound_synth(locked, 0, 0);
     return;
@@ -18,7 +18,7 @@ p_teleport(0_54_151_37_61);
 
 [oploc1,shadelairentrancer]
 p_arrivedelay;
-if(testbit(%morttonmulti, ^mortton_unlocked_shade_lair) = ^false & ~get_shadekeys_total = 0) {
+if(testbit(%morttonmulti, ^mortton_unlocked_shade_lair) = ^false | ~get_shadekeys_total = 0) {
     mes("The door seems locked. Perhaps you need a key.");
     sound_synth(locked, 0, 0);
     return;

--- a/scripts/minigames/game_mortton/scripts/mortton_pyre.rs2
+++ b/scripts/minigames/game_mortton/scripts/mortton_pyre.rs2
@@ -42,10 +42,6 @@ inv_setslot(inv, $logs_slot, $product, 1);
 stat_advance(firemaking, struct_param($struct, pyre_create_experience));
 
 [oplocu,temple_pyre]
-if(%morttonquest < ^mortton_created_pyre_logs) {
-    mes("You can't do that until you have made your own funeral pyre logs.");
-    return;
-}
 if(last_useitem = hollow_bark) {
     mes("You can't make a pyre with that kind of log.");
     return;
@@ -55,6 +51,10 @@ if(oc_category(last_useitem) = category_22) {
     return;
 }
 if(oc_category(last_useitem) = category_2050) {
+    if(%morttonquest < ^mortton_created_pyre_logs) {
+        mes("You can't do that until you have made your own funeral pyre logs.");
+        return;
+    }
     @add_logs_to_funeral_pyre(last_useitem);
 }
 ~displaymessage(^dm_default);

--- a/scripts/minigames/game_mortton/scripts/mortton_shades.rs2
+++ b/scripts/minigames/game_mortton/scripts/mortton_shades.rs2
@@ -1,4 +1,10 @@
+[ai_queue3,shadeshadow_level1]
+@level1_shade_death;
+
 [ai_queue3,shade_level1]
+@level1_shade_death;
+
+[label,level1_shade_death]
 gosub(npc_death);
 if (npc_findhero = ^false) {
     return;
@@ -7,6 +13,21 @@ if (npc_findhero = ^false) {
 obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
 longqueue(shadeattack_reset, 5, 0, ^accelerate); //5 ticks osrs
 
+if(%morttonquest >= ^mortton_kill_shades & %morttonquest < ^mortton_killed_5_shades) {
+    queue(mortton_quest_shade_kill, 0, 0);
+}
+
+if(~inzone_coord_pair_table(mortton_temple_zones, coord) = true & %morttonquest > ^mortton_shades_to_ulsquire) {
+    if_openoverlay(flamtaer_status);
+    if(%temple_sanctity_p < 100) {
+        %temple_sanctity = add(%temple_sanctity, 60);
+    }
+    if(gettimer(sanctity_drain) = ^false) {
+        settimer(sanctity_drain, 100);
+    }
+}
+
+[queue,mortton_quest_shade_kill]
 if(%morttonquest = ^mortton_kill_shades) {
     %morttonquest = ^mortton_killed_1_shade;
     mes("That's one Shade!");
@@ -24,67 +45,74 @@ if(%morttonquest = ^mortton_kill_shades) {
     mes("That's all five Shades!");
 }
 
-if(~inzone_coord_pair_table(mortton_temple_zones, coord) = true & %morttonquest > ^mortton_shades_to_ulsquire) {
-    if_openoverlay(flamtaer_status);
-    queue(update_flamtaer_overlay, 0, 0); //todo does this update here
-    if(%temple_sanctity_p < 100) {
-        %temple_sanctity = add(%temple_sanctity, 60);
-        %temple_sanctity_p = divide(%temple_sanctity, 30);
-    }
-    if(gettimer(sanctity_drain) = ^false) {
-        settimer(sanctity_drain, 100);
-    }
-}
-
 [queue,shadeattack_reset]
 %morttonmulti = clearbit(%morttonmulti, ^shadeattack);
 
 [ai_queue2,shadeshadow_level1]
 ~npc_default_damage(last_int);
+npc_queue(13, 0, 0);
+
+[ai_queue13,shadeshadow_level1]
 npc_anim(null, 0);
-npc_changetype(npc_param(next_npc_type), 95); //todo 95 ticks osrs todo: This isnt revert but change again..?
+npc_changetype(npc_param(next_npc_type), 500);
 npc_anim(shade_rise, 0);
 npc_setmode(none);
 npc_walk(npc_coord);
 npc_delay(1);
 npc_anim(null, 0);
-npc_setmode(null);
 if (finduid(%npc_aggressive_player) = true) {
-    %morttonmulti = setbit(%morttonmulti, ^shadeattack);
-    longqueue(shadeattack_reset, 100, 0, ^accelerate);
-    sound_synth(shade_appear, 0, 0); //This is area sound in osrs. Should it exist in 04?
-    %npc_attacking_uid = %npc_aggressive_player;
+    npc_setmode(opplayer2);
+    %npc_attacking_uid = uid;
     %aggressive_npc = npc_uid;
 }
+%npc_int = 10;
+npc_settimer(~random_range(5,15));
+
+[ai_queue14,shade_level1]
+%npc_int = 10;
 
 [ai_opplayer2,shadeshadow_level1] 
 //They did not do the shade rise anim when transforming from hunting in old videos
 //https://youtu.be/3d4dxPVz-7k?si=VjWR5sOid5NHU_V-&t=411
 //https://youtu.be/Cgfa0ebrSac?si=mHSBgvg_rRdqOm1J&t=70
-npc_changetype(npc_param(next_npc_type), 95);
+if (npc_stat(hitpoints) = 0) {
+    return;
+}
+
+if(%npc_aggressive_player ! uid & testbit(%morttonmulti, ^shadeattack) = ^false) {
+    //guess on distance.
+    .npc_findall(npc_coord, shadeshadow_level1, 10, ^vis_lineofsight);
+    while (.npc_findnext = true) {
+        if(.npc_getmode = wander) {
+            .npc_setmode(opplayer2);
+            .%npc_aggressive_player = uid;
+        }
+    }
+}
+
+%morttonmulti = setbit(%morttonmulti, ^shadeattack);
+clearqueue(shadeattack_reset);
+longqueue(shadeattack_reset, 100, 0, ^accelerate);
+sound_synth(shade_appear, 0, 0); //This is area sound in osrs. Should it exist in 04?
+npc_changetype(npc_param(next_npc_type), 500);
+%npc_attacking_uid = uid;
+%aggressive_npc = npc_uid;
+npc_queue(14, 0, 95);
 ~shade_attack;
 
 [ai_opplayer2,shade_level1]
-//todo is set here or no?
-%morttonmulti = setbit(%morttonmulti, ^shadeattack);
-longqueue(shadeattack_reset, 100, 0, ^accelerate);
 ~shade_attack;
 
 [ai_queue2,shade_level1]
 ~npc_default_damage(last_int);
-
-if (finduid(%npc_aggressive_player) = true) {
-    %morttonmulti = setbit(%morttonmulti, ^shadeattack);
-    longqueue(shadeattack_reset, 100, 0, ^accelerate);
-    %npc_attacking_uid = %npc_aggressive_player;
-    %aggressive_npc = npc_uid;
-}
+npc_settimer(~random_range(5,15));
 
 [proc,shade_attack]
 if (%npc_action_delay > map_clock) {
     return;
 }
 if (~npc_check_notcombat = false) {
+    npc_changetype(shadeshadow_level1, ^max_32bit_int);
     npc_setmode(null);
     return;
 }
@@ -149,7 +177,7 @@ if (npc_getmode = opplayer2 | %current_temple_build = 0) {
 }
 
 if (distance(npc_coord, ^mortton_temple_shadow_transform_center_coord) <= 5) {
-    npc_changetype_keepall(shade_level1, 500); //todo: How long
+    npc_changetype_keepall(shade_level1, ^max_32bit_int);
     npc_anim(shade_rise, 0);
     npc_setmode(none);
     npc_walk(npc_coord);
@@ -159,7 +187,15 @@ if (distance(npc_coord, ^mortton_temple_shadow_transform_center_coord) <= 5) {
 }
 
 [ai_timer,shade_level1]
-if (npc_getmode = opplayer2) {
+if (%npc_int = 10) {
+    npc_setmode(wander);
+    %npc_int = 0;
+    npc_changetype(shadeshadow_level1, ^max_32bit_int);
+    npc_settimer(~random_range(1,7));
+    return;
+}
+
+if(npc_getmode = opplayer2) {
     npc_settimer(~random_range(1,7));
     return;
 }

--- a/scripts/quests/quest_mortton/configs/quest_mortton.npc
+++ b/scripts/quests/quest_mortton/configs/quest_mortton.npc
@@ -197,7 +197,7 @@ vislevel=37
 head1=model_55_idk_head
 wanderrange=5
 maxrange=7
-// respawnrate= TODO
+respawnrate=25
 hitpoints=30
 attack=30
 strength=30
@@ -208,6 +208,9 @@ param=defend_sound,zombie_hit
 param=death_sound,zombie_death
 param=next_npc_type,mort_man
 category=category_348
+huntmode=cowardly
+// guess
+huntrange=1
 
 [mort_afflicted_woman]
 name=Afflicted
@@ -238,7 +241,7 @@ vislevel=34
 head1=model_113_idk_head
 wanderrange=5
 maxrange=7
-// respawnrate= TODO
+respawnrate=25
 hitpoints=28
 attack=28
 strength=28
@@ -249,6 +252,9 @@ param=defend_sound,zombie_hit
 param=death_sound,zombie_death
 param=next_npc_type,mort_woman
 category=category_348
+huntmode=cowardly
+// guess
+huntrange=1
 
 [mort_man2]
 name=Mort'ton local
@@ -331,7 +337,7 @@ head1=model_63_idk_head
 head2=model_83_idk_head
 wanderrange=5
 maxrange=7
-// respawnrate= TODO
+respawnrate=25
 hitpoints=26
 attack=26
 strength=26
@@ -342,6 +348,9 @@ param=defend_sound,zombie_hit
 param=death_sound,zombie_death
 param=next_npc_type,mort_man2
 category=category_348
+huntmode=cowardly
+// guess
+huntrange=1
 
 [mort_afflicted_woman2]
 name=Afflicted
@@ -372,7 +381,7 @@ vislevel=30
 head1=model_118_idk_head
 wanderrange=5
 maxrange=7
-// respawnrate= TODO
+respawnrate=25
 hitpoints=24
 attack=24
 strength=24
@@ -383,3 +392,6 @@ param=defend_sound,zombie_hit
 param=death_sound,zombie_death
 param=next_npc_type,mort_woman2
 category=category_348
+huntmode=cowardly
+// guess
+huntrange=1

--- a/scripts/quests/quest_mortton/scripts/afflicted.rs2
+++ b/scripts/quests/quest_mortton/scripts/afflicted.rs2
@@ -1,3 +1,53 @@
+[ai_queue3,_category_348]
+gosub(npc_death);
+if (npc_findhero = ^false) {
+    return;
+}
+
+obj_add(npc_coord, npc_param(death_drop), 1, ^lootdrop_duration);
+
+~trail_easycluedrop(128, npc_coord);
+
+def_int $random = random(128);
+
+if ($random < 1) {
+    obj_add(npc_coord, iron_dagger, 1, ^lootdrop_duration);
+} else if ($random < 3) {
+    obj_add(npc_coord, bronze_med_helm,1 , ^lootdrop_duration);
+} else if ($random < 25) {
+    if (map_members = ^true) {
+        obj_add(npc_coord, bolt, ~random_range(2,12), ^lootdrop_duration);
+    }
+} else if ($random < 28) {
+    obj_add(npc_coord, bronze_arrow, 7, ^lootdrop_duration);
+} else if ($random < 30) {
+    obj_add(npc_coord, earthrune, 4, ^lootdrop_duration);
+} else if ($random < 32) {
+    obj_add(npc_coord, firerune, 6, ^lootdrop_duration); 
+} else if ($random < 34) {
+    obj_add(npc_coord, mindrune, 9, ^lootdrop_duration);
+} else if ($random < 35) {
+    obj_add(npc_coord, chaosrune, 2, ^lootdrop_duration); 
+} else if ($random < 58) {
+    obj_add(npc_coord, ~randomherb, ^lootdrop_duration);
+} else if ($random < 96) {
+    obj_add(npc_coord, coins, 3, ^lootdrop_duration);
+} else if ($random < 105) {
+    obj_add(npc_coord, coins, 5, ^lootdrop_duration);
+} else if ($random < 109) {
+    obj_add(npc_coord, coins, 15, ^lootdrop_duration);
+} else if ($random < 110) {
+    obj_add(npc_coord, coins, 25, ^lootdrop_duration);
+} else if ($random < 115) {
+    obj_add(npc_coord, fishing_bait, 1, ^lootdrop_duration);
+} else if ($random < 117) {
+    obj_add(npc_coord, copper_ore, 1, ^lootdrop_duration);
+} else if ($random < 119) {
+    obj_add(npc_coord, earth_talisman, 1, ^lootdrop_duration);
+} else if ($random < 120) {
+    obj_add(npc_coord, cabbage, 1, ^lootdrop_duration);
+}
+
 [opnpc1,_category_348]
 if(compare(nc_name(npc_type),"Afflicted") = 0) {
     @afflicted_talk;
@@ -7,7 +57,7 @@ if(compare(nc_name(npc_type),"Afflicted") = 0) {
 
 [label,afflicted_talk]
 ~chatnpc("<p,shock><~generate_afflicted_speech>");
-~chatnpc("@dbl@~ This person doesn't make any sense at all. ~");
+~chatnpc("<p,shock>@dbl@~ This person doesn't make any sense at all. ~");
 
 [opnpcu,_category_348]
 if(oc_category(last_useitem) = category_108 & compare(nc_name(npc_type),"Afflicted") = 0) {
@@ -15,7 +65,7 @@ if(oc_category(last_useitem) = category_108 & compare(nc_name(npc_type),"Afflict
     npc_anim(null, 0);
     npc_changetype(npc_param(next_npc_type), 50); //50 ticks osrs
     queue(207_cure_affliction_reward, 0, 0);
-    ~chatnpc("<p,happy>Oh... thank you, you used the serum on me. Here have|something for your trouble");
+    ~chatnpc("<p,happy>Oh... thank you, you used the serum on me. Here have|something for your trouble.");
     //17 May 2005 (Update):
     //Serum 208 can now be used on afflicted for better rewards.
 // } else if(oc_category(last_useitem) = category_109 & compare(nc_name(npc_type),"Afflicted") = 0) {

--- a/scripts/quests/quest_mortton/scripts/mortton_journal.rs2
+++ b/scripts/quests/quest_mortton/scripts/mortton_journal.rs2
@@ -7,7 +7,7 @@ if(%morttonquest = 0) {
     ~quest_journal("Shades of Mort'ton", $text);
     return;
 } else if (%morttonquest = ^mortton_quest_complete) {
-    $text = "@str@I travelled to the town of Mort'ton where the people had an|@str@affliction. I found the diary of 'Herbi Flax' and managed to|@str@work out the ingredients for a special serum. The serum|@str@worked on the afflicted and I was able to speak to several|@str@villagers.|@str@After slaying five shades and helping to rebuild a sacred|@str@temple, I was able to put the shades spirits to rest. The town|@str@has pretty much returned to normal, except for all the shade|@str@activity, but now I have a way to put the shades spirits to rest|@str@and gain access to their treasure filled lairs!|";
+    $text = "@str@I travelled to the town of Mort'ton where the people had an|@str@affliction. I found the diary of 'Herbi Flax' and managed to|@str@work out the ingredients for a special serum. The serum|@str@worked on the afflicted and I was able to speak to several|@str@villagers.|@str@After slaying five shades and helping to rebuild a sacred|@str@temple, I was able to put the shades spirits to rest. The|@str@town has pretty much returned to normal, except for all the|@str@shade activity, but now I have a way to put the shades|@str@spirits to rest and gain access to their treasure filled lairs!|";
     $text = append($text, "@red@QUEST COMPLETE!"); 
     ~quest_journal("Shades of Mort'ton", $text);
     return;
@@ -21,7 +21,7 @@ if (%morttonquest >= ^mortton_made_serum) {
 if (%morttonquest >= ^mortton_kill_shades) {
     $text = append($text, "@str@I made serum 207 from tarromin, water and ashes by using|@str@Herbi Flax's diary. I wonder what the serum is used for?|");
     $text = append($text, "@str@I used the serum on a local NPC and I've been able to ask|@str@a few questions about the place.|");
-    if (%morttonquest < ^mortton_killed_5_shades) {
+    if (%morttonquest = ^mortton_kill_shades) {
         $text = append($text, "@dbl@I talked to @dre@Razmire Keelgan@dbl@ and he asked me to kill @dre@five|@dre@shades@dbl@ for him. He seems to hate them!|");
     } else {
         $text = append($text, "@str@I talked to Razmire Keelgan and he asked me to kill five|@str@shades for him. He seems to hate them!|");
@@ -42,7 +42,7 @@ if (%morttonquest >= ^mortton_can_light_altar) {
     $text = append($text, "@str@I helped rebuild the temple using limestone bricks, wooden|@str@planks and nails.|");
 }
 if (%morttonquest >= ^mortton_created_sacred_oil) {
-    $text = append($text, "@str@When all of the temple walls were rebuilt, a fire altar|@str@appeared. The flame from the altar was sacred.|@str@I placed a flask of olive oil in the flame and it became sacred|@str@oil.|");
+    $text = append($text, "@str@When all of the temple walls were rebuilt, a fire altar|@str@appeared. The flame from the altar was sacred.|@str@I placed a flask of olive oil in the flame and it became|@str@sacred oil.|");
 }
 if (%morttonquest >= ^mortton_created_pyre_logs) {
     $text = append($text, "@str@I used sacred oil on logs turning them into pyre logs.|");
@@ -55,13 +55,13 @@ if (%morttonquest >= ^mortton_lit_pyre) {
 }
 
 if(%morttonquest = ^mortton_read_diary) {
-    $text = append($text,"@dbl@I made my way down through @dre@Mort Myre@dbl@ and I found the|@dbl@town of @dre@Mort'ton@dbl@. I've found a @dre@diary@dbl@ which has some|@dbl@interesting @dre@notes@dbl@ in it. ");
-    if (inv_total(inv, serum_book) < 1) {
-        $text = append($text, "@dbl@Maybe it was important?");
+    $text = append($text,"@dbl@I made my way down through @dre@Mort Myre@dbl@ and I found the|@dbl@town of @dre@Mort'ton@dbl@. ");
+    if (inv_total(inv, serum_book) = 0 & inv_total(bank, serum_book) = 0) {
+        $text = append($text, "I discovered a @dre@diary@dbl@ which had some|@dbl@interesting @dre@notes@dbl@ in it. @dbl@Maybe it was important?");
     } else if (inv_total(bank, serum_book) > 0) {
-        $text = append($text, "@dbl@I placed the book in my @dre@bank@dbl@.");
+        $text = append($text, "I discovered a @dre@diary@dbl@ which had some|@dbl@interesting @dre@notes@dbl@ in it, @dbl@I placed the book in my @dre@bank@dbl@.");
     } else {
-        $text = append($text, "@dbl@Perhaps this can help me?");
+        $text = append($text, "I've found a @dre@diary@dbl@ which has some|@dbl@interesting @dre@notes@dbl@ in it. @dbl@Perhaps this can help me?");
     }
 }
 if(%morttonquest = ^mortton_made_serum) {
@@ -69,7 +69,7 @@ if(%morttonquest = ^mortton_made_serum) {
         $text = append($text, "@str@I made serum 207 from tarromin, water and ashes by|@str@using Herbi Flax's diary. I wonder what the serum is used|@str@for?|");
         $text = append($text, "@dbl@I used the @dre@serum@dbl@ on a local NPC and I've been able to|@dbl@ask a few questions about the place.");
     } else {
-        $text = append($text, "@dbl@I made @dre@serum 207@dbl@ from tarromin, water and ashes by|@dbl@using Herbi Flax's diary. I wonder what the @dre@serum@dbl@ is used|@dbl@for?");
+        $text = append($text, "@dbl@I made @dre@serum 207@dbl@ from tarromin, water and ashes by|@dbl@using @dre@Herbi Flax's@dbl@ diary. I wonder what the @dre@serum@dbl@ is used|@dbl@for?");
     }
 }
 
@@ -111,7 +111,7 @@ if (%morttonquest = ^mortton_can_light_altar) {
 }
 
 if (%morttonquest = ^mortton_created_sacred_oil) {
-    $text = append($text, "@dre@Ulsquire@dbl@ said something about putting the @dre@Shades@dbl@ to rest by|@dbl@giving them a @dre@holy cremation@dbl@, maybe this @dre@oil@dbl@ can help?");
+    $text = append($text, "@dre@Ulsquire@dbl@ said something about putting the @dre@Shades@dbl@ to rest|@dbl@by giving them a @dre@holy cremation@dbl@, maybe this @dre@oil@dbl@ can help?");
 }
 
 if (%morttonquest = ^mortton_created_pyre_logs) {
@@ -130,7 +130,7 @@ if (%morttonquest = ^mortton_created_pyre_logs) {
 }
 
 if (%morttonquest = ^mortton_logs_on_pyre) {
-    $text = append($text, "@dbl@I need to put the @dre@shade remains@dbl@ on the @dre@funeral pyre@dbl@ and then|@dre@light@dbl@ it in order to put the@dre@ shade spirit@dbl@ to rest.");
+    $text = append($text, "@dbl@I need to put the @dre@shade remains@dbl@ on the @dre@funeral pyre@dbl@ and|@dbl@then @dre@light@dbl@ it in order to put the@dre@ shade spirit@dbl@ to rest.");
 }
 
 if (%morttonquest = ^mortton_lit_pyre) {

--- a/scripts/quests/quest_mortton/scripts/razmire_keelgan.rs2
+++ b/scripts/quests/quest_mortton/scripts/razmire_keelgan.rs2
@@ -1,70 +1,45 @@
 [opnpc3,razmire_keelgan]
-//todo does this happen here
 if (testbit(%morttonmulti, ^mortton_cured_razmire) = ^false & testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^false) {
     npc_changetype(razmire_keelgan_afflicted,200);
     @afflicted_talk;
 }
 if(%morttonquest >= ^mortton_shades_to_razmire) {
     @razmire_general_open;
-} //todo: mes at different stages before this?
+} else if(%morttonquest > ^mortton_kill_shades & %morttonquest < ^mortton_shades_to_razmire) {
+    @razmire_killed_shades;
+} else {
+    @razmire_stores_closed_general;
+}
 
 [opnpc4,razmire_keelgan]
-//todo does this happen here
 if (testbit(%morttonmulti, ^mortton_cured_razmire) = ^false & testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^false) {
     npc_changetype(razmire_keelgan_afflicted,200);
     @afflicted_talk;
 }
 if(%morttonquest >= ^mortton_shades_to_razmire) {
     @razmire_building_open;
-} //todo: mes at different stages before this?
-
-[opnpcu,razmire_keelgan]
-if(oc_category(last_useitem) = category_108) {
-    inv_setslot(inv, last_useslot, oc_param(last_useitem, next_obj_stage), 1);
-    if(%morttonquest < ^mortton_made_serum) {
-        npc_changetype(razmire_keelgan,1);
-        ~chatnpc("<p,confused>The serum it works...but it's not too fresh, make some|yourself and then it might work for longer.");
-        @afflicted_talk;
-    }
-    npc_changetype(razmire_keelgan,200);
-    longqueue(razmire_reset, 200, 0, ^accelerate);
-    %morttonmulti = setbit(%morttonmulti, ^mortton_cured_razmire);
-    if (testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^true) {
-        ~chatnpc("<p,happy>You've already used the permanent serum on me, you|don't need to use that any more.");
-    }
-    @razmire_talk;
-} else if(oc_category(last_useitem) = category_109) {
-    inv_setslot(inv, last_useslot, oc_param(last_useitem, next_obj_stage), 1);
-    npc_changetype(razmire_keelgan,200);
-    longqueue(razmire_reset, 200, 0, ^accelerate);
-    %morttonmulti = setbit(%morttonmulti, ^mortton_cured_razmire);
-    if (testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^true) {
-        ~chatnpc("<p,happy>You've already used the permanent serum on me, you|don't need to use that any more.");
-    } else {
-        %morttonmulti = setbit(%morttonmulti, ^mortton_cured_razmire);
-        queue(razmire_perm_serum_reward, 0, 0);
-        ~chatnpc("<p,happy>Well done - I feel this serum is really working on me.|I think you've cracked it, my friend! I'd like to give|you something for your trouble!");
-    }
-    @razmire_talk;
+} else if(%morttonquest > ^mortton_kill_shades & %morttonquest < ^mortton_shades_to_razmire) {
+    @razmire_killed_shades;
 } else {
-    ~displaymessage(^dm_default);
+    @razmire_stores_closed_builders;
 }
 
-[queue,razmire_perm_serum_reward]
-//Guess https://oldschool.runescape.wiki/w/Transcript:Ulsquire_Shauncy#Using_Serum_208_on_him
-def_int $count = ~random_range(180,220);
-inv_add(inv, coins, $count);
-~objbox(coins,"Razmire gives you <tostring($count)> gold coins.", 250, 0, 0);
+[opnpcu,razmire_keelgan]
+@razmire_use_item;
 
 [opnpcu,razmire_keelgan_afflicted]
+@razmire_use_item;
+
+[label,razmire_use_item]
 if(oc_category(last_useitem) = category_108) {
-    inv_setslot(inv, last_useslot, oc_param(last_useitem, next_obj_stage), 1);
     if(%morttonquest < ^mortton_made_serum) {
         npc_changetype(razmire_keelgan,1);
+        inv_setslot(inv, last_useslot, oc_param(last_useitem, next_obj_stage), 1);
         ~chatnpc("<p,confused>The serum it works...but it's not too fresh, make some|yourself and then it might work for longer.");
         @afflicted_talk;
     }
     npc_changetype(razmire_keelgan,200);
+    inv_setslot(inv, last_useslot, oc_param(last_useitem, next_obj_stage), 1);
     longqueue(razmire_reset, 200, 0, ^accelerate);
     %morttonmulti = setbit(%morttonmulti, ^mortton_cured_razmire);
     if (testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^true) {
@@ -72,16 +47,18 @@ if(oc_category(last_useitem) = category_108) {
     }
     @razmire_talk;
 } else if(oc_category(last_useitem) = category_109) {
-    inv_setslot(inv, last_useslot, oc_param(last_useitem, next_obj_stage), 1);
     npc_changetype(razmire_keelgan,200);
-    longqueue(razmire_reset, 200, 0, ^accelerate);
-    %morttonmulti = setbit(%morttonmulti, ^mortton_cured_razmire);
-    if (testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^true) {
-        ~chatnpc("<p,happy>You've already used the permanent serum on me, you|don't need to use that any more.");
-    } else {
-        %morttonmulti = setbit(%morttonmulti, ^mortton_cured_razmire);
-        queue(razmire_perm_serum_reward, 0, 0);
+    if (testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^false) {
+        def_int $last_useslot = last_useslot;
+        def_obj $last_useitem = last_useitem;
         ~chatnpc("<p,happy>Well done - I feel this serum is really working on me.|I think you've cracked it, my friend! I'd like to give|you something for your trouble!");
+        %morttonmulti = setbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire);
+        inv_setslot(inv, $last_useslot, oc_param($last_useitem, next_obj_stage), 1);
+        def_int $count = ~random_range(180,220);
+        inv_add(inv, coins, $count);
+        ~objbox(coins,"Razmire gives you <tostring($count)> gold coins.", 250, 0, 0);
+    } else {
+        ~chatnpc("<p,happy>You've already used the permanent serum on me, you|don't need to use that any more.");
     }
     @razmire_talk;
 } else {
@@ -136,19 +113,19 @@ if(%morttonquest < ^mortton_kill_shades) {
 } else if(%morttonquest >= ^mortton_shades_to_razmire & %morttonquest <= ^mortton_ulsquire_temple) {
     ~chatnpc("<p,happy>Hello again...what can I do for you now?");
     @razmire_store_selection;
-} else if(%morttonquest >= ^mortton_rebuild_temple & %morttonquest <= ^mortton_can_light_altar) {
+} else if(%morttonquest = ^mortton_rebuild_temple) {
     ~chatplayer("<p,neutral>Hello there, I've started repairing the temple.");
     ~chatnpc("<p,happy>That's great, carry on the good work.");
     @razmire_questions_post_rebuild;
-} else if(%morttonquest >= ^mortton_created_sacred_oil & %morttonquest <= ^mortton_logs_on_pyre) {
-    @razmire_store_selection_post_oil;
+} else if(%morttonquest >= ^mortton_can_light_altar & %morttonquest <= ^mortton_logs_on_pyre) {
+    @razmire_store_post_oil;
 } else if(%morttonquest >= ^mortton_lit_pyre) {
     if (testbit(%morttonmulti, ^mortton_unlocked_shade_lair) = ^false) {
         ~chatplayer("<p,neutral>Hey, I've laid a Shade to rest, can you tell me where|the Shade lair is now?");
         %morttonmulti = setbit(%morttonmulti, ^mortton_unlocked_shade_lair);
         ~chatnpc("<p,neutral>Yeah, great job on putting that Shade to rest. The|entrance to the Shade Lair is due North of my shop.|Good hunting in the lair my friend!");
     }
-    @razmire_store_selection_post_oil;
+    @razmire_store_post_oil;
 }
 
 [label,razmire_questions_post_rebuild]
@@ -177,7 +154,7 @@ if(%morttonquest < ^mortton_kill_shades) {
 ~chatnpc("<p,neutral>My name is Razmire Keelgan, I run a couple of shops|in Mort'ton but don't get much custom these days.");
 ~chatplayer("<p,neutral>Which stores do you run?");
 ~chatnpc("<p,neutral>I run a general store with a few useful items, and I|have a building supplies store, I'm hoping that when|things get better down here, people will want to buy|items to repair their buildings.");
-@multi3("Can I see your general store please", razmire_stores_closed, "Can I see your build supplies store please", razmire_stores_closed, "I have other questions for you.", razmire_questions);
+@multi3("Can I see your general store please", razmire_stores_closed_general, "Can I see your build supplies store please", razmire_stores_closed_builders, "I have other questions for you.", razmire_questions);
 
 [label,razmire_place]
 ~chatplayer("<p,neutral>What is this place?");
@@ -211,7 +188,12 @@ if(%morttonquest < ^mortton_kill_shades) {
 ~chatnpc("<p,neutral>Life is a daily struggle with those Shades around here.|They attack when you least expect it...it's terrifying! I|tell you what, if you kill five of those Shades I'll see if I|can help you out! Is it a deal?");
 @multi3_header("Yes, I'll dispatch those dark and evil creatures.", razmire_yes, "Sorry, not right now, I need to do something else first.", razmire_not_now, "I have another question.", razmire_questions,"Kill five Shades?");
 
-[label,razmire_stores_closed]
+[label,razmire_stores_closed_general]
+~chatnpc("<p,neutral>Well to be honest, all of my stock is packed away right|now seeing as the town is all overrun with these Shades.|I tell you what. You put an end to five Shades for me|and I'll open the store for you!");
+~chatnpc("<p,neutral>I have details on that dilapidated temple to the North.|These shades have a purpose - they jealously guard|their burial treasure! If you can do me some favours, I|could help you to locate it!");
+@multi3_header("Yes, I'll dispatch those dark and evil creatures.", razmire_yes, "Sorry, not right now, I need to do something else first.", razmire_not_now, "I have another question.", razmire_questions,"Kill five Shades?");
+
+[label,razmire_stores_closed_builders]
 ~chatnpc("<p,neutral>Well to be honest, all of my stock is packed away right|now seeing as the town is all overrun with these Shades.|I tell you what. You put an end to five Shades for me|and I'll open the store for you!");
 ~chatnpc("<p,neutral>I have details on that dilapidated temple to the North.|These shades have a purpose - they jealously guard|their burial treasure! If you can do me some favours, I|could help you to locate it!");
 @multi2_header("Yes, I'll dispatch those dark and evil creatures.", razmire_yes, "Sorry, not right now, I need to do something else first.", razmire_not_now, "Kill five Shades for Razmire?");
@@ -262,6 +244,11 @@ if(%morttonquest < ^mortton_kill_shades) {
 
 [label,razmire_thanks]
 ~chatplayer("<p,neutral>Ok, thanks");
+
+[label,razmire_killed_shades]
+~chatnpc("<p,neutral>Have you killed those Shades yet?");
+~chatplayer("<p,neutral>No, sorry, not yet.");
+~chatnpc("<p,neutral>Well, come back when you have.");
 
 //osrs uses razmire as an npc controller, 
 //confirmed because if he changes types then the timer cadence changes too

--- a/scripts/quests/quest_mortton/scripts/ulsquire_shauncy.rs2
+++ b/scripts/quests/quest_mortton/scripts/ulsquire_shauncy.rs2
@@ -1,36 +1,10 @@
 [opnpcu,ulsquire_shauncy]
-if(oc_category(last_useitem) = category_108) {
-    inv_setslot(inv, last_useslot, oc_param(last_useitem, next_obj_stage), 1);
-    if(%morttonquest < ^mortton_made_serum) {
-        npc_changetype(ulsquire_shauncy,1);
-        ~chatnpc("<p,confused>The serum it works...but it's not too fresh, make some|yourself and then it might work for longer.");
-        @afflicted_talk;
-    }
-    npc_changetype(ulsquire_shauncy,200);
-    longqueue(ulsquire_reset, 200, 0, ^accelerate);
-    %morttonmulti = setbit(%morttonmulti, ^mortton_cured_ulsquire);
-    if (testbit(%morttonmulti, ^mortton_used_perm_serum_on_ulsquire) = ^true) {
-        ~chatnpc("<p,happy>You've already used the permanent serum on me, you|don't need to use that any more.");
-    }
-    @ulsquire_talk;
-} else if(oc_category(last_useitem) = category_109) {
-    inv_setslot(inv, last_useslot, oc_param(last_useitem, next_obj_stage), 1);
-    npc_changetype(ulsquire_shauncy,200);
-    longqueue(ulsquire_reset, 200, 0, ^accelerate);
-    %morttonmulti = setbit(%morttonmulti, ^mortton_cured_ulsquire);
-    if (testbit(%morttonmulti, ^mortton_used_perm_serum_on_ulsquire) = ^true) {
-        ~chatnpc("<p,happy>You've already used the permanent serum on me, you|don't need to use that any more.");
-    } else {
-        %morttonmulti = setbit(%morttonmulti, ^mortton_cured_ulsquire);
-        queue(ulsquire_perm_serum_reward, 0, 0);
-        ~chatnpc("<p,happy>Well done - I feel this serum is really working on me.|I think you've cracked it, my friend! I'd like to give|you something for your trouble!");
-    }
-    @ulsquire_talk;
-} else {
-    ~displaymessage(^dm_default);
-}
+@ulsquire_use_item;
 
 [opnpcu,ulsquire_shauncy_afflicted]
+@ulsquire_use_item;
+
+[label,ulsquire_use_item]
 if(oc_category(last_useitem) = category_108) {
     inv_setslot(inv, last_useslot, oc_param(last_useitem, next_obj_stage), 1);
     if(%morttonquest < ^mortton_made_serum) {
@@ -46,27 +20,25 @@ if(oc_category(last_useitem) = category_108) {
     }
     @ulsquire_talk;
 } else if(oc_category(last_useitem) = category_109) {
-    inv_setslot(inv, last_useslot, oc_param(last_useitem, next_obj_stage), 1);
     npc_changetype(ulsquire_shauncy,200);
-    longqueue(ulsquire_reset, 200, 0, ^accelerate);
-    %morttonmulti = setbit(%morttonmulti, ^mortton_cured_ulsquire);
     if (testbit(%morttonmulti, ^mortton_used_perm_serum_on_ulsquire) = ^true) {
         ~chatnpc("<p,happy>You've already used the permanent serum on me, you|don't need to use that any more.");
+        return;
     } else {
-        %morttonmulti = setbit(%morttonmulti, ^mortton_cured_ulsquire);
-        queue(ulsquire_perm_serum_reward, 0, 0);
+        def_int $last_useslot = last_useslot;
+        def_obj $last_useitem = last_useitem;
         ~chatnpc("<p,happy>Well done - I feel this serum is really working on me.|I think you've cracked it, my friend! I'd like to give|you something for your trouble!");
+        %morttonmulti = setbit(%morttonmulti, ^mortton_used_perm_serum_on_ulsquire);
+        inv_setslot(inv, $last_useslot, oc_param($last_useitem, next_obj_stage), 1);
+        //Guess https://oldschool.runescape.wiki/w/Transcript:Ulsquire_Shauncy#Using_Serum_208_on_him
+        def_int $count = ~random_range(180,220);
+        inv_add(inv, coins, $count);
+        ~objbox(coins,"Ulsquire gives you <tostring($count)> gold coins.", 250, 0, 0);
     }
     @ulsquire_talk;
 } else {
     ~displaymessage(^dm_default);
 }
-
-[queue,ulsquire_perm_serum_reward]
-//Guess https://oldschool.runescape.wiki/w/Transcript:Ulsquire_Shauncy#Using_Serum_208_on_him
-def_int $count = ~random_range(180,220);
-inv_add(inv, coins, $count);
-~objbox(coins,"Ulsquire gives you <tostring($count)> gold coins.", 250, 0, 0);
 
 [queue,ulsquire_reset]
 %morttonmulti = clearbit(%morttonmulti, ^mortton_cured_ulsquire);
@@ -101,11 +73,12 @@ if(%morttonquest < ^mortton_kill_shades) {
 } else if(%morttonquest = ^mortton_shades_to_razmire) {
     ~chatplayer("<p,neutral>Razmire said to come and talk to you.");
     ~chatnpc("<p,sad>Oh yes, well, that's very nice.");
-    ~chatplayer("<p,neutral>I just slayed 5 shades for Razmire, he said you might|be interested in seeing some shade remains?");
     if(inv_total(inv, shade_bones1) < 1) {
+        ~chatplayer("<p,neutral>I just slayed five shades for Razmire. He said that you|might be interested in seeing the shade remains.|Unfortunately I don't have any with me at the|moment...");
         ~chatnpc("<p,sad>That is a shame, I would have liked to have seen the|remains. Razmire was right. I'm keen to study them|and perhaps see if I can work out a way to put their|spirits to rest.");
         return;
     } else {
+        ~chatplayer("<p,neutral>I just slayed 5 shades for Razmire, he said you might|be interested in seeing some shade remains?");
         ~chatnpc("<p,neutral>Oh yes, that would be interesting!");
         inv_del(inv, shade_bones1, 1);
         %morttonquest = ^mortton_shades_to_ulsquire;
@@ -152,8 +125,7 @@ if(%morttonquest < ^mortton_kill_shades) {
 [label,ulsquire_temple_built]
 ~chatplayer("<p,neutral>What should I do when the temple is built?");
 ~chatnpc("<p,neutral>I've researched this much, it seems that the temple was|dedicated to the worship of elemental flame or fire. The|sacred flame was said to be very holy and was used|somehow to sanctify oil for use in cremations.");
-if (testbit(%morttonmulti, ^mortton_shades_dampe_intro) = ^false) {
-    //todo: Special dialogue if inv is full?
+if (testbit(%morttonmulti, ^mortton_shades_dampe_intro) = ^false & inv_freespace(inv) ! 0) {
     ~chatnpc("<p,neutral>The pagans believed that sacred oil sanctified the|cremation ceremony and thus helped the deceased pass|onto the next life, and it helped the logs to burn! In|case there's any truth in the story, have this!");
     %morttonmulti = setbit(%morttonmulti, ^mortton_shades_dampe_intro);
     inv_add(inv, oliveoil3, 1);

--- a/scripts/skill_herblore/scripts/brewing/brew_potion.rs2
+++ b/scripts/skill_herblore/scripts/brewing/brew_potion.rs2
@@ -103,7 +103,7 @@ if (map_members = ^false) {
     return(false);
 }
 
-if($struct = ashesvial & %morttonquest < ^mortton_read_diary) {
+if(($struct = ashesvial | $struct = mort_serum3_tarrominvial | $struct = mort_serum3_ashesvial) & %morttonquest < ^mortton_read_diary) {
     mes("You're not sure what effect this might have.");
     return(false);
 }

--- a/scripts/skill_herblore/scripts/brewing/brew_potion.rs2
+++ b/scripts/skill_herblore/scripts/brewing/brew_potion.rs2
@@ -103,6 +103,11 @@ if (map_members = ^false) {
     return(false);
 }
 
+if($struct = ashesvial & %morttonquest < ^mortton_read_diary) {
+    mes("You're not sure what effect this might have.");
+    return(false);
+}
+
 if($struct = ardrigal_mixture & %legendsquest < ^legends_talk_gujuo_pool) {
     mes("You're not really sure what you would make out of this.");
     return(false);


### PR DESCRIPTION
Requires https://github.com/LostCityRS/Engine-TS/pull/87

Some additional changes and small fixes for shades of mort'ton & general area

Still some remaining todos for this:

- Shade collision isn't as expected? From all sources I found they should be able to walk on blocked tiles such as water, but still respect locs that block and other npcs and player collision. We don't support this currently.
- More authentic shade swarming the temple when building, and fixing the logic for them attacking it
- More accurate success rates and experience drops for building the temple, just placeholders for now
- Catacomb shade combat logic. (Basically the same as loar shades but you can't safespot them. They quickly transform back and regen health on changetype)
- Pass on shade combat logic in general and make sure it matches Osrs. Seems pretty close atm but it's also ugly currently.. 