### PR TITLE
fix: ladder fairy check, gujuo opu bug, typo when teleing with ana

### DIFF
--- a/scripts/areas/area_lostcity/scripts/ladder_fairy.rs2
+++ b/scripts/areas/area_lostcity/scripts/ladder_fairy.rs2
@@ -1,7 +1,7 @@
 [opnpc1,fairy_ladder_attendant] @fairy_ladder_attendant_talk;
 
 [oploc1,zanarisladderout]
-if (npc_findexact(0_50_149_54_54, fairy_ladder_attendant) = true) {
+if (npc_findexact(0_50_149_53_54, fairy_ladder_attendant) = true) {
     @fairy_ladder_attendant_talk;
 }
 

--- a/scripts/quests/quest_legends/scripts/gujuo.rs2
+++ b/scripts/quests/quest_legends/scripts/gujuo.rs2
@@ -21,9 +21,8 @@ switch_obj(last_useitem) {
         def_int $choice = ~p_choice2("Yes, I'd like to bless my gold bowl.", 1, "No thanks, I'll wait.", 2);
         if ($choice = 1) {
             ~chatplayer("<p,neutral>Yes, I'd like to bless my gold bowl.");
-            @gujuo_start;
-        }
-        else {
+            @gujuo_bless_bowl;
+        } else {
             ~chatplayer("<p,neutral>No thanks, I'll wait.");
             ~chatnpc("<p,neutral>Very well, let me know when you want to try.");
             @gujuo_how_goes_ungadulu;

--- a/scripts/skill_magic/scripts/spells/teleport.rs2
+++ b/scripts/skill_magic/scripts/spells/teleport.rs2
@@ -89,7 +89,7 @@ if(inv_total(inv, plaguesample) > 0) {
 [proc,tele_checks]()
 if(inv_total(inv, thanainabarrel) > 0) {
     inv_del(inv, thanainabarrel, ^max_32bit_int);
-    mes("Your drop 'Ana in a barrel' before you teleport.");
+    mes("You drop 'Ana in a barrel' before you teleport.");
 }
 
 [proc,pre_tele_checks](coord $coord)(boolean)


### PR DESCRIPTION
for 225+

- update npc_findexact coord for ladder fairy to match its new spawn coordinate
- fix calling the wrong label when going through the golden bowl bless dialogue with gujuo
- fix typo when teleporting with ana in a barrel