### PR TITLE
fix: spelling error on Ardougne teleport without Watchtower complete (225+)

### DIFF
--- a/scripts/quests/quest_waterfall/scripts/quest_waterfall.rs2
+++ b/scripts/quests/quest_waterfall/scripts/quest_waterfall.rs2
@@ -250,7 +250,7 @@ p_delay(1);
 mes("and let your self down on to the ledge.");
 p_teleport(0_39_54_15_7);
 
-[oploc1,waterfall_ledge_door] // basing this off RS3, seems like RS3 mechanics for this havn't changed
+[oploc1,waterfall_ledge_door] // basing this off RS3, seems like RS3 mechanics for this haven't changed
 mes("The door begins to open.");
 p_delay(2);
 if(inv_total(worn, glarials_amulet_waterfall_quest) > 0 | inv_total(inv, glarials_amulet_waterfall_quest) > 0) {

--- a/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -33,7 +33,7 @@ if (p_finduid(uid) = true) {
     }  
     // https://www.reddit.com/r/2007scape/comments/b4vdki/watchtower_teleport_not_working_despite/, https://runescape.salmoneus.net/forums/topic/212538-cant-do-ardougne-tele-why-is-it-so/
     if(($spell = ^ardougne_teleport & %elenaquest < ^elena_complete_read_scroll) | ($spell = ^watchtower_teleport & %itwatchtower < ^itwatchtower_complete_read_scroll)) {
-        mes("You havn't learnt how to cast this spell yet.");
+        mes("You haven't learnt how to cast this spell yet.");
         return;
     }  
     if (~pre_tele_checks(coord) = false) {


### PR DESCRIPTION
For 225+

Corrected `You *havn't* learnt how to cast this spell yet.` to `You *haven't* learnt how to cast this spell yet.`