### PR TITLE
fix: sticktrap updates, various fixes

### DIFF
--- a/scripts/music/configs/musicregion.dbrow
+++ b/scripts/music/configs/musicregion.dbrow
@@ -146,7 +146,7 @@ data=musicdata,music_Elven_Mist
 
 [musicregion_36_51]
 table=musicregion
-data=mapsquare,0_36_50_0_0
+data=mapsquare,0_36_51_0_0
 data=musicdata,music_Overpass
 
 [musicregion_36_52]

--- a/scripts/music/scripts/move.rs2
+++ b/scripts/music/scripts/move.rs2
@@ -436,6 +436,7 @@ settimer(move_ikovtrigger, 1);
 
 [mapzone,0_49_46]
 ~start_desertheat_timer;
+@music_playbyregion(coord);
 
 [mapzone,0_49_47] 
 ~start_desertheat_timer;
@@ -505,6 +506,7 @@ settimer(move_ikovtrigger, 1);
 
 [mapzone,0_50_46]
 ~start_desertheat_timer;
+@music_playbyregion(coord);
 
 [mapzone,0_50_47] 
 ~start_desertheat_timer;

--- a/scripts/quests/quest_chompybird/configs/quest_chompybird.constant
+++ b/scripts/quests/quest_chompybird/configs/quest_chompybird.constant
@@ -5,7 +5,7 @@
 ^chompybird_removed_rock_from_chest = 20
 ^chompybird_shown_toad = 25
 ^chompybird_dropped_toad = 30
-^chompybird_chompy_ate_toad = 35
+^chompybird_chompy_bird_spawned = 35
 ^chompybird_rantz_tried_to_shoot_chompy = 40
 ^chompybird_rantz_gave_player_bow = 45
 ^chompybird_player_killed_chompy = 50

--- a/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -8,7 +8,7 @@
     npc_say("Sqwirk!");
     if(finduid(%npc_attacking_uid) = true) {
         if (%chompybird < ^chompybird_rantz_gave_player_bow) {
-            queue(chompy_bird_spawned, 0);
+            queue(chompy_bird_spawned, 0, 0);
             npc_queue(11, 0, add(15, random(10)));
         }
         hint_npc;

--- a/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -7,7 +7,7 @@
     npc_anim(chompy_landing, 0);
     npc_say("Sqwirk!");
     if(finduid(%npc_attacking_uid) = true) {
-        if (%chompybird >= ^chompybird_chompy_ate_toad & %chompybird < ^chompybird_rantz_gave_player_bow) {
+        if (%chompybird >= ^chompybird_dropped_toad & %chompybird < ^chompybird_rantz_gave_player_bow) {
             npc_queue(11, 0, add(15, random(10)));
         }
         hint_npc;
@@ -50,14 +50,15 @@ if (.npc_finduid(%chompy_attacking_toad) = true & distance(npc_coord, .npc_coord
     .npc_delay(1);
     .npc_del;
     npc_setmode(null);
-    if (p_finduid(%npc_attacking_uid) = true) {
-        if (%chompybird = ^chompybird_dropped_toad) {
-            %chompybird = ^chompybird_chompy_ate_toad;
-        }
-    }
+    queue(chompy_eaten_toad, 0);
 } else {
     npc_setmode(null);
     npc_sethuntmode(chompybird);
+}
+
+[queue,chompy_eaten_toad]
+if (%chompybird = ^chompybird_dropped_toad) {
+    %chompybird = ^chompybird_chompy_ate_toad;
 }
 
 [ai_timer,chompy_bird]

--- a/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
+++ b/scripts/quests/quest_chompybird/scripts/chompy_bird.rs2
@@ -7,7 +7,8 @@
     npc_anim(chompy_landing, 0);
     npc_say("Sqwirk!");
     if(finduid(%npc_attacking_uid) = true) {
-        if (%chompybird >= ^chompybird_dropped_toad & %chompybird < ^chompybird_rantz_gave_player_bow) {
+        if (%chompybird < ^chompybird_rantz_gave_player_bow) {
+            queue(chompy_bird_spawned, 0);
             npc_queue(11, 0, add(15, random(10)));
         }
         hint_npc;
@@ -50,15 +51,14 @@ if (.npc_finduid(%chompy_attacking_toad) = true & distance(npc_coord, .npc_coord
     .npc_delay(1);
     .npc_del;
     npc_setmode(null);
-    queue(chompy_eaten_toad, 0);
 } else {
     npc_setmode(null);
     npc_sethuntmode(chompybird);
 }
 
-[queue,chompy_eaten_toad]
+[queue,chompy_bird_spawned]
 if (%chompybird = ^chompybird_dropped_toad) {
-    %chompybird = ^chompybird_chompy_ate_toad;
+    %chompybird = ^chompybird_chompy_bird_spawned;
 }
 
 [ai_timer,chompy_bird]

--- a/scripts/quests/quest_chompybird/scripts/rantz.rs2
+++ b/scripts/quests/quest_chompybird/scripts/rantz.rs2
@@ -76,7 +76,7 @@ switch_int(%chompybird) {
         @where_to_put_toadies;
     // Maybe chompy_ate_toad has a separate set of dialogue, but in normal circumstances the stage
     // advances to rantz_tried_to_shoot_chompy too quickly to tell.
-    case ^chompybird_dropped_toad, ^chompybird_chompy_ate_toad :
+    case ^chompybird_dropped_toad, ^chompybird_chompy_bird_spawned :
         ~chatplayer("<p,neutral>There you go, I've placed the bait.");
         ~chatnpc("<p,happy>Goodz, me now waits for da chompy! It shouldn't be long now. Sneaky... sneaky...");
         ~chatplayer("<p,neutral>Yes, I know... stick da chompy!");

--- a/scripts/quests/quest_horror/scripts/horror_journal.rs2
+++ b/scripts/quests/quest_horror/scripts/horror_journal.rs2
@@ -38,7 +38,7 @@ if(%horrorquest > ^horror_started) {
     if(%horroragilitykey = ^true) {
         $text = append($text, "@dbl@I also need to use the key I got from Gunnjorn to enter @dbl@the lighthouse.|");
     } else {
-        $text = append($text, "@dbl@I also need to get the @dre@lighthouse key@dbl@ from her cousin @dre@Gunnjorn@dbl@.|");
+        $text = append($text, "@dbl@I also need to get the @dre@lighthouse key@dbl@ from her cousin|@dre@Gunnjorn@dbl@.|");
     }
 }
 

--- a/scripts/quests/quest_regicide/scripts/quest_regicide.rs2
+++ b/scripts/quests/quest_regicide/scripts/quest_regicide.rs2
@@ -29,10 +29,12 @@ p_teleport(0_36_150_10_24);
 p_teleport(0_36_50_8_16);
 
 [oploc1,regicide_trap_woodspring]
-p_delay(0);
 if(stat_random(agility, 30, 155) = false) {
-    @regicide_fail_trap_woodspring;
+    mes("FAIL");
+    weakqueue*(regicide_move_trap_woodspring, 0)(loc_type, loc_coord, coord);
+    return;
 }
+p_delay(0);
 switch_int(loc_angle) {
     case ^loc_east :
         if (coordx(coord) <= coordx(loc_coord)) {
@@ -75,49 +77,62 @@ switch_int(loc_angle) {
 }
 mes("You manage to skillfully pass the trap.");
 
-[label,regicide_fail_trap_woodspring]
-def_coord $dest;
-def_int $dir;
-p_stopaction;
+[queue,regicide_move_trap_woodspring](loc $loc_type, coord $loc_coord, coord $coord)
+if(loc_find($loc_coord, $loc_type) = true & coord = $coord) {
 switch_int(loc_angle) {
     case ^loc_east :
         if (coordx(coord) <= coordx(loc_coord)) {
-            ~forcemove(loc_coord);
+            p_walk(loc_coord);
         } else {
-            ~forcemove(movecoord(loc_coord, 1, 0, 0));
+            p_walk(movecoord(loc_coord, 1, 0, 0));
         }
+    case ^loc_west :
+        if (coordx(movecoord(coord, -1, 0, 0)) <= coordx(loc_coord)) {
+            p_walk(movecoord(loc_coord, 1, 0, 0));
+        } else {
+            p_walk(movecoord(loc_coord, 2, 0, 0));
+        }
+    case ^loc_north :
+        if (coordz(coord) <= coordz(loc_coord)) {
+            p_walk(loc_coord);
+        } else {
+            p_walk(movecoord(loc_coord, 0, 0, 1));
+        }
+    case ^loc_south :
+        if (coordz(coord) > coordz(loc_coord)) {
+            p_walk(movecoord(loc_coord, 0, 0, 2));
+        } else {
+            p_walk(movecoord(loc_coord, 0, 0, 1));
+        }
+}
+}
+
+[label,regicide_fail_trap_woodspring]
+def_coord $dest;
+def_int $dir;
+switch_int(loc_angle) {
+    case ^loc_east :
         $dest = movecoord(loc_coord, -1, 0, 0);
         $dir = ^exact_east;
     case ^loc_west :
-        if (coordx(movecoord(coord, -1, 0, 0)) <= coordx(loc_coord)) {
-            ~forcemove(movecoord(loc_coord, 1, 0, 0));
-        } else {
-            ~forcemove(movecoord(loc_coord, 2, 0, 0));
-        }
         $dest = movecoord(loc_coord, 3, 0, 0);
         $dir = ^exact_west;
     case ^loc_north :
-        if (coordz(coord) <= coordz(loc_coord)) {
-            ~forcemove(loc_coord);
-        } else {
-            ~forcemove(movecoord(loc_coord, 0, 0, 1));
-        }
         $dest = movecoord(loc_coord, 0, 0, -1);
         $dir = ^exact_north;
     case ^loc_south :
-        if (coordz(coord) > coordz(loc_coord)) {
-            ~forcemove(movecoord(loc_coord, 0, 0, 2));
-        } else {
-            ~forcemove(movecoord(loc_coord, 0, 0, 1));
-        }
         $dest = movecoord(loc_coord, 0, 0, 3);
         $dir = ^exact_south;
 }
-loc_anim(woodspring);
-mes("You set off the trap as you pass.");
-sound_synth(springtrap, 0, 0);
-~agility_exactmove(human_stumble_back, 10, 0, coord, $dest, 10, 56, $dir, false);
-~damage_self(8);
+if_close;
+if(p_finduid(uid) = true) {
+    p_stopaction;
+    loc_anim(woodspring);
+    mes("You set off the trap as you pass.");
+    sound_synth(springtrap, 0, 0);
+    ~agility_exactmove(human_stumble_back, 10, 0, coord, $dest, 10, 56, $dir, false);
+    ~damage_self(8);
+}
 
 [oploc1,regicide_trap_tripwire]
 def_int $dx = 0;

--- a/scripts/quests/quest_regicide/scripts/quest_regicide.rs2
+++ b/scripts/quests/quest_regicide/scripts/quest_regicide.rs2
@@ -30,7 +30,6 @@ p_teleport(0_36_50_8_16);
 
 [oploc1,regicide_trap_woodspring]
 if(stat_random(agility, 30, 155) = false) {
-    mes("FAIL");
     weakqueue*(regicide_move_trap_woodspring, 0)(loc_type, loc_coord, coord);
     return;
 }
@@ -79,32 +78,32 @@ mes("You manage to skillfully pass the trap.");
 
 [queue,regicide_move_trap_woodspring](loc $loc_type, coord $loc_coord, coord $coord)
 if(loc_find($loc_coord, $loc_type) = true & coord = $coord) {
-switch_int(loc_angle) {
-    case ^loc_east :
-        if (coordx(coord) <= coordx(loc_coord)) {
-            p_walk(loc_coord);
-        } else {
-            p_walk(movecoord(loc_coord, 1, 0, 0));
-        }
-    case ^loc_west :
-        if (coordx(movecoord(coord, -1, 0, 0)) <= coordx(loc_coord)) {
-            p_walk(movecoord(loc_coord, 1, 0, 0));
-        } else {
-            p_walk(movecoord(loc_coord, 2, 0, 0));
-        }
-    case ^loc_north :
-        if (coordz(coord) <= coordz(loc_coord)) {
-            p_walk(loc_coord);
-        } else {
-            p_walk(movecoord(loc_coord, 0, 0, 1));
-        }
-    case ^loc_south :
-        if (coordz(coord) > coordz(loc_coord)) {
-            p_walk(movecoord(loc_coord, 0, 0, 2));
-        } else {
-            p_walk(movecoord(loc_coord, 0, 0, 1));
-        }
-}
+    switch_int(loc_angle) {
+        case ^loc_east :
+            if (coordx(coord) <= coordx(loc_coord)) {
+                p_walk(loc_coord);
+            } else {
+                p_walk(movecoord(loc_coord, 1, 0, 0));
+            }
+        case ^loc_west :
+            if (coordx(movecoord(coord, -1, 0, 0)) <= coordx(loc_coord)) {
+                p_walk(movecoord(loc_coord, 1, 0, 0));
+            } else {
+                p_walk(movecoord(loc_coord, 2, 0, 0));
+            }
+        case ^loc_north :
+            if (coordz(coord) <= coordz(loc_coord)) {
+                p_walk(loc_coord);
+            } else {
+                p_walk(movecoord(loc_coord, 0, 0, 1));
+            }
+        case ^loc_south :
+            if (coordz(coord) > coordz(loc_coord)) {
+                p_walk(movecoord(loc_coord, 0, 0, 2));
+            } else {
+                p_walk(movecoord(loc_coord, 0, 0, 1));
+            }
+    }
 }
 
 [label,regicide_fail_trap_woodspring]

--- a/scripts/quests/quest_regicide/scripts/regicide_zones.rs2
+++ b/scripts/quests/quest_regicide/scripts/regicide_zones.rs2
@@ -1,25 +1,25 @@
 // woodsprings
-[zone,0_35_50_48_8] settimer(regicide_woodspring, 1);
-[zone,0_35_50_48_16] settimer(regicide_woodspring, 1);
-[zone,0_35_50_56_8] settimer(regicide_woodspring, 1);
-[zone,0_35_50_8_24] settimer(regicide_woodspring, 1);
-[zone,0_35_50_16_24] settimer(regicide_woodspring, 1);
-[zone,0_34_50_0_8] settimer(regicide_woodspring, 1);
-[zone,0_34_49_56_40] settimer(regicide_woodspring, 1);
-[zone,0_34_49_16_32] settimer(regicide_woodspring, 1);
-[zone,0_34_49_24_32] settimer(regicide_woodspring, 1);
-[zone,0_35_49_32_24] settimer(regicide_woodspring, 1);
+[zone,0_35_50_48_8] softtimer(regicide_woodspring, 1);
+[zone,0_35_50_48_16] softtimer(regicide_woodspring, 1);
+[zone,0_35_50_56_8] softtimer(regicide_woodspring, 1);
+[zone,0_35_50_8_24] softtimer(regicide_woodspring, 1);
+[zone,0_35_50_16_24] softtimer(regicide_woodspring, 1);
+[zone,0_34_50_0_8] softtimer(regicide_woodspring, 1);
+[zone,0_34_49_56_40] softtimer(regicide_woodspring, 1);
+[zone,0_34_49_16_32] softtimer(regicide_woodspring, 1);
+[zone,0_34_49_24_32] softtimer(regicide_woodspring, 1);
+[zone,0_35_49_32_24] softtimer(regicide_woodspring, 1);
 
-[zoneexit,0_35_50_48_8] cleartimer(regicide_woodspring);
-[zoneexit,0_35_50_48_16] cleartimer(regicide_woodspring);
-[zoneexit,0_35_50_56_8] cleartimer(regicide_woodspring);
-[zoneexit,0_35_50_8_24] cleartimer(regicide_woodspring);
-[zoneexit,0_35_50_16_24] cleartimer(regicide_woodspring);
-[zoneexit,0_35_50_0_8] cleartimer(regicide_woodspring);
-[zoneexit,0_34_49_56_40] cleartimer(regicide_woodspring);
-[zoneexit,0_34_49_16_32] cleartimer(regicide_woodspring);
-[zoneexit,0_34_49_24_32] cleartimer(regicide_woodspring);
-[zoneexit,0_35_49_32_24] cleartimer(regicide_woodspring);
+[zoneexit,0_35_50_48_8] clearsofttimer(regicide_woodspring);
+[zoneexit,0_35_50_48_16] clearsofttimer(regicide_woodspring);
+[zoneexit,0_35_50_56_8] clearsofttimer(regicide_woodspring);
+[zoneexit,0_35_50_8_24] clearsofttimer(regicide_woodspring);
+[zoneexit,0_35_50_16_24] clearsofttimer(regicide_woodspring);
+[zoneexit,0_35_50_0_8] clearsofttimer(regicide_woodspring);
+[zoneexit,0_34_49_56_40] clearsofttimer(regicide_woodspring);
+[zoneexit,0_34_49_16_32] clearsofttimer(regicide_woodspring);
+[zoneexit,0_34_49_24_32] clearsofttimer(regicide_woodspring);
+[zoneexit,0_35_49_32_24] clearsofttimer(regicide_woodspring);
 
 // tripwires, 40_48 doesnt have a trigger on the adj zone, so if you come in from the east side
 // it will be delayed by 1t
@@ -48,7 +48,7 @@
 [zoneexit,0_35_50_24_0] cleartimer(regicide_pitfall);
 [zoneexit,0_35_50_32_56] cleartimer(regicide_pitfall);
 
-[timer,regicide_woodspring]
+[softtimer,regicide_woodspring]
 if(coord = 0_35_50_55_14 | coord = 0_35_50_55_15) {
     if(loc_find(0_35_50_55_14, regicide_trap_woodspring) = true) @regicide_fail_trap_woodspring;
 } else if(coord = 0_35_50_17_27 | coord = 0_35_50_18_27) {
@@ -74,7 +74,7 @@ if(loc_find(coord, regicide_pitfall_side) = true | loc_find(coord, regicide_pitf
     p_delay(0);
     mes("It's a trap!");
     anim(human_walk_logbalance_stumble, 0);
-    // sound
+    sound_synth(stumble_loop, 3, 0);
     p_delay(0);
     @regicide_pitfall_falldown;
 }

--- a/scripts/quests/quest_upass/scripts/upass_grid.rs2
+++ b/scripts/quests/quest_upass/scripts/upass_grid.rs2
@@ -79,7 +79,7 @@ p_stopaction;
 p_delay(0);
 mes("It's a trap!");
 anim(human_walk_logbalance_stumble, 0);
-// sound
+sound_synth(stumble_loop, 3, 0);
 p_delay(0);
 mes("You fall onto the spikes.");
 // seems to just be random based off old videos, changed with sote on osrs to be relative to where you fall

--- a/scripts/skill_combat/configs/melee/spears.obj
+++ b/scripts/skill_combat/configs/melee/spears.obj
@@ -1048,4 +1048,6 @@ param=poison_severity,30
 param=tbwt_karambwan_poison,^true
 param=next_obj_stage,dragon_spear
 param=tbwt_weapon_poison_clear,You gingerly wipe the poison off the spear
+param=specwep,^true
+param=sa_energy,250
 // osrs slash sound staff_crush / crush sound newstaff

--- a/scripts/skill_combat/scripts/player/player_special_attack.rs2
+++ b/scripts/skill_combat/scripts/player/player_special_attack.rs2
@@ -24,7 +24,7 @@ switch_obj($weapon) {
     case magic_shortbow : @pvm_magic_shortbow_sa;
     case magic_longbow : @pvm_magic_longbow_sa;
     case rune_thrownaxe : @pvm_rune_thrownaxe_sa;
-    case dragon_spear, dragon_spear_p : @pvm_dragon_spear_sa;
+    case dragon_spear, dragon_spear_p, tbwt_dragon_spear_kp : @pvm_dragon_spear_sa;
     case rune_claws : @pvm_rune_claws_sa;
     case dragon_halberd : @pvm_dragon_halberd_sa;
 }

--- a/scripts/skill_combat/scripts/pvp/pvp_special_attack.rs2
+++ b/scripts/skill_combat/scripts/pvp/pvp_special_attack.rs2
@@ -42,7 +42,7 @@ switch_obj($weapon) {
     case magic_shortbow : @pvp_magic_shortbow_sa;
     case magic_longbow : @pvp_magic_longbow_sa;
     case rune_thrownaxe : @pvp_rune_thrownaxe_sa;
-    case dragon_spear, dragon_spear_p : @pvp_dragon_spear_sa;
+    case dragon_spear, dragon_spear_p, tbwt_dragon_spear_kp : @pvp_dragon_spear_sa;
     case rune_claws : @pvp_rune_claws_sa;
     case dragon_halberd : @pvp_dragon_halberd_sa;
 }

--- a/scripts/skill_smithing/configs/smithing/smithing.inv
+++ b/scripts/skill_smithing/configs/smithing/smithing.inv
@@ -103,8 +103,8 @@ size=5
 stock1=steel_dart_tip,10
 stock2=steel_arrowheads,15
 stock3=steel_knife,5
-stock5=nails,2
-stock4=studs,1
+stock4=nails,2
+stock5=studs,1
 
 [smithing_mithril1]
 size=5
@@ -213,24 +213,24 @@ stock3=rune_knife,5
 
 [smithing_bronze_claws]
 size=1
-stock0=bronze_claws,1
+stock1=bronze_claws,1
 
 [smithing_iron_claws]
 size=1
-stock0=iron_claws,1
+stock1=iron_claws,1
 
 [smithing_steel_claws]
 size=1
-stock0=steel_claws,1
+stock1=steel_claws,1
 
 [smithing_mithril_claws]
 size=1
-stock0=mithril_claws,1
+stock1=mithril_claws,1
 
 [smithing_adamant_claws]
 size=1
-stock0=adamant_claws,1
+stock1=adamant_claws,1
 
 [smithing_rune_claws]
 size=1
-stock0=rune_claws,1
+stock1=rune_claws,1


### PR DESCRIPTION
- update the stick trap in isafdar to weakqueue movement on to the trap when failing + softtimer for the trap functionality, this matches what osrs has for this trap and will allow spamming the op1 repeatedly until you pass
- fix broken linebreak in horror journal
- add spec to dspear (kp)
- fix "overpass" trying to play in the wrong mapsquare, also added triggers for "bandit camp" and "sunburn"
- add sounds to the leaf and grid traps in regicide/underground pass (the underground pass sound can be added to 244+ probably)
- fixed incorrect stock values for the smithing interface