### PR TITLE
fix: peer banking fixes, wrong inv for olaf trial completion

### DIFF
--- a/scripts/interface_bank/scripts/bank.rs2
+++ b/scripts/interface_bank/scripts/bank.rs2
@@ -84,15 +84,17 @@ if ($withdraw > 0) {
     }
 }
 
-[proc,bank_deposit_request](inv $inv, obj $obj, int $amount, int $slot)
+[proc,bank_deposit_request](inv $inv, obj $obj, int $amount, int $slot, int $mes)(boolean)
 def_int $overflow = inv_itemspace2(bank, oc_uncert($obj), $amount, ^max_32bit_int);
-if (sub(^max_32bit_int, $amount) < inv_total(bank, $obj)) {
-    mes("You already have a full stack of that item in the bank."); // 2024 osrs
-} else if ($overflow >= $amount) {
+if (sub(^max_32bit_int, $amount) < inv_total(bank, oc_uncert($obj))) {
+    if($mes = ^true) mes("You already have a full stack of that item in the bank."); // 2024 osrs
+    return (false);
+}
+if ($overflow >= $amount) {
     // https://youtu.be/2BgXLZD-xgo?t=28
     // https://youtu.be/Ep4gaI5ic1s?t=197
-    mes("You don't have enough space in your bank account."); // osrs
-    return;
+    if($mes = ^true) mes("You don't have enough space in your bank account."); // osrs
+    return (false);
 }
 def_int $deposit = sub($amount, $overflow);
 if ($deposit > 0) {
@@ -100,9 +102,9 @@ if ($deposit > 0) {
     inv_moveitem_uncert($inv, bank, $obj, $deposit);
 }
 
-[proc,bank_check_nobreak](obj $obj)(boolean)
+[proc,bank_check_nobreak](obj $obj, int $send_mes)(boolean)
 if (oc_param($obj, unbankable) = ^true) {
-    mes("A magical force prevents you from banking this item!"); // osrs
+    if($send_mes = ^true) mes("A magical force prevents you from banking this item!"); // osrs
     return(true);
 }
 

--- a/scripts/interface_bank/scripts/bank_deposit.rs2
+++ b/scripts/interface_bank/scripts/bank_deposit.rs2
@@ -19,9 +19,9 @@ def_int $number = inv_total(inv, $item);
 // How many should we deposit?
 if ($requested_number < $number) $number = $requested_number;
 // Is it actually bankable?
-if (~bank_check_nobreak($item) = true) {
+if (~bank_check_nobreak($item, ^true) = true) {
     // custom handling here if needed.
     return;
 }
 // Okay, deposit it into the bank.
-~bank_deposit_request(inv, $item, $number, $slot);
+~bank_deposit_request(inv, $item, $number, $slot, ^true);

--- a/scripts/quests/quest_viking/scripts/viking_olaf.rs2
+++ b/scripts/quests/quest_viking/scripts/viking_olaf.rs2
@@ -472,7 +472,7 @@ mes("You feel the musical ability from the Fossegrimen leave you...");
 %viking_bits = clearbit(%viking_bits, ^viking_rock_stew);
 ~set_viking_olaf_progress(^olaf_complete);
 def_int $totalinv = inv_total(inv, viking_enchanted_strung_lyre);
-def_int $totalbank = inv_total(inv, viking_enchanted_strung_lyre);
+def_int $totalbank = inv_total(bank, viking_enchanted_strung_lyre);
 if($totalinv > 0) {
     inv_del(inv, viking_enchanted_strung_lyre, $totalinv);
     inv_add(inv, viking_strung_lyre, $totalinv);

--- a/scripts/quests/quest_viking/scripts/viking_peer.rs2
+++ b/scripts/quests/quest_viking/scripts/viking_peer.rs2
@@ -183,25 +183,50 @@ if($op = 2) {
 @peer_deposit;
 
 [label,peer_deposit]
-def_int $space_needed = 0;
-$space_needed = add($space_needed, ~moveallinv_itemspace2(inv, bank));
-$space_needed = add($space_needed, ~moveallinv_itemspace2(worn, bank));
-if(inv_freespace(bank) < $space_needed | inv_totalparam(inv, unbankable) > 0 | inv_totalparam(worn, unbankable) > 0) {
-    ~chatnpc("<p,neutral>I am sorry outerlander, the spell is not working.");
-    return;
-}
-
-~moveallinv(inv, bank);
-def_int $size = inv_size(worn);
+def_int $size = inv_size(inv);
+def_int $dep_count;
 def_int $i = 0;
 def_obj $obj;
+def_int $fail = ^false;
+while ($i < $size) {
+    $obj = inv_getobj(inv, $i);
+    if ($obj ! null) {
+        if (~bank_check_nobreak($obj, ^false) = false) {
+            if(~bank_deposit_request(inv, $obj, inv_total(inv, $obj), $i, ^false) = true) {
+                $dep_count = add($dep_count, 1);
+            } else {
+                $fail = ^true;
+            }
+        } else {
+            $fail = ^true;
+        }
+    }
+    $i = add($i, 1);
+}
+
+$size = inv_size(worn);
+$i = 0;
 while ($i < $size) {
     $obj = inv_getobj(worn, $i);
     if ($obj ! null) {
-        inv_moveitem(worn, bank, $obj, inv_total(worn, $obj));
-        ~update_all($obj); // based off rsprox logs it does update_all (and plays unequip sounds) for ea item
+        if (~bank_check_nobreak($obj, ^false) = false) {
+            if(~bank_deposit_request(worn, $obj, inv_total(worn, $obj), $i, ^false) = true) {
+                $dep_count = add($dep_count, 1);
+            } else {
+                $fail = ^true;
+            }
+        } else {
+            $fail = ^true;
+        }
     }
     $i = add($i, 1);
+}
+
+if($fail = ^true) {
+    if($dep_count > 0) mes("Some of your items cannot be stored in the bank.");
+    else mes("Your items cannot be stored in the bank.");
+    ~chatnpc("<p,sad>I am sorry outerlander, the spell is not working.");
+    return;
 }
 ~chatnpc("<p,neutral>The task is done. I wish you luck with your test, outerlander.");
 


### PR DESCRIPTION
for 274
- rewrite the peer banking system to only use bank procs for checks/depositing
- change $totalbank to pull from bank in olafs trial completion
- fixed full stack message not showing for cert items (this can be applied to 225+)