### PR TITLE
fix: Velrak the Explorer's dialogue option was incorrect (225+)

### DIFF
--- a/scripts/areas/area_taverly/dungeon/scripts/velrak_the_explorer.rs2
+++ b/scripts/areas/area_taverly/dungeon/scripts/velrak_the_explorer.rs2
@@ -10,7 +10,7 @@ if($option = 1) {
     ~chatplayer("<p,quiz>So... do you know anywhere good to explore?");
     ~chatnpc("<p,sad>Well, this dungeon was quite good to explore|...until I got captured, anyway.|I was given a key to an inner part of this dungeon|by a mysterious cloaked stranger!");
     ~chatnpc("<p,sad>It's rather tough for me to get that far into the dungeon however... I just keep getting captured!|Would you like to give it a go?");
-    $option = ~p_choice2("Yes please!", 1, "Do I get a reward?", 2);
+    $option = ~p_choice2("Yes please!", 1, "No, it's too dangerous for me too.", 2);
     if($option = 1) {
         ~chatplayer("<p,happy>Yes please!");
         inv_add(inv, dusty_key, 1);


### PR DESCRIPTION
For 225+

Changes dialogue option from: "Do I get a reward?"
https://github.com/user-attachments/assets/c8bd377a-19f4-4f14-9409-4880884f8c01

To: "No, it's too dangerous for me too."
https://github.com/user-attachments/assets/9a366eb4-bba8-46e3-b1a2-d95f894cc4ca


As per: https://oldschool.runescape.wiki/w/Transcript:Velrak_the_explorer & https://runescape.wiki/w/Transcript:Velrak_the_explorer
