### PR TITLE
[WIP] feat:Werewolf Agility Course & Werewolf Skullball

### DIFF
--- a/scripts/_test/scripts/debug/debug_werewolf_agility.rs2
+++ b/scripts/_test/scripts/debug/debug_werewolf_agility.rs2
@@ -1,0 +1,5 @@
+
+[debugproc,waareset]
+if (p_finduid(uid) = true) {
+    p_telejump(0_55_154_18_17);
+}

--- a/scripts/_test/scripts/debug/debug_werewolf_agility.rs2
+++ b/scripts/_test/scripts/debug/debug_werewolf_agility.rs2
@@ -3,3 +3,8 @@
 if (p_finduid(uid) = true) {
     p_telejump(0_55_154_18_17);
 }
+
+[debugproc,waazipline]
+if (p_finduid(uid) = true) {
+    p_telejump(0_55_154_8_54);
+}

--- a/scripts/_unpack/377/all.npc
+++ b/scripts/_unpack/377/all.npc
@@ -36949,6 +36949,8 @@ op4=Shoot
 op5=Show-Goal
 vislevel=hide
 ambient=20
+wanderrange=0
+moverestrict=nomove
 
 [werewolf_skullballboss]
 name=Skullball Boss
@@ -36969,6 +36971,8 @@ readyanim=werewolf_ready
 op1=Talk-To
 vislevel=hide
 head1=npc_1660_head
+wanderrange=0
+moverestrict=nomove
 
 [werewolf_trainer_start]
 name=Agility Boss
@@ -36990,6 +36994,8 @@ readyanim=werewolf_ready
 vislevel=hide
 op1=Talk-To
 head1=npc_1660_head
+wanderrange=0
+moverestrict=nomove
 
 [werewolf_trainer_1]
 name=Skullball Trainer
@@ -37069,6 +37075,8 @@ readyanim=werewolf_ready
 vislevel=hide
 op1=Talk-To
 head1=npc_1660_head
+wanderrange=0
+moverestrict=nomove
 
 [fenk_gardener_multi]
 walkanim=human_walk_f,human_walk_b,human_walk_l,human_walk_r

--- a/scripts/_unpack/377/all.varp
+++ b/scripts/_unpack/377/all.varp
@@ -644,6 +644,8 @@ scope=perm
 [varp_397]
 
 [varp_398]
+type=npc_uid
+scope=temp
 
 [fenk_quest]
 transmit=yes

--- a/scripts/minigames/game_werewolf_agility/scripts/agility_boss.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/agility_boss.rs2
@@ -1,0 +1,16 @@
+[opnpc1,werewolf_trainer_start]
+if (inv_total(worn, ring_of_charos) = 1 | inv_total(worn, ring_of_charos_unlocked) = 1) {
+    @werewolf_trainer_ask_course;
+} else {
+    @werewolf_trainer_human;
+}
+
+[label,werewolf_trainer_ask_course]
+~chatplayer("<p,confused>How do I use the agility course?");
+~chatnpc("<p,neutral>I'll throw you a stick, which you need to|fetch as quickly as possible, |from the area beyond the pipes.");
+~chatnpc("<p,neutral>Be wary of the deathslide - you must hang by your teeth,|and if your strength is not up to the job you will|fall into a pit of spikes. Also, I would advise not|carrying too much extra weight.");
+~chatnpc("<p,neutral>Bring the stick back to the werewolf waiting at|the end of the death slide to get your agility bonus.");
+~chatnpc("<p,neutral>I will throw your stick as soon as you jump onto the|first stone.");
+
+[label,werewolf_trainer_human]
+~chatnpc("<p,neutral>Grrr - you don't belong in here, human!");

--- a/scripts/minigames/game_werewolf_agility/scripts/agility_boss.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/agility_boss.rs2
@@ -7,10 +7,10 @@ if (inv_total(worn, ring_of_charos) = 1 | inv_total(worn, ring_of_charos_unlocke
 
 [label,werewolf_trainer_ask_course]
 ~chatplayer("<p,confused>How do I use the agility course?");
-~chatnpc("<p,neutral>I'll throw you a stick, which you need to|fetch as quickly as possible, |from the area beyond the pipes.");
-~chatnpc("<p,neutral>Be wary of the deathslide - you must hang by your teeth,|and if your strength is not up to the job you will|fall into a pit of spikes. Also, I would advise not|carrying too much extra weight.");
-~chatnpc("<p,neutral>Bring the stick back to the werewolf waiting at|the end of the death slide to get your agility bonus.");
-~chatnpc("<p,neutral>I will throw your stick as soon as you jump onto the|first stone.");
+~chatnpc("<p,shifty>I'll throw you a stick, which you need to|fetch as quickly as possible, |from the area beyond the pipes.");
+~chatnpc("<p,shifty>Be wary of the deathslide - you must hang by your teeth,|and if your strength is not up to the job you will|fall into a pit of spikes. Also, I would advise not|carrying too much extra weight.");
+~chatnpc("<p,shifty>Bring the stick back to the werewolf waiting at|the end of the death slide to get your agility bonus.");
+~chatnpc("<p,shifty>I will throw your stick as soon as you jump onto the|first stone.");
 
 [label,werewolf_trainer_human]
-~chatnpc("<p,neutral>Grrr - you don't belong in here, human!");
+~chatnpc("<p,shifty>Grrr - you don't belong in here, human!");

--- a/scripts/minigames/game_werewolf_agility/scripts/agility_trainer.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/agility_trainer.rs2
@@ -1,0 +1,13 @@
+[opnpc1,werewolf_trainer_stick]
+if (inv_total(inv, waa_stick) >= 1 ) {
+    inv_del(inv, waa_stick, 1);
+    stat_advance(agility, 190);
+    mes("You give the stick to the werewolf.");
+} else {
+    ~chatnpc("<p,shifty>Have you brought the stick yet?");
+    ~chatplayer("<p,confused>What stick?");
+    ~chatnpc("<p,shifty>Come on, get round that course - I need something to chew!");
+}
+
+[opnpcu,werewolf_trainer_stick]
+// No idea if this is also the same.

--- a/scripts/minigames/game_werewolf_agility/scripts/skullball_boss.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/skullball_boss.rs2
@@ -1,0 +1,58 @@
+[opnpc1,werewolf_skullballboss]
+if (inv_total(worn, ring_of_charos) = 1 | inv_total(worn, ring_of_charos_unlocked) = 1) {
+    @skullballinprogress;
+    // if (%skullball_instance = 1) {
+    //     @skullballinprogress;
+    // } else {
+    //     @noskullball;
+    // }
+} else {
+    @ishuman;
+}
+
+[label,ishuman]
+~chatnpc("<p,shifty>Grrr - you don't belong in here, human!");
+
+[label,skullballinprogress]
+@multi3(
+    "What are the instructions for using the skullball course?", explainskullball, 
+    "I seem to have lost my ball - can I have another one?", lostskullball, 
+    "I give up, I can't do it - take my ball away.", clearskullball
+);
+
+[label,noskullball]
+@multi2(
+    "I would like to do the skullball course.", checkskullball, 
+    "What are the instructions for using the skullball course?", explainskullball
+);
+
+[label,checkskullball]
+~chatplayer("<p,neutral>I would like to do the skullball course.");
+if (stat(agility) < 25) {
+    @requirementnotmet;
+} else {
+    @startskullball;
+}
+
+[label,requirementnotmet]
+~mesbox("You need an Agility level of at least 25 to do this.");
+
+[label,startskullball]
+// ~skullball_startcourse;
+
+[label,lostskullball]
+~chatplayer("<p,confused>I seem to have lost my ball - can I have another one?");
+~chatnpc("<p,shifty>No problem, here's another one. You'll have to start from the beginning again, but the timer will be restarted too.");
+// ~skullball_startcourse;
+
+[label,clearskullball]
+~chatplayer("<p,neutral>I give up, I can't do it - take my ball away.");
+~chatnpc("<p,shifty>Oh dear, such a defeatist.");
+// ~skullball_startcourse;
+
+[label,explainskullball]
+~chatplayer("<p,confused>What are the instructions for using the skullball course?");
+~chatnpc("<p,shifty>The skullball comes out of one of these four spawnholes. Just kick the ball through the middle of each goal, through the skeleton's feet.");
+~chatnpc("<p,shifty>There are 10 goals, which you must complete in order, and one final goal.");
+~chatnpc("<p,shifty>An arrow will point to your ball, just in case lots of people are using the course at the same time as yourself.");
+~chatnpc("<p,shifty>The better your time, the more agility XP you will be awarded. The timer starts when you score your first goal.");

--- a/scripts/minigames/game_werewolf_agility/scripts/skullball_boss.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/skullball_boss.rs2
@@ -1,11 +1,12 @@
+// https://youtu.be/4q9XA9QXxEM <-- Shows that skullball boss doesn't turn to look at you while you talk to him for the ball.
 [opnpc1,werewolf_skullballboss]
 if (inv_total(worn, ring_of_charos) = 1 | inv_total(worn, ring_of_charos_unlocked) = 1) {
-    @skullballinprogress;
-    // if (%skullball_instance = 1) {
-    //     @skullballinprogress;
-    // } else {
-    //     @noskullball;
-    // }
+    // @skullballinprogress;
+    if (npc_finduid(%varp_398) = true) { // varp_398 is guessed and temp stores ball npc uid.
+        @skullballinprogress;
+    } else {
+        @noskullball;
+    }
 } else {
     @ishuman;
 }
@@ -38,12 +39,12 @@ if (stat(agility) < 25) {
 ~mesbox("You need an Agility level of at least 25 to do this.");
 
 [label,startskullball]
-// ~skullball_startcourse;
+~skullball_startcourse;
 
 [label,lostskullball]
 ~chatplayer("<p,confused>I seem to have lost my ball - can I have another one?");
 ~chatnpc("<p,shifty>No problem, here's another one. You'll have to start from the beginning again, but the timer will be restarted too.");
-// ~skullball_startcourse;
+~skullball_startcourse;
 
 [label,clearskullball]
 ~chatplayer("<p,neutral>I give up, I can't do it - take my ball away.");

--- a/scripts/minigames/game_werewolf_agility/scripts/skullball_trainer.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/skullball_trainer.rs2
@@ -1,0 +1,33 @@
+[opnpc1,werewolf_trainer_1]
+if (inv_total(worn, ring_of_charos) = 1 | inv_total(worn, ring_of_charos_unlocked) = 1) {
+    @skullball_trainer_skullballinprogress;
+    // if (%skullball_instance = 1) {
+    //     @skullball_trainer_skullballinprogress;
+    // } else {
+    //     @skullball_trainer_noskullball;
+    // }
+} else {
+    @skullball_trainer_ishuman;
+}
+
+[label,skullball_trainer_ishuman]
+~chatnpc("<p,shifty>Grrr - you don't belong in here, human!");
+
+[label,skullball_trainer_noskullball]
+~chatplayer("<p,confused>What is this place?");
+~chatnpc("<p,neutral>This is the Skullball Course");
+~chatnpc("<p,neutral>Go talk to the boss at the beginning of the course if you'd like a go.");
+
+[label,skullball_trainer_skullballinprogress]
+~chatplayer("<p,confused>How many goals have I got left?");
+// if (%skullball_currentgoal = 10) {
+//     @finalgoal;
+// } else {
+//     @xgoals;
+// }
+
+[label,xgoals]
+~chatnpc("<p,neutral>You have [10 - %skullball_currentgoal] goals left to complete.");
+
+[label,finalgoal]
+~chatnpc("<p,neutral>You have the final goal left to complete.");

--- a/scripts/minigames/game_werewolf_agility/scripts/werewolf_agility.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/werewolf_agility.rs2
@@ -39,12 +39,42 @@ else: shoot south
 // waa_stepping_stone
 [aploc1,loc_5138]
 p_arrivedelay;
-if (distance(loc_coord, coord) > 2) {
+if (coord = 0_55_154_18_17 & loc_coord = 0_55_154_18_19) {
+    ~agility_exactmove(human_jump_stones, 0, 0, coord, loc_coord, 0, 20, ^exact_north, false);
+} else if (coord = 0_55_154_18_19 & loc_coord = 0_55_154_18_21) {
+    ~agility_exactmove(human_jump_stones, 0, 0, coord, loc_coord, 0, 20, ^exact_north, false);
+} else if (coord = 0_55_154_18_21 & loc_coord = 0_55_154_20_21) {
+    ~agility_exactmove(human_jump_stones, 0, 0, coord, loc_coord, 0, 20, ^exact_east, false);
+} else if (coord = 0_55_154_20_21 & loc_coord = 0_55_154_20_23) {
+    ~agility_exactmove(human_jump_stones, 0, 0, coord, loc_coord, 0, 20, ^exact_north, false);
+} else if (coord = 0_55_154_20_23 & loc_coord = 0_55_154_20_25) {
+    ~agility_exactmove(human_jump_stones, 0, 0, coord, loc_coord, 0, 20, ^exact_north, false);
+} else {
     p_aprange(2);
-    return;
 }
-mes("jump");
-switch_coord (coord) {
-    case 0_55_154_18_21 : ~agility_force_move(10, human_jump_stones, movecoord(coord, 2, 0, 0));
-    case default : ~agility_force_move(10, human_jump_stones, movecoord(coord, 0, 0, 2));
+
+// waa_hurdle
+[oploc1,loc_5133] ~waa_jump_hurdle;
+[oploc1,loc_5134] ~waa_jump_hurdle;
+[oploc1,loc_5135] ~waa_jump_hurdle;
+[proc,waa_jump_hurdle]
+p_arrivedelay;
+if (coordz(coord) < coordz(loc_coord) ) {
+    ~agility_exactmove(human_jump_hurdle, 0, 0, coord, movecoord(coord, 0, 0, 2), 0, 30, ^exact_north, false);
 }
+
+// waa_pipe
+[oploc1,loc_5152]
+if (coordz(coord) < coordz(loc_coord) ) {
+    ~agility_exactmove(human_doublepipesqueeze, 30, 5, coord, movecoord(coord, 0, 0, 6), 30, 126, ^exact_north, true);
+}
+
+// waa_skull_slope
+[oploc1,loc_5136]
+~agility_force_move(0, human_climbing, movecoord(coord, -3, 0, 0));
+
+// waa_zip_line 0,55,154,8,54
+[oploc1,loc_5139]
+~agility_exactmove(zipline_slide, 30, 0, coord, movecoord(coord, 0, 0, -40), 0, 300, ^exact_south, false);
+p_delay(1);
+anim(null, 0);

--- a/scripts/minigames/game_werewolf_agility/scripts/werewolf_agility.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/werewolf_agility.rs2
@@ -85,7 +85,7 @@ else: shoot south
 [aploc1,loc_5138]
 p_arrivedelay;
 if (coord = 0_55_154_18_17 & loc_coord = 0_55_154_18_19) {
-    if (npc_find(0_55_154_20_17, werewolf_trainer_start, 1, 0) = true) { 
+    if (inv_total(inv, waa_stick) = 0 & npc_find(0_55_154_20_17, werewolf_trainer_start, 1, 0) = true) { 
         npc_facesquare(movecoord(npc_coord, 0, 0, 1));
         npc_say("FETCH!!!!!"); 
         npc_anim(waa_werewolf_stick_throw, 0);
@@ -113,8 +113,11 @@ if (coord = 0_55_154_18_17 & loc_coord = 0_55_154_18_19) {
 [proc,waa_jump_hurdle]
 p_arrivedelay;
 if (coordz(coord) < coordz(loc_coord) ) {
-    sound_synth(jump, 0, 0);
+    sound_synth(hurdle, 0, 0);
     ~agility_exactmove(human_jump_hurdle, 0, 0, coord, movecoord(coord, 0, 0, 2), 0, 30, ^exact_north, false);
+} else {
+    // https://youtu.be/mwyd29YHyD8
+    mes("Don't look backwards - keep going forwards!");
 }
 
 // waa_pipe
@@ -127,11 +130,23 @@ if (coordz(coord) < coordz(loc_coord) ) {
     sound_synth(squeeze_out, 0, 0);
 }
 
+[proc,waa_agility_exactmove](seq $anim, int $anim_delay, int $movement_delay, coord $start_coord, coord $end_coord, int $start_cycle, int $end_cycle, int $direction, boolean $merge_with_loc)
+anim($anim, $anim_delay);
+p_exactmove($start_coord, $end_coord, $start_cycle, $end_cycle, $direction);
+p_delay($movement_delay);
+
+
+
 // waa_skull_slope
 [oploc1,loc_5136]
 ~agility_force_move(0, human_climbing, movecoord(coord, -3, 0, 0));
 
 // waa_zip_line 0,55,154,8,54
+// The 2 videos with the old models.
+// 2:47.5 - 2:52.5 = 5s // https://youtu.be/QnQZ0ayGy28
+// 3:21.5 - 3:26.5 = 5s // https://youtu.be/fmzzLy5fXK4
+// Just to compare, slightly newer models, still same timing.
+// 1:16.9 - 1:21.9 = 5s // https://youtu.be/hQ1B_F7OXBs
 [oploc1,loc_5139] ~waa_zip_line;
 [oploc1,loc_5140] ~waa_zip_line;
 [oploc1,loc_5141] ~waa_zip_line;
@@ -139,17 +154,21 @@ if (coordz(coord) < coordz(loc_coord) ) {
 p_arrivedelay;
 ~forcemove(0_55_154_8_54);
 facesquare(movecoord(coord, 0, 0, -1));
+mes("You bravely cling on to the death slide by your teeth...");
 anim(zipline_bite, 0);
-p_delay(2);
-~agility_exactmove(zipline_slide, 0, 0, coord, movecoord(coord, 0, 0, -9), 0, 120, ^exact_south, false);
-p_delay(2);
-// Failpoint 1
-~agility_exactmove(zipline_slide, 0, 0, movecoord(coord, 0, 0, 1), movecoord(coord, 0, 0, -9), 0, 120, ^exact_south, false);
-p_delay(2);
-// Failpoint 2
-~agility_exactmove(zipline_slide, 0, 0, movecoord(coord, 0, 0, 1), movecoord(coord, 0, 0, -9), 0, 120, ^exact_south, false);
-p_delay(2);
-// Failpoint 3
-~agility_exactmove(zipline_slide, 0, 0, movecoord(coord, 0, 0, 1), movecoord(coord, 0, 0, -9), 0, 120, ^exact_south, false);
-p_delay(2);
+sound_synth(bite, 0, 0);
+p_delay(1);
+say("WAAAAAARRRGGGHHHH!!!!!!");
+sound_synth(deathslide, 0, 0);
+anim(zipline_slide, 0);
+p_exactmove(0_55_154_8_54, 0_55_154_8_17, 0, 225, ^exact_south);
+p_delay(7);
+mes("... and land safely on your feet.");
+// ~waa_agility_exactmove(zipline_slide, 0, 2, 0_55_154_8_54, 0_55_154_8_44, 0, 80, ^exact_south, false);
+// // Failpoint 1
+// ~waa_agility_exactmove(zipline_slide, 0, 2, 0_55_154_8_44, 0_55_154_8_34, 0, 80, ^exact_south, false);
+// // Failpoint 2
+// ~waa_agility_exactmove(zipline_slide, 0, 2, 0_55_154_8_34, 0_55_154_8_24, 0, 80, ^exact_south, false);
+// // Failpoint 3
+// ~waa_agility_exactmove(zipline_slide, 0, 2, 0_55_154_8_24, 0_55_154_8_17, 0, 80, ^exact_south, false);
 anim(null, 0);

--- a/scripts/minigames/game_werewolf_agility/scripts/werewolf_agility.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/werewolf_agility.rs2
@@ -1,0 +1,50 @@
+// Similar to [oploc1,trapdoor]
+// 0,55,54,24,8
+// waa_trapdoor
+[oploc1,loc_5131]
+sound_synth(door_open, 0, 0);
+loc_change(loc_5132, 500);
+
+// waa_trapdoor_open
+[oploc1,loc_5132]
+anim(human_pickupfloor, 0);
+p_delay(0);
+p_telejump(0_55_154_29_9);
+
+// waa_trapdoor_open
+[oploc2,loc_5132]
+loc_change(loc_5131, 500);
+
+// waa_ladder_exit
+[oploc1,loc_5130]
+p_arrivedelay;
+~climb_ladder(0_55_54_24_8, true);
+
+
+// npc_add($coord, $boss, 1000);
+// npc_anim(npc_param(spawn_anim), 0);
+// npc_setmode(null);
+// %npc_action_delay = add(map_clock, $action_delay);
+// %npc_aggressive_player = uid;
+// %npc_lastcombat = add(map_clock, 8);
+
+// mes("That isn't your ball!")
+/**
+if 1w of ball: shoot east
+elif same zcoord as ball: shoot west
+elif any tile 1s of ball: shoot north
+else: shoot south
+**/
+
+// waa_stepping_stone
+[aploc1,loc_5138]
+p_arrivedelay;
+if (distance(loc_coord, coord) > 2) {
+    p_aprange(2);
+    return;
+}
+mes("jump");
+switch_coord (coord) {
+    case 0_55_154_18_21 : ~agility_force_move(10, human_jump_stones, movecoord(coord, 2, 0, 0));
+    case default : ~agility_force_move(10, human_jump_stones, movecoord(coord, 0, 0, 2));
+}

--- a/scripts/minigames/game_werewolf_agility/scripts/werewolf_agility.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/werewolf_agility.rs2
@@ -21,12 +21,32 @@ p_arrivedelay;
 ~climb_ladder(0_55_54_24_8, true);
 
 
-// npc_add($coord, $boss, 1000);
+[proc,skullball_startcourse]
+hint_stop;
+npc_add(0_55_154_34_5, waa_skullball, 1000);
+~npc_forcewalk(0_55_154_34_8);
+hint_npc;
 // npc_anim(npc_param(spawn_anim), 0);
 // npc_setmode(null);
 // %npc_action_delay = add(map_clock, $action_delay);
 // %npc_aggressive_player = uid;
 // %npc_lastcombat = add(map_clock, 8);
+
+// Skullball Tap
+[opnpc1,waa_skullball]
+p_arrivedelay;
+anim(kick_skull_ball, 0);
+~npc_forcewalk(movecoord(npc_coord, sub(coordx(npc_coord), coordx(coord)), 0, sub(coordz(npc_coord), coordz(coord))) );
+
+
+// Skullball Kick
+[opnpc3,waa_skullball]
+
+// Skullball Shoot
+[opnpc4,waa_skullball]
+
+// Skullball Show Goal
+[opnpc5,waa_skullball]
 
 // mes("That isn't your ball!")
 /**
@@ -40,6 +60,12 @@ else: shoot south
 [aploc1,loc_5138]
 p_arrivedelay;
 if (coord = 0_55_154_18_17 & loc_coord = 0_55_154_18_19) {
+    if (npc_find(0_55_154_20_17, werewolf_trainer_start, 1, 0) = true) { 
+        npc_facesquare(movecoord(npc_coord, 0, 0, 1));
+        npc_say("FETCH!!!!!"); 
+        npc_anim(waa_werewolf_stick_throw, 0);
+        ~coord_projectile(0_55_154_20_17, 0_55_154_20_27, waa_stick_travel, 0, 0, 30, 0, 10, 11, 5);
+    }
     ~agility_exactmove(human_jump_stones, 0, 0, coord, loc_coord, 0, 20, ^exact_north, false);
 } else if (coord = 0_55_154_18_19 & loc_coord = 0_55_154_18_21) {
     ~agility_exactmove(human_jump_stones, 0, 0, coord, loc_coord, 0, 20, ^exact_north, false);
@@ -60,13 +86,18 @@ if (coord = 0_55_154_18_17 & loc_coord = 0_55_154_18_19) {
 [proc,waa_jump_hurdle]
 p_arrivedelay;
 if (coordz(coord) < coordz(loc_coord) ) {
+    sound_synth(jump, 0, 0);
     ~agility_exactmove(human_jump_hurdle, 0, 0, coord, movecoord(coord, 0, 0, 2), 0, 30, ^exact_north, false);
 }
 
 // waa_pipe
 [oploc1,loc_5152]
 if (coordz(coord) < coordz(loc_coord) ) {
-    ~agility_exactmove(human_doublepipesqueeze, 30, 5, coord, movecoord(coord, 0, 0, 6), 30, 126, ^exact_north, true);
+    ~agility_exactmove(human_doublepipesqueeze, 30, 3, coord, movecoord(coord, 0, 0, 3), 30, 126, ^exact_north, true);
+    sound_synth(squeeze_in, 0, 0);
+    ~change_merged_loc(movecoord(coord, 0, 0, 1));
+    ~agility_exactmove(human_doublepipesqueeze, 30, 3, coord, movecoord(coord, 0, 0, 3), 30, 126, ^exact_north, true);
+    sound_synth(squeeze_out, 0, 0);
 }
 
 // waa_skull_slope
@@ -74,7 +105,24 @@ if (coordz(coord) < coordz(loc_coord) ) {
 ~agility_force_move(0, human_climbing, movecoord(coord, -3, 0, 0));
 
 // waa_zip_line 0,55,154,8,54
-[oploc1,loc_5139]
-~agility_exactmove(zipline_slide, 30, 0, coord, movecoord(coord, 0, 0, -40), 0, 300, ^exact_south, false);
-p_delay(1);
+[oploc1,loc_5139] ~waa_zip_line;
+[oploc1,loc_5140] ~waa_zip_line;
+[oploc1,loc_5141] ~waa_zip_line;
+[proc,waa_zip_line]
+p_arrivedelay;
+~forcemove(0_55_154_8_54);
+facesquare(movecoord(coord, 0, 0, -1));
+anim(zipline_bite, 0);
+p_delay(2);
+~agility_exactmove(zipline_slide, 0, 0, coord, movecoord(coord, 0, 0, -9), 0, 120, ^exact_south, false);
+p_delay(2);
+// Failpoint 1
+~agility_exactmove(zipline_slide, 0, 0, movecoord(coord, 0, 0, 1), movecoord(coord, 0, 0, -9), 0, 120, ^exact_south, false);
+p_delay(2);
+// Failpoint 2
+~agility_exactmove(zipline_slide, 0, 0, movecoord(coord, 0, 0, 1), movecoord(coord, 0, 0, -9), 0, 120, ^exact_south, false);
+p_delay(2);
+// Failpoint 3
+~agility_exactmove(zipline_slide, 0, 0, movecoord(coord, 0, 0, 1), movecoord(coord, 0, 0, -9), 0, 120, ^exact_south, false);
+p_delay(2);
 anim(null, 0);

--- a/scripts/minigames/game_werewolf_agility/scripts/werewolf_agility.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/werewolf_agility.rs2
@@ -162,7 +162,7 @@ say("WAAAAAARRRGGGHHHH!!!!!!");
 sound_synth(deathslide, 0, 0);
 anim(zipline_slide, 0);
 p_exactmove(0_55_154_8_54, 0_55_154_8_17, 0, 225, ^exact_south);
-p_delay(7);
+p_delay(7); // For odd reasons 7*6 = 4200 ms matches videos.
 mes("... and land safely on your feet.");
 // ~waa_agility_exactmove(zipline_slide, 0, 2, 0_55_154_8_54, 0_55_154_8_44, 0, 80, ^exact_south, false);
 // // Failpoint 1

--- a/scripts/minigames/game_werewolf_agility/scripts/werewolf_agility.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/werewolf_agility.rs2
@@ -18,13 +18,20 @@ loc_change(loc_5131, 500);
 // waa_ladder_exit
 [oploc1,loc_5130]
 p_arrivedelay;
-~climb_ladder(0_55_54_24_8, true);
+~climb_ladder(0_55_54_23_7, true);
 
-
+// Skullball Start
 [proc,skullball_startcourse]
+if_close;
 hint_stop;
-npc_add(0_55_154_34_5, waa_skullball, 1000);
-~npc_forcewalk(0_55_154_34_8);
+switch_int(random(4)) {
+    case 0 : npc_add(0_55_154_32_3, waa_skullball, 1000);
+    case 1 : npc_add(0_55_154_34_4, waa_skullball, 1000);
+    case 2 : npc_add(0_55_154_35_4, waa_skullball, 1000);
+    case 3 : npc_add(0_55_154_37_3, waa_skullball, 1000);
+}
+%npc_aggressive_player = uid; // We assign the agressive player to know who owns the skullball.
+~npc_forcewalk(movecoord(npc_coord, 0, 0, 4));
 hint_npc;
 // npc_anim(npc_param(spawn_anim), 0);
 // npc_setmode(null);
@@ -36,14 +43,32 @@ hint_npc;
 [opnpc1,waa_skullball]
 p_arrivedelay;
 anim(kick_skull_ball, 0);
-~npc_forcewalk(movecoord(npc_coord, sub(coordx(npc_coord), coordx(coord)), 0, sub(coordz(npc_coord), coordz(coord))) );
-
+~npc_forcewalk(movecoord(
+    npc_coord, 
+    sub(coordx(npc_coord), coordx(coord)), 
+    0, 
+    sub(coordz(npc_coord), coordz(coord))
+));
 
 // Skullball Kick
 [opnpc3,waa_skullball]
+~npc_forcewalk(movecoord(
+    npc_coord, 
+    multiply(sub(coordx(npc_coord), coordx(coord)), 4), 
+    0, 
+    multiply(sub(coordz(npc_coord), coordz(coord)), 4)
+));
+
 
 // Skullball Shoot
 [opnpc4,waa_skullball]
+~npc_forcewalk(movecoord(
+    npc_coord, 
+    multiply(sub(coordx(npc_coord), coordx(coord)), 9), 
+    0, 
+    multiply(sub(coordz(npc_coord), coordz(coord)), 9)
+));
+
 
 // Skullball Show Goal
 [opnpc5,waa_skullball]
@@ -65,6 +90,8 @@ if (coord = 0_55_154_18_17 & loc_coord = 0_55_154_18_19) {
         npc_say("FETCH!!!!!"); 
         npc_anim(waa_werewolf_stick_throw, 0);
         ~coord_projectile(0_55_154_20_17, 0_55_154_20_27, waa_stick_travel, 0, 0, 30, 0, 10, 11, 5);
+        def_coord $random_stick_coord = map_findsquare(0_55_154_22_56,0, 2, ^map_findsquare_lineofwalk);
+        obj_add($random_stick_coord, waa_stick, 1, ^lootdrop_duration);
     }
     ~agility_exactmove(human_jump_stones, 0, 0, coord, loc_coord, 0, 20, ^exact_north, false);
 } else if (coord = 0_55_154_18_19 & loc_coord = 0_55_154_18_21) {

--- a/scripts/minigames/game_werewolf_agility/scripts/werewolf_guard.rs2
+++ b/scripts/minigames/game_werewolf_agility/scripts/werewolf_guard.rs2
@@ -1,0 +1,21 @@
+[opnpc1,waa_werewolf_guard]
+~chatplayer("<p,neutral>What's beneath the trapdoor?");
+if (inv_total(worn, ring_of_charos) = 1 | inv_total(worn, ring_of_charos_unlocked) = 1) {
+    @werewolf_guard_has_ring;
+} else {
+    @werewolf_guard_no_ring;
+}
+
+[label,werewolf_guard_no_ring]
+~chatnpc("<p,shifty>That's none of your business, human, and I'll never tell.");
+~chatplayer("<p,neutral>Oh, come on - I'm only curious.");
+~chatnpc("<p,shifty>If it wasn't my duty to stand here and guard our agility course from the likes of you, I would be relieving you of your life right now.");
+~chatplayer("<p,neutral>So it's an agility course, then?");
+~chatnpc("<p,shifty>No ... yes ... oh blast - you didn't hear me say anything, right?");
+~chatplayer("<p,neutral>No problem. Can I come in?");
+~chatnpc("<p,shifty>No, human - it's werewolves only.");
+
+[label,werewolf_guard_has_ring]
+~chatnpc("<p,shifty>It's an agility course designed for lycanthropes like ourselves, my friend.");
+~chatplayer("<p,neutral>Can I come in and use it?");
+~chatnpc("<p,shifty>Certainly. The cavern contains two courses - on the|west side is a level 60 Agility Course, and on the east|side is a level 25 Skullball Course.");


### PR DESCRIPTION
Implements the Werewolf Agility Area (waa_) for 291 along with creatures of fenkenstrain. This includes both the agility course on the left and the skullball course on the right.

A port from my contribution to 09, https://gitlab.com/2009scape/2009scape/-/merge_requests/1976/diffs#5a8b9aeb4eb65f09b8970602db196d5100849cc2

This one will be a bit more difficult for me as 09 used different APIs for animations and agility.

Thanks to other contributors who are helping use rsprox to figure out which varps and functionality is being used for this!

https://www.youtube.com/@captainbeeky2000/videos - source with a lot of were wolf agility runs