### PR TITLE
fix: Some Eadgar's Ruse fixes

### DIFF
--- a/scripts/general/scripts/quests.rs2
+++ b/scripts/general/scripts/quests.rs2
@@ -320,6 +320,7 @@ if (testbit(%ibanmulti, ^upass_started_bit) = ^true & %upass ! ^upass_complete) 
 ~send_quest_progress_colour(questlist:regicide, %regicide_quest, ^regicide_complete);
 ~send_quest_progress_colour(questlist:viking, %viking, ^viking_complete);
 ~send_quest_progress_colour(questlist:horror, %horrorquest, ^horror_complete);
+~send_quest_progress_colour(questlist:eadgar, %eadgar_quest, ^eadgar_complete);
 if_settab(questlist, ^tab_quest_journal);
 
 if (%drunkmonkquest >= ^drunkmonk_spoken_to_omad) {

--- a/scripts/quests/quest_eadgar/scripts/eadgar_journal.rs2
+++ b/scripts/quests/quest_eadgar/scripts/eadgar_journal.rs2
@@ -148,7 +148,7 @@ if($quest_progress >= ^eadgar_unlocked_storeroom) {
 
 if($quest_progress = ^eadgar_complete) {
     // from my run of the quest in OSRS (RS3 is the same aside from linebreaks)
-    $prev_text = append($prev_text, "|@str@I snuck into the storeroom and got some goutweed. I gave it to|@str@Sanfew and he taught me the Trollheim Teleport spell.");
+    $prev_text = append($prev_text, "|@str@I snuck into the storeroom and got some goutweed. I gave|@str@ it to Sanfew and he taught me the Trollheim Teleport spell.");
     $new_text = append($prev_text, "||@dre@QUEST COMPLETE!");
 }
 

--- a/scripts/quests/quest_eadgar/scripts/eadgar_troll_chief_cook.rs2
+++ b/scripts/quests/quest_eadgar/scripts/eadgar_troll_chief_cook.rs2
@@ -1,5 +1,15 @@
 /* Moved to the Eadgar's Ruse directory in 274 since this is Burntmeat's first quest-related appearance */
 [opnpc1,eadgar_troll_chief_cook]
+@eadgar_talk_to_troll_cook;
+
+[opnpcu,eadgar_troll_chief_cook]
+if (last_useitem = eadgar_fake_man) {
+    @eadgar_talk_to_troll_cook;
+} else {
+    ~displaymessage(^dm_default);
+}
+
+[label,eadgar_talk_to_troll_cook]
 if(%eadgar_quest > ^eadgar_spoken_eadgar_first & %eadgar_quest < ^eadgar_got_fake_man) {
     // rsprox/branon
     ~chatnpc("<p,neutral>Did you find tasty human?");

--- a/scripts/quests/quest_eadgar/scripts/quest_eadgar.rs2
+++ b/scripts/quests/quest_eadgar/scripts/quest_eadgar.rs2
@@ -487,6 +487,7 @@ if(npc_find(0_44_157_41_27, eadgar_storeroom_guard, 4, 0) = true) {
     // guess based on osrs videos, it's pretty centered vertically but looks scaled down slightly
     // todo change to match https://web.archive.org/web/20051025140652im_/http://www.runeweb.net/fireball/Eadgars%20Ruse%20Images/Eadgar18.PNG
     ~objbox(eadgar_goutweed_herb, "You've found some goutweed!", 225, 0, calc(^objbox_height / 4));
+    if_close;
     inv_add(inv, eadgar_goutweed_herb, 1); // what happens if inv is full?
     npc_say("Hm?");
     npc_facesquare(coord);

--- a/scripts/skill_combat/configs/magic/spells.constant
+++ b/scripts/skill_combat/configs/magic/spells.constant
@@ -54,7 +54,7 @@
 ^charge = 40
 ^ardougne_teleport = 49
 ^lumbridge_teleport = 50
-^trollheim_teleport = 51
+^trollheim_teleport = 52
 
 // npc spells
 ^skeleton_mage_attack = 100


### PR DESCRIPTION
- Ensure quest list progress updates on login.
- Ensure you can use the Fake Man on Burntmeat as per https://youtu.be/945tUgBj3SM?si=wSyuOfEMn6axABI-&t=912
- Close interfaces upon gaining goutweed.
- Journal no longer starts a new line without strikethrough in Quest Complete stage.
- Fix Trollheim Teleport trying to cast Wind Strike.