### PR TITLE
fix: Move retreat logic before retal ready check

### DIFF
--- a/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -306,7 +306,7 @@ return (false);
 
 
 [proc,npc_retal_ready]()(boolean)
-if ((add(%npc_action_delay, 8) < map_clock) | (npc_getmode ! applayer2 & npc_getmode ! opplayer2 & npc_getmode ! playerescape)) {
+if ((add(%npc_action_delay, 8) < map_clock) | (npc_getmode ! applayer2 & npc_getmode ! opplayer2)) {
     return (true);
 }
 return (false);

--- a/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -20,7 +20,7 @@ if (~npc_retal_ready = false) {
 %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2)); // flinch
 %npc_attacking_uid = %npc_aggressive_player;
 
-if(npc_getmode ! playerescape) {
+if (npc_stat(hitpoints) > npc_param(retreat)) {
     npc_setmode(opplayer2);
     if (npc_inrange = false) {
         npc_setmode(playerescape);
@@ -45,7 +45,7 @@ if (~npc_retal_ready = false) {
 %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
 %npc_attacking_uid = %npc_aggressive_player;
 
-if(npc_getmode ! playerescape) {
+if (npc_stat(hitpoints) > npc_param(retreat)) {
     npc_setmode(applayer2);
     if (npc_inrange = false) {
         npc_setmode(playerescape);

--- a/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -5,11 +5,10 @@
 
 // a default melee retaliate script.
 [proc,npc_default_retaliate]
-if (finduid(%npc_aggressive_player) = false | ~npc_retal_ready = false) {
+if (finduid(%npc_aggressive_player) = false) {
     return;
 }
-%npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2)); // flinch
-%npc_attacking_uid = %npc_aggressive_player;
+
 if (npc_stat(hitpoints) <= npc_param(retreat)) {
     npc_setmode(playerescape);
 } else {
@@ -19,13 +18,19 @@ if (npc_stat(hitpoints) <= npc_param(retreat)) {
     }
 }
 
-// mostly used for ranged and magic npc's
-[proc,npc_default_retaliate_ap]
-if (finduid(%npc_aggressive_player) = false | ~npc_retal_ready = false) {
+if (~npc_retal_ready = false) {
     return;
 }
-%npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
+
+%npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2)); // flinch
 %npc_attacking_uid = %npc_aggressive_player;
+
+// mostly used for ranged and magic npc's
+[proc,npc_default_retaliate_ap]
+if (finduid(%npc_aggressive_player) = false) {
+    return;
+}
+
 // default to ap
 if (npc_stat(hitpoints) <= npc_param(retreat)) {
     npc_setmode(playerescape);
@@ -35,6 +40,13 @@ if (npc_stat(hitpoints) <= npc_param(retreat)) {
         npc_setmode(playerescape);
     }
 }
+
+if (~npc_retal_ready = false) {
+    return;
+}
+
+%npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
+%npc_attacking_uid = %npc_aggressive_player;
 
 
 // a default melee attack script.

--- a/scripts/skill_combat/scripts/npc/npc_combat.rs2
+++ b/scripts/skill_combat/scripts/npc/npc_combat.rs2
@@ -11,11 +11,6 @@ if (finduid(%npc_aggressive_player) = false) {
 
 if (npc_stat(hitpoints) <= npc_param(retreat)) {
     npc_setmode(playerescape);
-} else {
-    npc_setmode(opplayer2);
-    if (npc_inrange = false) {
-        npc_setmode(playerescape);
-    }
 }
 
 if (~npc_retal_ready = false) {
@@ -24,6 +19,13 @@ if (~npc_retal_ready = false) {
 
 %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2)); // flinch
 %npc_attacking_uid = %npc_aggressive_player;
+
+if(npc_getmode ! playerescape) {
+    npc_setmode(opplayer2);
+    if (npc_inrange = false) {
+        npc_setmode(playerescape);
+    }
+}
 
 // mostly used for ranged and magic npc's
 [proc,npc_default_retaliate_ap]
@@ -34,11 +36,6 @@ if (finduid(%npc_aggressive_player) = false) {
 // default to ap
 if (npc_stat(hitpoints) <= npc_param(retreat)) {
     npc_setmode(playerescape);
-} else {
-    npc_setmode(applayer2);
-    if (npc_inrange = false) {
-        npc_setmode(playerescape);
-    }
 }
 
 if (~npc_retal_ready = false) {
@@ -47,6 +44,13 @@ if (~npc_retal_ready = false) {
 
 %npc_action_delay = add(map_clock, divide(npc_param(attackrate), 2));
 %npc_attacking_uid = %npc_aggressive_player;
+
+if(npc_getmode ! playerescape) {
+    npc_setmode(applayer2);
+    if (npc_inrange = false) {
+        npc_setmode(playerescape);
+    }
+}
 
 
 // a default melee attack script.

--- a/scripts/skill_combat/scripts/player/player_combat.rs2
+++ b/scripts/skill_combat/scripts/player/player_combat.rs2
@@ -109,7 +109,7 @@ if (map_multiway(npc_coord) = false) {
         return(false);
     }
     // npc has been attacked in the last 8 ticks, and not by the current player
-    if ((add(%npc_lastcombat, 8) > map_clock & %npc_aggressive_player ! uid)) {
+    if ((add(%npc_lastcombat, 8) > map_clock & %npc_aggressive_player ! uid & finduid(%npc_aggressive_player) = true)) {
         mes("Someone else is fighting that.");
         return(false);
     }
@@ -134,7 +134,7 @@ if (map_multiway(npc_coord) = false) {
         return(false);
     }
     // npc has been attacked in the last 8 ticks, and not by the current player
-    if ((add(%npc_lastcombat, 8) > map_clock & %npc_aggressive_player ! uid)) {
+    if ((add(%npc_lastcombat, 8) > map_clock & %npc_aggressive_player ! uid & finduid(%npc_aggressive_player) = true)) {
         mes("Someone else is fighting that.");
         return(false);
     }

--- a/scripts/skill_combat/scripts/player/player_combat.rs2
+++ b/scripts/skill_combat/scripts/player/player_combat.rs2
@@ -109,7 +109,7 @@ if (map_multiway(npc_coord) = false) {
         return(false);
     }
     // npc has been attacked in the last 8 ticks, and not by the current player
-    if ((add(%npc_lastcombat, 8) > map_clock & %npc_aggressive_player ! uid & finduid(%npc_aggressive_player) = true)) {
+    if ((add(%npc_lastcombat, 8) > map_clock & %npc_aggressive_player ! uid)) {
         mes("Someone else is fighting that.");
         return(false);
     }
@@ -134,7 +134,7 @@ if (map_multiway(npc_coord) = false) {
         return(false);
     }
     // npc has been attacked in the last 8 ticks, and not by the current player
-    if ((add(%npc_lastcombat, 8) > map_clock & %npc_aggressive_player ! uid & finduid(%npc_aggressive_player) = true)) {
+    if ((add(%npc_lastcombat, 8) > map_clock & %npc_aggressive_player ! uid)) {
         mes("Someone else is fighting that.");
         return(false);
     }


### PR DESCRIPTION
For 225+

Retreat logic was unreachable before during normal combat. This better matches osrs. Npcs don't flinch or go into playerescape mode unless the finduid is succcessful, but the retreat logic needs placed before the retal ready check. 