### PR TITLE
fix: Leather chaps incorrect amounts & runelink fixes & obj config update

### DIFF
--- a/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
+++ b/scripts/minigames/game_duelarena/scripts/duel_arena.rs2
@@ -47,6 +47,7 @@ if (~in_games_room(coord) = true & ~in_games_room(.coord) = true) {
             if_settext(boardgames_challenge:runelink_rank, "<tostring(%boardgames_runelink_rank)> vs <tostring(.%boardgames_runelink_rank)>");
             // if_settext(boardgames_challenge:runesquares_rank, "<tostring(%boardgames_runesquares_rank)> vs <tostring(.%boardgames_runesquares_rank)>");
             // if_settext(boardgames_challenge:runeversi_rank, "<tostring(%boardgames_runeversi_rank)> vs <tostring(.%boardgames_runeversi_rank)>");
+            %if1 = 0;
             if_openmain(boardgames_challenge);
         }
     } else {

--- a/scripts/minigames/game_gamesroom/boardgames_runelink/scripts/boardgames_runelink.rs2
+++ b/scripts/minigames/game_gamesroom/boardgames_runelink/scripts/boardgames_runelink.rs2
@@ -547,7 +547,7 @@ def_int $p2_rank = .%boardgames_runelink_rank;
 
 def_int $rank_change = ~calculate_rank_change($p2_rank, $p1_rank);
 
-if (%boardgames_rankedgame = 1 & inv_totalcat(boardgames_boardinv, boardgames_piece) > 3) {
+    if(%boardgames_rankedgame = 1 & add(inv_totalcat(boardgames_boardinv, boardgames_piece), inv_totalcat(boardgames_boardinv, draughts_king)) > 3) {
     %boardgames_runelink_rank = add(%boardgames_runelink_rank, $rank_change);
     if (%boardgames_runelink_rank > 60000) {
         %boardgames_runelink_rank = 60000;
@@ -593,7 +593,7 @@ if (%boardgames_closemode = ^boardgames_draw) {
         if_settext(boardgames_runelink_view:status1, "Player resigned.");
     }
 
-    if(%boardgames_rankedgame = 1 & inv_totalcat(boardgames_boardinv, boardgames_piece) > 3) {
+    if(%boardgames_rankedgame = 1 & add(inv_totalcat(boardgames_boardinv, boardgames_piece), inv_totalcat(boardgames_boardinv, draughts_king)) > 3) {
         if_settext(boardgames_runelink_view:status2, "Rank change: +<tostring($rank_change)>");
     } else {
         if_settext(boardgames_runelink_view:status2, "");
@@ -607,7 +607,7 @@ if (%boardgames_closemode = ^boardgames_draw) {
         if_settext(boardgames_runelink_view:status1, "Player resigned.");
     }
 
-    if(%boardgames_rankedgame = 1 & inv_totalcat(boardgames_boardinv, boardgames_piece) > 3) {
+    if(%boardgames_rankedgame = 1 & add(inv_totalcat(boardgames_boardinv, boardgames_piece), inv_totalcat(boardgames_boardinv, draughts_king)) > 3) {
         if_settext(boardgames_runelink_view:status2, "Rank change: -<tostring($rank_change)>");
     } else {
         if_settext(boardgames_runelink_view:status2, "");
@@ -681,7 +681,7 @@ if (%boardgames_viewing = 0) {
     def_int $loser_rank = %boardgames_runelink_rank;
     def_int $rank_change = ~calculate_rank_change($loser_rank, $winner_rank);
 
-    if (%boardgames_rankedgame = 1 & inv_totalcat(boardgames_boardinv, boardgames_piece) > 3) {
+    if(%boardgames_rankedgame = 1 & add(inv_totalcat(boardgames_boardinv, boardgames_piece), inv_totalcat(boardgames_boardinv, draughts_king)) > 3) {
         .%boardgames_runelink_rank = add(.%boardgames_runelink_rank, $rank_change);
         if (.%boardgames_runelink_rank > 60000) {
             .%boardgames_runelink_rank = 60000;
@@ -702,7 +702,7 @@ if (%boardgames_viewing = 0) {
     if_settext(boardgames_runelink_view:winner, "You lose!");
     if_settext(boardgames_runelink_view:status1, "Player resigned.");
     
-    if(%boardgames_rankedgame = 1 & inv_totalcat(boardgames_boardinv, boardgames_piece) > 3) {
+    if(%boardgames_rankedgame = 1 & add(inv_totalcat(boardgames_boardinv, boardgames_piece), inv_totalcat(boardgames_boardinv, draughts_king)) > 3) {
         if_settext(boardgames_runelink_view:status2, "Rank change: -<tostring($rank_change)>");
     } else {
         if_settext(boardgames_runelink_view:status2, "");

--- a/scripts/minigames/game_mortton/configs/mortton.obj
+++ b/scripts/minigames/game_mortton/configs/mortton.obj
@@ -13,6 +13,7 @@ members=yes
 category=category_2049
 param=pyre_shade_exp,250
 param=shades_struct,loar_shades
+weight=1360g
 
 [shade_bones2]
 name=Phrin remains
@@ -29,6 +30,7 @@ members=yes
 category=category_2049
 param=pyre_shade_exp,375
 param=shades_struct,phrin_shades
+weight=1360g
 
 [shade_bones3]
 name=Riyl remains
@@ -45,6 +47,7 @@ members=yes
 category=category_2049
 param=pyre_shade_exp,525
 param=shades_struct,riyl_shades
+weight=1360g
 
 [shade_bones4]
 name=Asyn remains
@@ -61,6 +64,7 @@ members=yes
 category=category_2049
 param=pyre_shade_exp,700
 param=shades_struct,asyn_shades
+weight=1360g
 
 [shade_bones5]
 name=Fiyr remains
@@ -77,6 +81,7 @@ members=yes
 category=category_2049
 param=pyre_shade_exp,900
 param=shades_struct,fiyr_shades
+weight=1360g
 
 [sacred_oil4]
 name=Sacred oil(4)
@@ -94,6 +99,7 @@ param=next_obj_stage,sacred_oil3
 param=dose_count,4
 param=decant_potion_enum,potion_sacredoil
 category=category_111
+weight=35g
 
 [sacred_oil3]
 name=Sacred oil(3)
@@ -111,6 +117,7 @@ param=next_obj_stage,sacred_oil2
 param=dose_count,3
 param=decant_potion_enum,potion_sacredoil
 category=category_111
+weight=30g
 
 [sacred_oil2]
 name=Sacred oil(2)
@@ -128,6 +135,7 @@ param=next_obj_stage,sacred_oil1
 param=dose_count,2
 param=decant_potion_enum,potion_sacredoil
 category=category_111
+weight=25g
 
 [sacred_oil1]
 name=Sacred oil(1)
@@ -145,6 +153,7 @@ param=next_obj_stage,vial_empty
 param=dose_count,1
 param=decant_potion_enum,potion_sacredoil
 category=category_111
+weight=20g
 
 [logs_pyre]
 name=Pyre logs
@@ -161,6 +170,7 @@ model=model_2800_obj
 members=yes
 category=category_2050
 param=funeral_pyre_struct,pyre_logs
+weight=1360g
 
 [oak_logs_pyre]
 name=Oak pyre logs
@@ -177,6 +187,7 @@ model=model_2800_obj
 members=yes
 category=category_2050
 param=funeral_pyre_struct,pyre_oak_logs
+weight=1360g
 
 [willow_logs_pyre]
 name=Willow pyre logs
@@ -193,6 +204,7 @@ model=model_2800_obj
 members=yes
 category=category_2050
 param=funeral_pyre_struct,pyre_willow_logs
+weight=1360g
 
 [maple_logs_pyre]
 name=Maple pyre logs
@@ -209,6 +221,7 @@ model=model_2800_obj
 members=yes
 category=category_2050
 param=funeral_pyre_struct,pyre_maple_logs
+weight=1360g
 
 [yew_logs_pyre]
 name=Yew pyre logs
@@ -225,6 +238,7 @@ model=model_2800_obj
 members=yes
 category=category_2050
 param=funeral_pyre_struct,pyre_yew_logs
+weight=1360g
 
 [magic_logs_pyre]
 name=Magic pyre logs
@@ -242,6 +256,7 @@ model=model_2800_obj
 members=yes
 category=category_2050
 param=funeral_pyre_struct,pyre_magic_logs
+weight=1360g
 
 [shadekey_bronze_bloodred]
 name=Bronze key red
@@ -265,6 +280,7 @@ cost=81
 members=yes
 category=category_112
 tradeable=no
+weight=10g
 
 [shadekey_bronze_brown]
 name=Bronze key brown
@@ -288,6 +304,7 @@ cost=82
 members=yes
 category=category_112
 tradeable=no
+weight=10g
 
 [shadekey_bronze_crimson]
 name=Bronze key crimson
@@ -311,6 +328,7 @@ cost=83
 members=yes
 category=category_112
 tradeable=no
+weight=10g
 
 [shadekey_bronze_black]
 name=Bronze key black
@@ -334,6 +352,7 @@ cost=84
 members=yes
 category=category_112
 tradeable=no
+weight=10g
 
 [shadekey_bronze_purple]
 name=Bronze key purple
@@ -357,6 +376,7 @@ cost=85
 members=yes
 category=category_112
 tradeable=no
+weight=10g
 
 [shadekey_steel_bloodred]
 name=Steel key red
@@ -380,6 +400,7 @@ cost=86
 members=yes
 category=category_113
 tradeable=no
+weight=10g
 
 [shadekey_steel_brown]
 name=Steel key brown
@@ -403,6 +424,7 @@ cost=87
 members=yes
 category=category_113
 tradeable=no
+weight=10g
 
 [shadekey_steel_crimson]
 name=Steel key crimson
@@ -426,6 +448,7 @@ cost=88
 members=yes
 category=category_113
 tradeable=no
+weight=10g
 
 [shadekey_steel_black]
 name=Steel key black
@@ -449,6 +472,7 @@ cost=89
 members=yes
 category=category_113
 tradeable=no
+weight=10g
 
 [shadekey_steel_purple]
 name=Steel key purple
@@ -472,6 +496,7 @@ cost=90
 members=yes
 category=category_113
 tradeable=no
+weight=10g
 
 [shadekey_black_bloodred]
 name=Black key red
@@ -495,6 +520,7 @@ cost=91
 members=yes
 category=category_114
 tradeable=no
+weight=10g
 
 [shadekey_black_brown]
 name=Black key brown
@@ -518,6 +544,7 @@ cost=92
 members=yes
 category=category_114
 tradeable=no
+weight=10g
 
 [shadekey_black_crimson]
 name=Black key crimson
@@ -541,6 +568,7 @@ cost=93
 members=yes
 category=category_114
 tradeable=no
+weight=10g
 
 [shadekey_black_black]
 name=Black key black
@@ -564,6 +592,7 @@ cost=94
 members=yes
 category=category_114
 tradeable=no
+weight=10g
 
 [shadekey_black_purple]
 name=Black key purple
@@ -587,6 +616,7 @@ cost=95
 members=yes
 category=category_114
 tradeable=no
+weight=10g
 
 [shadekey_silver_bloodred]
 name=Silver key red
@@ -610,6 +640,7 @@ cost=96
 members=yes
 category=category_115
 tradeable=no
+weight=10g
 
 [shadekey_silver_brown]
 name=Silver key brown
@@ -633,6 +664,7 @@ cost=97
 members=yes
 category=category_115
 tradeable=no
+weight=10g
 
 [shadekey_silver_crimson]
 name=Silver key crimson
@@ -656,6 +688,7 @@ cost=98
 members=yes
 category=category_115
 tradeable=no
+weight=10g
 
 [shadekey_silver_black]
 name=Silver key black
@@ -679,6 +712,7 @@ cost=99
 members=yes
 category=category_115
 tradeable=no
+weight=10g
 
 [shadekey_silver_purple]
 name=Silver key purple
@@ -702,3 +736,4 @@ cost=100
 members=yes
 category=category_115
 tradeable=no
+weight=10g

--- a/scripts/quests/quest_mortton/configs/quest_mortton.obj
+++ b/scripts/quests/quest_mortton/configs/quest_mortton.obj
@@ -18,6 +18,7 @@ iop1=Read
 2dxan=244
 members=yes
 tradeable=no
+weight=510g
 
 [ashesvial]
 name=Unfinished potion
@@ -31,6 +32,7 @@ model=model_2789_obj
 2dyan=1996
 2dxan=84
 members=yes
+weight=56g
 
 [mort_serum4]
 name=Serum 207 (4)
@@ -49,6 +51,7 @@ param=next_obj_stage,mort_serum3
 param=next_obj_stage_temple,mort_serum_perm4
 param=dose_count,4
 param=decant_potion_enum,potion_mortserum
+weight=35g
 
 [mort_serum3]
 name=Serum 207 (3)
@@ -67,6 +70,7 @@ param=next_obj_stage,mort_serum2
 param=next_obj_stage_temple,mort_serum_perm3
 param=dose_count,3
 param=decant_potion_enum,potion_mortserum
+weight=30g
 
 [mort_serum2]
 name=Serum 207 (2)
@@ -85,6 +89,7 @@ param=next_obj_stage,mort_serum1
 param=next_obj_stage_temple,mort_serum_perm2
 param=dose_count,2
 param=decant_potion_enum,potion_mortserum
+weight=25g
 
 [mort_serum1]
 name=Serum 207 (1)
@@ -103,6 +108,7 @@ param=next_obj_stage,vial_empty
 param=next_obj_stage_temple,mort_serum_perm1
 param=dose_count,1
 param=decant_potion_enum,potion_mortserum
+weight=20g
 
 [mort_serum_perm4]
 name=Serum 207(p) (4)
@@ -121,6 +127,7 @@ param=dose_count,4
 param=decant_potion_enum,potion_mortserumperm
 category=category_109
 tradeable=false
+weight=35g
 
 [mort_serum_perm3]
 name=Serum 207(p) (3)
@@ -139,6 +146,7 @@ param=dose_count,3
 param=decant_potion_enum,potion_mortserumperm
 category=category_109
 tradeable=false
+weight=30g
 
 [mort_serum_perm2]
 name=Serum 207(p) (2)
@@ -157,6 +165,7 @@ param=dose_count,2
 param=decant_potion_enum,potion_mortserumperm
 category=category_109
 tradeable=false
+weight=25g
 
 [mort_serum_perm1]
 name=Serum 207(p) (1)
@@ -175,6 +184,7 @@ param=dose_count,1
 param=decant_potion_enum,potion_mortserumperm
 category=category_109
 tradeable=false
+weight=20g
 
 [limestonebrick]
 name=Limestone brick
@@ -189,6 +199,7 @@ model=model_2510_obj
 2dyan=136
 2dxan=200
 members=yes
+weight=1360g
 
 [oliveoil4]
 name=Olive oil(4)
@@ -206,6 +217,7 @@ category=category_110
 param=next_obj_stage,sacred_oil4
 param=dose_count,4
 param=decant_potion_enum,potion_oliveoil
+weight=35g
 
 [oliveoil3]
 name=Olive oil(3)
@@ -223,6 +235,7 @@ category=category_110
 param=next_obj_stage,sacred_oil3
 param=dose_count,3
 param=decant_potion_enum,potion_oliveoil
+weight=30g
 
 [oliveoil2]
 name=Olive oil(2)
@@ -240,6 +253,7 @@ category=category_110
 param=next_obj_stage,sacred_oil2
 param=dose_count,2
 param=decant_potion_enum,potion_oliveoil
+weight=25g
 
 [oliveoil1]
 name=Olive oil(1)
@@ -257,3 +271,4 @@ category=category_110
 param=next_obj_stage,sacred_oil1
 param=dose_count,1
 param=decant_potion_enum,potion_oliveoil
+weight=20g

--- a/scripts/skill_crafting/configs/snelm/snelm.obj
+++ b/scripts/skill_crafting/configs/snelm/snelm.obj
@@ -460,7 +460,7 @@ model=obj_3355
 2dxan=232
 weight=10kg
 category=category_3
-param=next_obj_stage,snelm_point_red+black
+param=next_obj_stage,snelm_point_yellow
 
 [shellpoint_blue]
 name=Blamish blue shell

--- a/scripts/skill_crafting/scripts/leather/leather.rs2
+++ b/scripts/skill_crafting/scripts/leather/leather.rs2
@@ -15,8 +15,8 @@
 [if_button,leather_crafting:com_120] @craft_leather(leather_vambraces, 10);
 
 [if_button,leather_crafting:com_125] @craft_leather(leather_chaps, 1);
-[if_button,leather_crafting:com_124] @craft_leather(leather_chaps, 1);
-[if_button,leather_crafting:com_123] @craft_leather(leather_chaps, 1);
+[if_button,leather_crafting:com_124] @craft_leather(leather_chaps, 5);
+[if_button,leather_crafting:com_123] @craft_leather(leather_chaps, 10);
 
 [if_button,leather_crafting:com_128] @craft_leather(coif, 1);
 [if_button,leather_crafting:com_127] @craft_leather(coif, 5);


### PR DESCRIPTION
- Added weight to some objs that were missing it.
- Fixed boardgames initial interface not defaulting to correct option
- Fixed edge case in runelink that didn't change rating when it should
- Fixed leather chaps crafting for 5 and 10 amounts
- Fixed wrong snelm for pointed yellow shells