### PR TITLE
feat: Add the commands for date

### DIFF
--- a/scripts/engine.rs2
+++ b/scripts/engine.rs2
@@ -1024,6 +1024,10 @@
 [command,atan2_deg](int $x, int $y)(int)
 // info: Get the absolute value of a number
 [command,abs](int $num)(int)
+// info: Get number of minutes elapsed since Unix epoch (Jan 1, 1970)
+[command,date_minutes]()(int)
+// info: Get 'runeday': number of days since membership started (Feb 27, 2002)
+[command,date_runeday]()(int)
 
 // DB ops (7500-7599)
 // info: dynamic arg (indexed key)


### PR DESCRIPTION
Adds 
// info: Get number of minutes elapsed since Unix epoch (Jan 1, 1970)
[command,date_minutes]()(int)
// info: Get 'runeday': number of days since membership started (Feb 27, 2002)
[command,date_runeday]()(int)