### PR TITLE
fix: Clearing wrong pyre and boardgames spectate script error

### DIFF
--- a/scripts/minigames/game_gamesroom/boardgames_draughts/scripts/boardgames_draughts.rs2
+++ b/scripts/minigames/game_gamesroom/boardgames_draughts/scripts/boardgames_draughts.rs2
@@ -1109,7 +1109,7 @@ if (%boardgames_closinginterface = 0) {
 minimap_toggle(1);
 huntall(loc_coord, 1, 0);
 while (.huntnext = true) {
-    if(.%boardgames_viewing = 0) {
+    if(.%boardgames_viewing = 0 & .%boardgames_ingame = 1) {
         if(.%boardgames_control = 1) {
             %boardgames_tablenum = .%boardgames_tablenum;
             if_setobject(boardgames_draughts_view:p2_rune, ~get_boardgames_rune_obj(.%boardgames_piece), 72);

--- a/scripts/minigames/game_mortton/scripts/mortton_pyre.rs2
+++ b/scripts/minigames/game_mortton/scripts/mortton_pyre.rs2
@@ -204,7 +204,9 @@ sound_synth(smokepuff, 0, 0);
 %mortton_current_shade = null;
 loc_findallzone($coord);
 if(loc_findnext = true) {
-    loc_change(temple_pyre, 1);
+    if(loc_coord = $coord) {
+        loc_change(temple_pyre, 1);
+    }
 }
 if(npc_find(~get_pyre_coord($coord, $rotation), shade_heaven, 0, 0) = true) {
     npc_del;


### PR DESCRIPTION
- Fixes deleting pyre of someone nearby instead of your own

- Fixes occasional script error with spectating boardgames