### PR TITLE
fix: More Eadgar's Ruse fixes

### DIFF
--- a/scripts/areas/area_taverly/scripts/sanfew.rs2
+++ b/scripts/areas/area_taverly/scripts/sanfew.rs2
@@ -111,11 +111,12 @@ if(%death_equiproom = ^death_complete & %troll_quest = ^troll_complete) {
         @multi2("I'll do it.", sanfew_ill_do_it, "No thanks.", sanfew_no_thanks);
     } else {
         // Before my run of the quest in OSRS, I tried starting the quest with Death Plateau and Troll Stronghold completed but under 31 Herblore and I got:
-        ~chatnpc("<p,neutral>Not just yet, young 'un.");
-        // The wiki says there should be different dialog (below) but I'm skeptical of the spelling ("'m" versus "I'm")
-        // and also this line didn't show up for me, so... TODO I guess?
-        //~chatnpc("<p,sad>'m afraid you are not yet learned enough in the art of Herblore to be able to help me, adventurer...");
-        ~mesbox("You do not meet all of the requirements to start the Eadgar's Ruse quest.");
+        //~chatnpc("<p,neutral>Not just yet, young 'un.");
+        // OSRS wiki *says* there should be different dialog (below) but this wasn't the case when I checked OSRS
+        ~chatnpc("<p,sad>I'm afraid you are not yet learned enough in the art of Herblore to be able to help me, adventurer...");
+        // This line is also used in RS3 (but the mesbox afterwards is *not* - dialog simply ends)
+        // Relatively unsure which to use, but switched to the RS3 behavior as it feels older to me
+        //~mesbox("You do not meet all of the requirements to start the Eadgar's Ruse quest.");
     }
 } else {
     ~chatnpc("<p,neutral>Well, not right now I don't think young 'un. In fact, I need to make some more preparations myself for the ritual. Rest assured, if I need any more help I will ask you again.");

--- a/scripts/areas/area_taverly/scripts/sanfew.rs2
+++ b/scripts/areas/area_taverly/scripts/sanfew.rs2
@@ -110,13 +110,15 @@ if(%death_equiproom = ^death_complete & %troll_quest = ^troll_complete) {
         ~chatnpc("<p,neutral>My friend Eadgar lives in the area, and he may be able to help you. Bring some goutweed back and I will teach you something useful.");
         @multi2("I'll do it.", sanfew_ill_do_it, "No thanks.", sanfew_no_thanks);
     } else {
-        // Before my run of the quest in OSRS, I tried starting the quest with Death Plateau and Troll Stronghold completed but under 31 Herblore and I got:
+        // OSRS: I tried starting the quest with Death Plateau and Troll Stronghold completed but under 31 Herblore and I got:
         //~chatnpc("<p,neutral>Not just yet, young 'un.");
-        // OSRS wiki *says* there should be different dialog (below) but this wasn't the case when I checked OSRS
-        ~chatnpc("<p,sad>I'm afraid you are not yet learned enough in the art of Herblore to be able to help me, adventurer...");
-        // This line is also used in RS3 (but the mesbox afterwards is *not* - dialog simply ends)
-        // Relatively unsure which to use, but switched to the RS3 behavior as it feels older to me
         //~mesbox("You do not meet all of the requirements to start the Eadgar's Ruse quest.");
+        //
+        // This is confusing because according to the wiki transcript, you should only get that line/mesbox if you are *missing* the quest prereqs (Death Plateau and/or Troll Stronghold)
+        // OSRS wiki says there should be different dialog for *only* missing Herblore level (below) but this wasn't the case when I checked OSRS
+        ~chatnpc("<p,sad>I'm afraid you are not yet learned enough in the art of Herblore to be able to help me, adventurer...");
+        // The above line *is* used in RS3 if you are missing Herblore req only (but the mesbox afterwards is *not* - dialog simply ends)
+        // Relatively unsure which to use, but switched to the RS3 behavior as it feels older to me
     }
 } else {
     // TODO this might be the wrong dialog - this is the "generic" line for when Sanfew has no more quests for you (after Druidic Ritual/Eadgar's Ruse)

--- a/scripts/areas/area_taverly/scripts/sanfew.rs2
+++ b/scripts/areas/area_taverly/scripts/sanfew.rs2
@@ -119,6 +119,9 @@ if(%death_equiproom = ^death_complete & %troll_quest = ^troll_complete) {
         //~mesbox("You do not meet all of the requirements to start the Eadgar's Ruse quest.");
     }
 } else {
+    // TODO this might be the wrong dialog - this is the "generic" line for when Sanfew has no more quests for you (after Druidic Ritual/Eadgar's Ruse)
+    // there might be another line for specifically trying to start Eadgar's Ruse without quest prereqs completed
+    // I don't yet have a test case recorded for trying to start Eadgar's Ruse with Druidic Ritual completed but NOT Death Plateau/Troll Stronghold
     ~chatnpc("<p,neutral>Well, not right now I don't think young 'un. In fact, I need to make some more preparations myself for the ritual. Rest assured, if I need any more help I will ask you again.");
 }
 
@@ -131,10 +134,9 @@ if(%death_equiproom = ^death_complete & %troll_quest = ^troll_complete) {
 ~chatnpc("<p,happy>Thank you, adventurer!");
 
 [label,sanfew_no_thanks]
-// source https://oldschool.runescape.wiki/w/Transcript:Eadgar%27s_Ruse?oldid=15100939
-// todo need to verify mesanim for these, think i missed them
+// mesanims from RS3
 ~chatplayer("<p,neutral>No thanks.");
-~chatnpc("<p,neutral>Oh well. No doubt some other adventurer will eventually come who can help me.");
+~chatnpc("<p,sad>Oh well. No doubt some other adventurer will eventually come who can help me.");
 
 [label,eadgar_sanfew_reminder]
 // rsprox/branon
@@ -171,7 +173,7 @@ if(inv_total(inv, eadgar_goutweed_herb) > 0) {
     ~chatplayer("<p,happy>I have some more goutweed for you.");
     ~chatnpc("<p,happy>Ah, good. Here are some herbs in exchange.");
 } else {
-    //TODO: Check mesanims for these
-    ~chatplayer("<p,neutral>Did you say you needed more goutweed?");
+    //mesanims rsprox/branon
+    ~chatplayer("<p,quiz>Did you say you needed more goutweed?");
     ~chatnpc("<p,neutral>I don't need any more goutweed for the ritual, but it's still quite difficult for me to get. If you ever come across some, bring it to me; I'll exchange it for some other herbs.");
 }

--- a/scripts/quests/quest_eadgar/scripts/eadgar_druid_washing.rs2
+++ b/scripts/quests/quest_eadgar/scripts/eadgar_druid_washing.rs2
@@ -1,19 +1,17 @@
 [opnpc1,eadgar_druid_washing]
 // mesanims rsprox/branon
 ~chatplayer("<p,happy>So, you're doing laundry, eh?");
-if(.npc_find(coord, eadgar_druid_washing, 5, 0) = true) {
-    ~.chatnpcnoturn("<p,neutral>Yes. What is it to you?");
-    ~chatplayer("<p,happy>Nice day for it.");
-    ~.chatnpcnoturn("<p,neutral>I suppose it is.");
-    if(%eadgar_quest = ^eadgar_needs_items & testbit(%eadgar_bits, ^eadgar_given_clothes) = ^false) {
-        if(inv_total(inv, eadgar_dirty_druid_robe) = 0 & inv_total(bank, eadgar_dirty_druid_robe) = 0) {
-            ~chatplayer("<p,quiz>You wouldn't be able to spare any of those dirty robes by any chance? It's a matter of the utmost importance.");
-            ~.chatnpcnoturn("<p,angry>What? No! These are my robes!");
-            switch_int(~p_choice3("Fine.", 1, "Sanfew won't be happy...", 2, "You'll give me those robes right now...", 3)) {
-                case 1 : @eadgar_tegid_fine;
-                case 2 : @eadgar_tegid_sanfew_wont_be_happy;
-                case 3 : @eadgar_tegid_threaten;
-            }
+~chatnpcnoturn("<p,neutral>Yes. What is it to you?");
+~chatplayer("<p,happy>Nice day for it.");
+~chatnpcnoturn("<p,neutral>I suppose it is.");
+if(%eadgar_quest = ^eadgar_needs_items & testbit(%eadgar_bits, ^eadgar_given_clothes) = ^false) {
+    if(inv_total(inv, eadgar_dirty_druid_robe) = 0 & inv_total(bank, eadgar_dirty_druid_robe) = 0) {
+        ~chatplayer("<p,quiz>You wouldn't be able to spare any of those dirty robes by any chance? It's a matter of the utmost importance.");
+        ~chatnpcnoturn("<p,angry>What? No! These are my robes!");
+        switch_int(~p_choice3("Fine.", 1, "Sanfew won't be happy...", 2, "You'll give me those robes right now...", 3)) {
+            case 1 : @eadgar_tegid_fine;
+            case 2 : @eadgar_tegid_sanfew_wont_be_happy;
+            case 3 : @eadgar_tegid_threaten;
         }
     }
 }
@@ -27,16 +25,16 @@ if(.npc_find(coord, eadgar_druid_washing, 5, 0) = true) {
 // mesanims rsprox/branon
 queue(eadgar_tegid_give_clothes, 0, 0);
 ~chatplayer("<p,neutral>I'm sure Sanfew won't be happy when I tell him it's your fault he can't perform the purification ritual.");
-~.chatnpcnoturn("<p,happy>What? Oh well, if it's a matter of that much importance, I suppose you can borrow one...");
+~chatnpcnoturn("<p,happy>What? Oh well, if it's a matter of that much importance, I suppose you can borrow one...");
 
 [label,eadgar_tegid_threaten]
 // dialog from LP41 video
 // mesanims rsprox/branon
 queue(eadgar_tegid_give_clothes, 0, 0);
 ~chatplayer("<p,angry>You'll give me those robes right now...or I'm going to cut down trees until you do.");
-~.chatnpcnoturn("<p,scared>You wouldn't dare!");
+~chatnpcnoturn("<p,scared>You wouldn't dare!");
 ~chatplayer("<p,quiz>Of course I would. They're just trees.");
-~.chatnpcnoturn("<p,scared>You monster! Take the robes and leave this place!");
+~chatnpcnoturn("<p,scared>You monster! Take the robes and leave this place!");
 
 [queue,eadgar_tegid_give_clothes]
 inv_add(inv, eadgar_dirty_druid_robe, 1);

--- a/scripts/quests/quest_eadgar/scripts/eadgar_druid_washing.rs2
+++ b/scripts/quests/quest_eadgar/scripts/eadgar_druid_washing.rs2
@@ -1,17 +1,19 @@
 [opnpc1,eadgar_druid_washing]
 // mesanims rsprox/branon
 ~chatplayer("<p,happy>So, you're doing laundry, eh?");
-~chatnpc("<p,neutral>Yes. What is it to you?");
-~chatplayer("<p,happy>Nice day for it.");
-~chatnpc("<p,neutral>I suppose it is.");
-if(%eadgar_quest = ^eadgar_needs_items & testbit(%eadgar_bits, ^eadgar_given_clothes) = ^false) {
-    if(inv_total(inv, eadgar_dirty_druid_robe) = 0 & inv_total(bank, eadgar_dirty_druid_robe) = 0) {
-        ~chatplayer("<p,quiz>You wouldn't be able to spare any of those dirty robes by any chance? It's a matter of the utmost importance.");
-        ~chatnpc("<p,angry>What? No! These are my robes!");
-        switch_int(~p_choice3("Fine.", 1, "Sanfew won't be happy...", 2, "You'll give me those robes right now...", 3)) {
-            case 1 : @eadgar_tegid_fine;
-            case 2 : @eadgar_tegid_sanfew_wont_be_happy;
-            case 3 : @eadgar_tegid_threaten;
+if(.npc_find(coord, eadgar_druid_washing, 5, 0) = true) {
+    ~.chatnpcnoturn("<p,neutral>Yes. What is it to you?");
+    ~chatplayer("<p,happy>Nice day for it.");
+    ~.chatnpcnoturn("<p,neutral>I suppose it is.");
+    if(%eadgar_quest = ^eadgar_needs_items & testbit(%eadgar_bits, ^eadgar_given_clothes) = ^false) {
+        if(inv_total(inv, eadgar_dirty_druid_robe) = 0 & inv_total(bank, eadgar_dirty_druid_robe) = 0) {
+            ~chatplayer("<p,quiz>You wouldn't be able to spare any of those dirty robes by any chance? It's a matter of the utmost importance.");
+            ~.chatnpcnoturn("<p,angry>What? No! These are my robes!");
+            switch_int(~p_choice3("Fine.", 1, "Sanfew won't be happy...", 2, "You'll give me those robes right now...", 3)) {
+                case 1 : @eadgar_tegid_fine;
+                case 2 : @eadgar_tegid_sanfew_wont_be_happy;
+                case 3 : @eadgar_tegid_threaten;
+            }
         }
     }
 }
@@ -25,16 +27,16 @@ if(%eadgar_quest = ^eadgar_needs_items & testbit(%eadgar_bits, ^eadgar_given_clo
 // mesanims rsprox/branon
 queue(eadgar_tegid_give_clothes, 0, 0);
 ~chatplayer("<p,neutral>I'm sure Sanfew won't be happy when I tell him it's your fault he can't perform the purification ritual.");
-~chatnpc("<p,happy>What? Oh well, if it's a matter of that much importance, I suppose you can borrow one...");
+~.chatnpcnoturn("<p,happy>What? Oh well, if it's a matter of that much importance, I suppose you can borrow one...");
 
 [label,eadgar_tegid_threaten]
 // dialog from LP41 video
 // mesanims rsprox/branon
 queue(eadgar_tegid_give_clothes, 0, 0);
 ~chatplayer("<p,angry>You'll give me those robes right now...or I'm going to cut down trees until you do.");
-~chatnpc("<p,scared>You wouldn't dare!");
+~.chatnpcnoturn("<p,scared>You wouldn't dare!");
 ~chatplayer("<p,quiz>Of course I would. They're just trees.");
-~chatnpc("<p,scared>You monster! Take the robes and leave this place!");
+~.chatnpcnoturn("<p,scared>You monster! Take the robes and leave this place!");
 
 [queue,eadgar_tegid_give_clothes]
 inv_add(inv, eadgar_dirty_druid_robe, 1);

--- a/scripts/quests/quest_eadgar/scripts/eadgar_journal.rs2
+++ b/scripts/quests/quest_eadgar/scripts/eadgar_journal.rs2
@@ -1,6 +1,3 @@
-// Sources
-// 2014 OSRS: https://youtu.be/945tUgBj3SM?t=14
-
 [if_button,questlist:eadgar]
 def_int $quest_progress = %eadgar_quest;
 def_string $prev_text;
@@ -119,7 +116,7 @@ if($quest_progress >= ^eadgar_got_parrot_back) {
 
 if($quest_progress >= ^eadgar_got_fake_man) {
     // https://youtu.be/945tUgBj3SM?t=896 - once again, no period at the end of the new text. 2007 linebreaks work fine here
-    // todo does this journal entry change at all if losing the fake man
+    // this entry does NOT change if the fake man is lost
     $prev_text = append($prev_text, " and|@str@gave it to Eadgar.||@str@I got Eadgar's fake man");
     if($quest_progress = ^eadgar_got_fake_man) {
         $new_text = append($prev_text, ".|@dbl@I should give the fake man to the @dre@Troll cook");

--- a/scripts/quests/quest_eadgar/scripts/eadgar_journal.rs2
+++ b/scripts/quests/quest_eadgar/scripts/eadgar_journal.rs2
@@ -65,8 +65,7 @@ if ($quest_progress = ^eadgar_needs_items) {
     def_int $grain_needed = calc(10 - %eadgar_grain);
     def_string $items_remaining = "@dre@";
     if(testbit(%eadgar_bits, ^eadgar_given_logs) ! 1) {
-        // TODO the string for logs needs verified as far as formatting, the rest match OSRS including plural vs singular for >1 vs 1
-        $items_remaining = append($items_remaining, "|Some Logs");
+        $items_remaining = append($items_remaining, "|Logs");
     }
     if($chickens_needed > 0) {
         if($chickens_needed > 1) {

--- a/scripts/quests/quest_eadgar/scripts/eadgar_troll_chief_cook.rs2
+++ b/scripts/quests/quest_eadgar/scripts/eadgar_troll_chief_cook.rs2
@@ -33,8 +33,8 @@ if(%eadgar_quest = ^eadgar_got_fake_man & inv_total(inv, eadgar_fake_man) > 0) {
     inv_del(inv, eadgar_fake_man, 1);
     inv_add(inv, burnt_meat, 1);
     ~chatplayer("<p,neutral>This is burnt meat.");
-    // my run missed mesanims for these two, todo verify at some point
-    ~chatnpc("<p,neutral>It first thing I ever try to cook! Very precious to Burntmeat.");
+    // mesanims for these two from RS3
+    ~chatnpc("<p,happy>It first thing I ever try to cook! Very precious to Burntmeat.");
     ~chatplayer("<p,neutral>Thank you... and how's the stew?");
     @burntmeat_gave_fake_man;
 } else {

--- a/scripts/quests/quest_eadgar/scripts/eadgar_troll_thistle.rs2
+++ b/scripts/quests/quest_eadgar/scripts/eadgar_troll_thistle.rs2
@@ -37,7 +37,9 @@ if(last_useitem = ranarrvial) {
     ~attempt_grind_ingredient(last_useslot, last_slot);
 }
 
-[opheldu,eadgar_ground_troll_thistle]
+[opheldu,eadgar_ground_troll_thistle] @eadgar_mix_troll_truth_potion;
+
+[label,eadgar_mix_troll_truth_potion]
 if(%eadgar_quest = ^eadgar_needs_potion) {
     ~attempt_brew_potion(last_useslot, last_slot);
 } else if(%eadgar_quest > ^eadgar_needs_potion) {

--- a/scripts/quests/quest_eadgar/scripts/eadgar_troll_thistle.rs2
+++ b/scripts/quests/quest_eadgar/scripts/eadgar_troll_thistle.rs2
@@ -40,8 +40,11 @@ if(last_useitem = ranarrvial) {
 [opheldu,eadgar_ground_troll_thistle]
 if(%eadgar_quest = ^eadgar_needs_potion) {
     ~attempt_brew_potion(last_useslot, last_slot);
-} else if(%eadgar_quest = ^eadgar_complete) {
-    mes("You don't need to make any more."); // todo check if this is the case immediately after handing in the potion, or if completion is required before troll potions become unmixable
+} else if(%eadgar_quest > ^eadgar_needs_potion) {
+    // OSRS: Only tested this after quest completion, but potion was unmixable
+    // RS3: Potion becomes unmixable immediately after handing it in
+    // Here I'm assuming both observed behaviors are actually the same, and going with the latter case
+    mes("You don't need to make any more.");
 } else {
     // osrs, from Ashie
     ~chatplayer("<p,confused>Hmmm...perhaps I shouldn't try and mix these together. It might have unpredictable results...");

--- a/scripts/quests/quest_eadgar/scripts/eadgar_zoo_keeper_aviary.rs2
+++ b/scripts/quests/quest_eadgar/scripts/eadgar_zoo_keeper_aviary.rs2
@@ -53,7 +53,7 @@ if (testbit(%eadgar_bits, ^eadgar_pete_dialog_1) = ^true) { // no message is giv
         }
     }
 } else {
-    mes("Why would you want to do that?"); // todo double check this against my video
+    mes("Why would you want to do that?");
 }
 
 [oplocu,eadgar_aviary_wall_hatch]
@@ -76,7 +76,7 @@ if(%eadgar_quest >= ^eadgar_explained_plan) { // on or after this stage, the par
 // this includes post-quest: although eadgar won't actually give you a parrot after quest completion, the aviary hatch interaction remains the same
     ~chatplayer("<p,confused>The parrott flew off, I wonder where it went? Silly thing prefered Eadgar to me!");
     mes("The parrott flew off, you need to find it again.");
-    return; // todo check if alco-chunks are deleted here
+    return; // alco-chunks are not deleted here
 }
 inv_del(inv, eadgar_alco_chunks, 1);
 queue(eadgar_get_parrot, 0, 0); // appears to be queued here judging by indio's clip
@@ -87,7 +87,7 @@ if(.npc_find(coord, eadgar_zoo_keeper_aviary, 14, 0) = true) {
     ~.chatnpc("<p,angry>Hey! What are you doing with that parrot?");
     ~chatplayer("<p,shifty>Nothing.");
     ~.chatnpc("<p,scared>It looks drunk! You should NEVER feed alcohol to a parrot!");
-    ~chatplayer("<p,happy>Well, good thing I found it! I'll just take it to the vet for you, shall I?"); // not sure which mesanim this is
+    ~chatplayer("<p,happy>Well, good thing I found it! I'll just take it to the vet for you, shall I?");
     ~.chatnpc("<p,happy>Oh, thank you! We're ever so busy here at the Zoo.");
 }
 

--- a/scripts/quests/quest_eadgar/scripts/quest_eadgar.rs2
+++ b/scripts/quests/quest_eadgar/scripts/quest_eadgar.rs2
@@ -147,7 +147,7 @@ if(inv_freespace(inv) > 0) {
 [oploc1,eadgar_rack]
 // rsprox/branon
 if(%eadgar_quest >= ^eadgar_hid_parrot & %eadgar_quest <= ^eadgar_needs_potion) {
-    switch_int(random(2)) {
+    switch_int(randominc(2)) {
         case 0 : ~chatnpc_specific("Parrot", eadgar_parrotts, "<p,neutral>Polly wanna cracker!");
         case 1 : ~chatnpc_specific("Parrot", eadgar_parrotts, "<p,neutral>Pieces of eight! Pieces of eight!");
         case 2 : ~chatnpc_specific("Parrot", eadgar_parrotts, "<p,neutral>Who's a pretty boy then?");

--- a/scripts/quests/quest_eadgar/scripts/quest_eadgar.rs2
+++ b/scripts/quests/quest_eadgar/scripts/quest_eadgar.rs2
@@ -279,7 +279,7 @@ $grain_num = min(calc(10 - %eadgar_grain), $grain_num);
 
 // videos show items are removed here, immediately before the player's "I have XYZ" dialog fires
 if ($logs_num >= 1 & testbit(%eadgar_bits, ^eadgar_given_logs) = ^false) {
-    inv_del(inv, logs, 1);
+    inv_del(inv, $log_type, 1);
     %eadgar_bits = setbit(%eadgar_bits, ^eadgar_given_logs);
 } else {
     $logs_str = "no logs";
@@ -288,7 +288,7 @@ if ($logs_num >= 1 & testbit(%eadgar_bits, ^eadgar_given_logs) = ^false) {
     //
     // Player gives Eadgar ALL of a required item (1 logs for example)
     // Player returns later with other items, while still carrying an extra of the previous item (1 extra logs to make a fire)
-    // The player's dialog will reads "I have no logs" while turning in other items, even though there are actually logs in the inventory.
+    // The player's dialog will read "I have no logs" while turning in other items, even though there are actually logs in the inventory.
 }
 
 if ($chickens_num > 0) {

--- a/scripts/quests/quest_eadgar/scripts/quest_eadgar.rs2
+++ b/scripts/quests/quest_eadgar/scripts/quest_eadgar.rs2
@@ -11,7 +11,8 @@ switch_int(%eadgar_quest) {
     case ^eadgar_needs_parrot_back : @eadgar_needs_parrot_back;
     case ^eadgar_got_parrot_back : @eadgar_got_parrot_back;
     case ^eadgar_got_fake_man : @eadgar_given_fake_man_yet;
-    case ^eadgar_got_burnt_meat, ^eadgar_unlocked_storeroom : @eadgar_did_the_plan_work; // todo is this dialog available after receiving the burnt meat or only after unlocking the storeroom? using both for now
+    case ^eadgar_got_burnt_meat, ^eadgar_unlocked_storeroom : @eadgar_did_the_plan_work; // In RS3 this dialog is available after getting the burnt meat / In OSRS it's available after unlocking the storeroom
+    // I haven't checked the inverse for either game yet but for now I'm assuming behavior is the same and the dialog should be available during both quest stages (minor TODO I guess)
 }
 
 [label,eadgar_quest_initial_tree]
@@ -118,7 +119,7 @@ if(inv_total(inv, eadgar_drunk_parrot) > 0 | inv_total(bank, eadgar_drunk_parrot
 // rsprox/branon
 ~chatplayer("<p,quiz>What should I do with this parrot?");
 ~chatnpc("<p,neutral>I told you, put it somewhere it'll learn to say the sort of thing the trolls will expect it to say.");
-~chatnpc("<p,neutral>That is likely to be screaming. There's bound to be a good spot somewhere in the troll prison.");
+~chatnpc("<p,neutral>This is likely to be screaming. There's bound to be a good spot somewhere in the troll prison.");
 @eadgar_scarecrow_tree; // only time this dialog tree is accessible!
 
 [proc,eadgar_lost_parrot_start] // this dialog is used in two places and needs to resume execution in both, so i made it a proc
@@ -218,7 +219,33 @@ if(%eadgar_quest = ^eadgar_explained_plan) {
 @eadgar_scarecrow_tree;
 
 [label,eadgar_scarecrow_items]
-def_int $logs_num = inv_total(inv, logs);
+// All the videos and guides use normal logs but we checked some others:
+// OSRS - Maple logs work but Redwood logs do not - likely not using a category.
+// RS3 - Achey logs work.
+//
+// Current theory is that any 2004-era log should work, with priority from lowest to highest level.
+// TODO not sure about pyre logs...
+def_obj $log_type = null;
+if(inv_total(inv, logs) > 0) {
+    $log_type = logs;
+} else if(inv_total(inv, achey_tree_logs) > 0) {
+    $log_type = achey_tree_logs;
+} else if(inv_total(inv, oak_logs) > 0) {
+    $log_type = oak_logs;
+} else if(inv_total(inv, willow_logs) > 0) {
+    $log_type = willow_logs;
+} else if(inv_total(inv, maple_logs) > 0) {
+    $log_type = maple_logs;
+} else if(inv_total(inv, yew_logs) > 0) {
+    $log_type = yew_logs;
+} else if(inv_total(inv, magic_logs) > 0) {
+    $log_type = magic_logs;
+}
+
+def_int $logs_num = 0;
+if($log_type ! null) {
+    $logs_num = inv_total(inv, $log_type);
+}
 def_int $chickens_num = min(inv_total(inv, raw_chicken), calc(5 - %eadgar_chickens));
 def_int $grain_num = min(inv_total(inv, grain), calc(10 - %eadgar_grain));
 def_int $clothes_num = inv_total(inv, eadgar_dirty_druid_robe);
@@ -256,10 +283,12 @@ if ($logs_num >= 1 & testbit(%eadgar_bits, ^eadgar_given_logs) = ^false) {
     %eadgar_bits = setbit(%eadgar_bits, ^eadgar_given_logs);
 } else {
     $logs_str = "no logs";
-    // This is to match Soup's OSRS video.
-    // The player gives Eadgar the logs first, then returns later with the dirty clothes, while still carrying
-    // a second set of logs for making a fire. The player's dialog reads "I have no logs" while turning in the clothes,
-    // even though there are actually logs in the inventory.
+    // Resetting the strings to say "no" even if the items are present in the inventory is done on purpose to match OSRS/RS3.
+    // This happens for all the items, logs/chickens/grain/clothes. Works like this:
+    //
+    // Player gives Eadgar ALL of a required item (1 logs for example)
+    // Player returns later with other items, while still carrying an extra of the previous item (1 extra logs to make a fire)
+    // The player's dialog will reads "I have no logs" while turning in other items, even though there are actually logs in the inventory.
 }
 
 if ($chickens_num > 0) {
@@ -267,8 +296,7 @@ if ($chickens_num > 0) {
 } else {
     $chickens_str = "no chickens";
 }
-// TODO check if this "no X" dialog behavior is consistent for grain and chickens also
-// I forgot to check these, but for now I'm assuming it is
+
 if ($grain_num > 0) {
     inv_del(inv, grain, $grain_num);
 } else {
@@ -287,12 +315,18 @@ if ($clothes_num >= 1 & testbit(%eadgar_bits, ^eadgar_given_clothes) = ^false) {
 %eadgar_grain = calc(%eadgar_grain + $grain_num);
 
 // check if anything more is needed
-def_int $logs_needed = calc(1 - $logs_num);
 def_int $chickens_needed = calc(5 - %eadgar_chickens);
 def_int $grain_needed = calc(10 - %eadgar_grain);
-def_int $clothes_needed = calc(1 - $clothes_num);
 
-// rsprox/branon
+// TODO we are currently missing a possible dialog line here:
+//~chatplayer("<p,neutral>I don't have anything.");
+//
+// I ran across this in RS3 by talking to Eadgar with an empty inventory (no required items present)
+// Appears to exist in OSRS too: https://chisel.weirdgloop.org/dialogue/content/2449
+//
+// The issue is I don't know if this line ONLY appears if the player has NO required item types at all,
+// or if it also appears when (for example) all 10 grain have been turned in, but the player has 1 grain in their inventory
+// and nothing else (required item is present, but it's not a type of item we still *need*)
 ~chatplayer("<p,neutral>I have <$logs_str>, <$chickens_str>, <$grain_str> and <$clothes_str>.");
 
 // if not all items are delivered, dialog goes back to default tree after eadgar tells you what else is needed
@@ -355,17 +389,20 @@ if(p_finduid(uid) = true) {
 // rsprox/branon
 if(inv_total(inv, eadgar_ground_troll_thistle_potion) > 0) {
     ~chatplayer("<p,happy>I've got the troll truth potion.");
+    queue(eadgar_give_potion, 0, 0); // todo might actually be queued before player dialog above
     // Jagex appears to have changed this line at some point after 2014: https://youtu.be/945tUgBj3SM?t=860 
     // Eadgar says "thank you" instead of "hand it here" in OSRS now   
     ~chatnpc("<p,happy>Excellent, hand it here. Now just go fetch that poor parrot back, it's probably had enough by now."); 
-    inv_del(inv, eadgar_ground_troll_thistle_potion, 1); // only one is taken
-    %eadgar_quest = ^eadgar_needs_parrot_back;
 } else {
     // rsprox/branon
     ~chatplayer("<p,quiz>How do I make the troll truth potion again?");
     ~chatnpc("<p,neutral>Troll Thistle grows around this mountain. If properly prepared, it can be made into a sort of Troll truth potion.");
     @eadgar_how_prepare_troll_truth_potion;
 }
+
+[queue,eadgar_give_potion]
+%eadgar_quest = ^eadgar_needs_parrot_back;
+inv_del(inv, eadgar_ground_troll_thistle_potion, 1); // only one is taken
 
 [label,eadgar_needs_parrot_back]
 // rsprox/branon
@@ -375,8 +412,8 @@ if(inv_total(inv, eadgar_ground_troll_thistle_potion) > 0) {
 
 [label,eadgar_got_parrot_back]
 if(inv_total(inv, eadgar_drunk_parrot) > 0) {
-    // todo skipped this leaf in my run, need mesanims here
-    ~chatplayer("<p,neutral>I've brought the parrot.");
+    // mesanims from RS3
+    ~chatplayer("<p,happy>I've brought the parrot.");
     ~chatnpc("<p,happy>Hand it here...there we go! Can you tell this isn't a bona fide human being? I sure can't!");
 } else {
     // rsprox/branon

--- a/scripts/quests/quest_eadgar/scripts/quest_eadgar.rs2
+++ b/scripts/quests/quest_eadgar/scripts/quest_eadgar.rs2
@@ -145,7 +145,7 @@ if(inv_freespace(inv) > 0) {
 
 [oploc1,eadgar_rack]
 // rsprox/branon
-if(%eadgar_quest = ^eadgar_hid_parrot) {
+if(%eadgar_quest >= ^eadgar_hid_parrot & %eadgar_quest <= ^eadgar_needs_potion) {
     switch_int(random(2)) {
         case 0 : ~chatnpc_specific("Parrot", eadgar_parrotts, "<p,neutral>Polly wanna cracker!");
         case 1 : ~chatnpc_specific("Parrot", eadgar_parrotts, "<p,neutral>Pieces of eight! Pieces of eight!");

--- a/scripts/skill_herblore/scripts/brewing/brew_potion.rs2
+++ b/scripts/skill_herblore/scripts/brewing/brew_potion.rs2
@@ -37,6 +37,7 @@ if(last_useitem = ground_bat_bones) {
 switch_obj(last_useitem) {
     case eadgar_troll_thistle : mes("I need to dry it over a fire first."); // different mes than opheldu the other way around
     case eadgar_dried_troll_thistle : @eadgar_dried_troll_thistle_mes;
+    case eadgar_ground_troll_thistle : @eadgar_mix_troll_truth_potion;
     case default : ~attempt_brew_potion(last_useslot, last_slot);        
 }
 


### PR DESCRIPTION
Fixes/changes:
* Players will no longer erroneously be told that there is nothing under the torture rack during quest stages where the parrot, in fact, _is_ under the rack
* All three of the parrot's random dialog lines now have a chance to roll while it is under the rack
* Players now lose the ability to mix more troll potions after giving one to Eadgar, instead of after quest completion
* Eadgar will now accept more types of logs for creating the fake man
* Tegid no longer turns around and washes his robe in the dirt while speaking to the player

Authenticity tweaks:
* The exact quest journal string for the logs is now known (shockingly, it's “Logs”)
* Quest stage checks for mixing troll potions now occur for both opheldu directions
* Handing in the troll potion to Eadgar is now queued
* Mesanims/dialog corrected in multiple areas
* Resolved/removed several todo's where no changes were necessary
  * _Added_ some todo's as well but that’s just the way it goes aye?