### PR TITLE
fix: double death bug at duel arena

### DIFF
--- a/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
+++ b/scripts/minigames/game_duelarena/scripts/duel_arena_finish.rs2
@@ -3,6 +3,7 @@ if (~in_duel_arena(coord) = true & %duelstatus < ^duelstatus_lost) {
     %duelstatus = ^duelstatus_lost;
     ~player_death;
 
+    ~combat_clearqueue;
     clearqueue(duel_finish);
     queue(duel_finish, 0, 0);
 


### PR DESCRIPTION
For 225+

How to recreate:
- Take damage to 0 hp
- Eat food next tick (same tick as death)
- Take poison damage (same tick as death)

Fixed by adding `combat_clearqueue` to `player_death_duel` label... But I think its due a rewrite at some point. The `duel_finish` queue was coded to try to reproduce the double `Oh dear you are dead!` mes authentic bug, but Im starting to think thats not how the double mes bug worked - need to figure this out sometime.

Before:

https://github.com/user-attachments/assets/edaf0823-6bf0-42e2-9b80-5b86da0d1906


After:

https://github.com/user-attachments/assets/72d35eee-a584-403a-b89a-db4f70a98cf6

