### PR TITLE
fix: god books preaching fixes

### DIFF
--- a/scripts/quests/quest_horror/scripts/horror_godbook.rs2
+++ b/scripts/quests/quest_horror/scripts/horror_godbook.rs2
@@ -370,7 +370,8 @@ switch_int($op) {
         p_delay(2);
         say("This is Saradomin's wisdom.");
 }
-%sa_energy = sub(%sa_energy, 250);
+~set_sa_timer;
+~sub_sa_energy(250);
 
 [opheld3,zamorakbook_complete]
 if(%sa_energy < 250) {
@@ -434,7 +435,8 @@ switch_int($op) {
         p_delay(2);
         say("Zamorak give me strength!");
 }
-%sa_energy = sub(%sa_energy, 250);
+~set_sa_timer;
+~sub_sa_energy(250);
 
 [opheld3,guthixbook_complete]
 if(%sa_energy < 250) {
@@ -498,4 +500,5 @@ switch_int($op) {
         p_delay(2);
         say("May Guthix bring you balance.");
 }
-%sa_energy = sub(%sa_energy, 250);
+~set_sa_timer;
+~sub_sa_energy(250);

--- a/scripts/quests/quest_horror/scripts/horror_godbook.rs2
+++ b/scripts/quests/quest_horror/scripts/horror_godbook.rs2
@@ -314,7 +314,7 @@ if(%horror_balancepage1 = ^true & %horror_balancepage2 = ^true & %horror_balance
 
 [opheld3,saradominbook_complete]
 if(%sa_energy < 250) {
-    // https://media.discordapp.net/attachments/1510562081072611388/1510612185150132295/image.png?ex=6a1d72ba&is=6a1c213a&hm=287878b463785335651c2661140cffbcdb2c762a4ae0659f439cd2f93a673099&=&format=webp&quality=lossless
+    // https://i.imgur.com/onxUvRr.png
     mes("You do not have enough Special Energy to preach.");
     return;
 }
@@ -371,12 +371,11 @@ switch_int($op) {
         p_delay(2);
         say("This is Saradomin's wisdom.");
 }
-~set_sa_timer;
 ~sub_sa_energy(250);
 
 [opheld3,zamorakbook_complete]
 if(%sa_energy < 250) {
-    // https://media.discordapp.net/attachments/1510562081072611388/1510612185150132295/image.png?ex=6a1d72ba&is=6a1c213a&hm=287878b463785335651c2661140cffbcdb2c762a4ae0659f439cd2f93a673099&=&format=webp&quality=lossless
+    // https://i.imgur.com/onxUvRr.png
     mes("You do not have enough Special Energy to preach.");
     return;
 }
@@ -437,12 +436,11 @@ switch_int($op) {
         p_delay(2);
         say("Zamorak give me strength!");
 }
-~set_sa_timer;
 ~sub_sa_energy(250);
 
 [opheld3,guthixbook_complete]
 if(%sa_energy < 250) {
-    // https://media.discordapp.net/attachments/1510562081072611388/1510612185150132295/image.png?ex=6a1d72ba&is=6a1c213a&hm=287878b463785335651c2661140cffbcdb2c762a4ae0659f439cd2f93a673099&=&format=webp&quality=lossless
+    // https://i.imgur.com/onxUvRr.png
     mes("You do not have enough Special Energy to preach.");
     return;
 }
@@ -503,5 +501,4 @@ switch_int($op) {
         p_delay(2);
         say("May Guthix bring you balance.");
 }
-~set_sa_timer;
 ~sub_sa_energy(250);

--- a/scripts/quests/quest_horror/scripts/horror_godbook.rs2
+++ b/scripts/quests/quest_horror/scripts/horror_godbook.rs2
@@ -314,7 +314,8 @@ if(%horror_balancepage1 = ^true & %horror_balancepage2 = ^true & %horror_balance
 
 [opheld3,saradominbook_complete]
 if(%sa_energy < 250) {
-    mes("You don't have enough Special Energy to preach.");
+    // https://media.discordapp.net/attachments/1510562081072611388/1510612185150132295/image.png?ex=6a1d72ba&is=6a1c213a&hm=287878b463785335651c2661140cffbcdb2c762a4ae0659f439cd2f93a673099&=&format=webp&quality=lossless
+    mes("You do not have enough Special Energy to preach.");
     return;
 }
 def_int $op = ~p_choice4_header("Partnerships", 1, "Last Rites", 2, "Blessings", 3, "Preach", 4, "Select a relevant passage");
@@ -375,7 +376,8 @@ switch_int($op) {
 
 [opheld3,zamorakbook_complete]
 if(%sa_energy < 250) {
-    mes("You don't have enough Special Energy to preach.");
+    // https://media.discordapp.net/attachments/1510562081072611388/1510612185150132295/image.png?ex=6a1d72ba&is=6a1c213a&hm=287878b463785335651c2661140cffbcdb2c762a4ae0659f439cd2f93a673099&=&format=webp&quality=lossless
+    mes("You do not have enough Special Energy to preach.");
     return;
 }
 def_int $op = ~p_choice4_header("Wedding Ceremony", 1, "Last Rites", 2, "Blessings", 3, "Preach", 4, "Select a relevant passage");
@@ -440,7 +442,8 @@ switch_int($op) {
 
 [opheld3,guthixbook_complete]
 if(%sa_energy < 250) {
-    mes("You don't have enough Special Energy to preach.");
+    // https://media.discordapp.net/attachments/1510562081072611388/1510612185150132295/image.png?ex=6a1d72ba&is=6a1c213a&hm=287878b463785335651c2661140cffbcdb2c762a4ae0659f439cd2f93a673099&=&format=webp&quality=lossless
+    mes("You do not have enough Special Energy to preach.");
     return;
 }
 def_int $op = ~p_choice4_header("Wedding Ceremony", 1, "Last Rites", 2, "Blessings", 3, "Preach", 4, "Select a relevant passage");

--- a/scripts/skill_combat/scripts/player/specwep.rs2
+++ b/scripts/skill_combat/scripts/player/specwep.rs2
@@ -12,16 +12,13 @@ if (%sa_energy < oc_param(inv_getobj(worn, ^wearpos_rhand), sa_energy)) {
 }
 return(true);
 
-[proc,set_sa_timer]
+[proc,sub_sa_energy](int $energy_used)
 if (%sa_energy = ^sa_max_energy) {
     settimer(sa_regen, ^sa_regen_interval);
 }
-
-[proc,sub_sa_energy](int $energy_used)
 %sa_energy = max(sub(%sa_energy, $energy_used), 0);
 
 [proc,set_sa_vars](int $energy_used)
-~set_sa_timer;
 ~sub_sa_energy($energy_used);
 %sa_attack = ^false;
 

--- a/scripts/skill_combat/scripts/player/specwep.rs2
+++ b/scripts/skill_combat/scripts/player/specwep.rs2
@@ -12,11 +12,17 @@ if (%sa_energy < oc_param(inv_getobj(worn, ^wearpos_rhand), sa_energy)) {
 }
 return(true);
 
-[proc,set_sa_vars](int $energy_used)
+[proc,set_sa_timer]
 if (%sa_energy = ^sa_max_energy) {
     settimer(sa_regen, ^sa_regen_interval);
 }
+
+[proc,sub_sa_energy](int $energy_used)
 %sa_energy = max(sub(%sa_energy, $energy_used), 0);
+
+[proc,set_sa_vars](int $energy_used)
+~set_sa_timer;
+~sub_sa_energy($energy_used);
 %sa_attack = ^false;
 
 [proc,sa_reset]


### PR DESCRIPTION
- Fix issue where preaching with a god book wasn't setting the spec regen timer if the player had a full spec bar.
- Slight change to mes wording based on source (`don't have enough` to `do not have enough`)

I've split the `set_sa_vars` proc up rather than calling it from the god books because I assume we want to keep the existing behaviour of not setting `%sa_attack = ^false` when preaching.