### PR TITLE
fix: Storeroom door quest stage check (274)

### DIFF
--- a/scripts/quests/quest_eadgar/scripts/quest_eadgar.rs2
+++ b/scripts/quests/quest_eadgar/scripts/quest_eadgar.rs2
@@ -452,7 +452,7 @@ if(%eadgar_quest = ^eadgar_got_burnt_meat & inv_total(inv, eadgar_troll_storeroo
 if(coord = 0_44_157_53_37) {
     @eadgar_storeroom_open;
 } else {
-    if(%eadgar_quest = ^eadgar_unlocked_storeroom) {
+    if(%eadgar_quest >= ^eadgar_unlocked_storeroom) {
         @eadgar_storeroom_open;
     } else if(inv_total(inv, eadgar_troll_storeroom_key) > 0 & %eadgar_quest = ^eadgar_got_burnt_meat) { // todo any sound for unlocking?
         %eadgar_quest = ^eadgar_unlocked_storeroom;


### PR DESCRIPTION
Previously, if you had completed the Eadgar's Ruse quest, you'd not be able to re-enter the storeroom. This PR fixes that.