### PR TITLE
fix: Spelling error when drinking some alcohol drinks - 225+

### DIFF
--- a/scripts/player/configs/consumption/consume_messages.dbrow
+++ b/scripts/player/configs/consumption/consume_messages.dbrow
@@ -160,28 +160,28 @@ data=message_delay,2
 [vodka_consume_messages]
 table=consume_messages_table
 data=consumable,vodka
-data=consume_message1,You drink the vodka. You feel slighlty reinvigorated...
+data=consume_message1,You drink the vodka. You feel slightly reinvigorated...
 data=consume_message2,...and slightly dizzy too.
 data=restore_message2,0
 
 [whisky_consume_messages]
 table=consume_messages_table
 data=consumable,whisky
-data=consume_message1,You drink the whisky. You feel slighlty reinvigorated...
+data=consume_message1,You drink the whisky. You feel slightly reinvigorated...
 data=consume_message2,...and slightly dizzy too.
 data=restore_message2,0
 
 [gin_consume_messages]
 table=consume_messages_table
 data=consumable,gin
-data=consume_message1,You drink the gin. You feel slighlty reinvigorated...
+data=consume_message1,You drink the gin. You feel slightly reinvigorated...
 data=consume_message2,...and slightly dizzy too.
 data=restore_message2,0
 
 [brandy_consume_messages]
 table=consume_messages_table
 data=consumable,brandy
-data=consume_message1,You drink the brandy. You feel slighlty reinvigorated...
+data=consume_message1,You drink the brandy. You feel slightly reinvigorated...
 data=consume_message2,...and slightly dizzy too.
 data=restore_message2,0
 
@@ -198,7 +198,7 @@ data=consumable,chocolate_saturday
 data=consumable,sgg
 data=consumable,drunk_dragon
 data=consume_message1,"You drink the cocktail. It tastes great,"
-data=consume_message2,although you feel slighlty dizzy.
+data=consume_message2,although you feel slightly dizzy.
 data=restore_message2,0
 
 [cocktail2_consume_messages]


### PR DESCRIPTION
For 225+

Doesn't look like this is an intentional spelling error, as I can't find any comments in the codebase.
[RSC Wiki](https://runescapeclassic.fandom.com/wiki/Dragon_bitter) shows correct spelling, too.