### PR TITLE
fix: Funeral pyre fixes

### DIFF
--- a/scripts/minigames/game_mortton/scripts/mortton_pyre.rs2
+++ b/scripts/minigames/game_mortton/scripts/mortton_pyre.rs2
@@ -50,6 +50,11 @@ if(oc_category(last_useitem) = category_22) {
     ~objbox(last_useitem, "These logs won't burn hot enough to cremate the dead.|You need to make pyre logs.", 200, 0, 0);
     return;
 }
+if(last_useitem = tinderbox) {
+    mes("You should add some pyre logs and some suitable remains");
+    mes("before you light the pyre."); // todo: this is one mes in osrs but doesn't fit here
+    return;
+}
 if(oc_category(last_useitem) = category_2050) {
     if(%morttonquest < ^mortton_created_pyre_logs) {
         mes("You can't do that until you have made your own funeral pyre logs.");
@@ -96,6 +101,10 @@ if(oc_category(last_useitem) = category_2049) {
 ~displaymessage(^dm_default);
 
 [label,add_remains_to_funeral_pyre](obj $remains)
+if(getqueue(funeral_pyre_reward) > 0) {
+        mes("You've already set fire to a funeral pyre.");
+        return;
+}
 if(%pyre_loc = 0) {
     mes("You need to put wood on the pyre before adding the remains.");
     return;
@@ -117,9 +126,9 @@ inv_del(inv, $remains, 1);
 mes("You place the shade's remains on the logs.");
 
 [oplocu,_category_2052]
-if(%pyre_loc = 0) {
-    mes("You should add some pyre logs and some suitable remains before you light the pyre.");
-    return;
+if(getqueue(funeral_pyre_reward) > 0) {
+        mes("You've already set fire to a funeral pyre."); // todo: different mes? 
+        return;
 }
 
 def_int $current_pyre = ~get_pyre_loc_id(loc_coord);
@@ -135,6 +144,10 @@ if(last_useitem = tinderbox) {
 }
 
 [oploc1,_category_2052]
+if(getqueue(funeral_pyre_reward) > 0) {
+        mes("You've already set fire to a funeral pyre.");
+        return;
+}
 def_int $current_pyre = ~get_pyre_loc_id(loc_coord);
 if ($current_pyre ! %pyre_loc) {
     mes("This funeral pyre is not yours.");
@@ -148,10 +161,6 @@ if(inv_total(inv, tinderbox) > 0) {
 }
 
 [label,light_funeral_pyre]
-if(%morttonquest < ^mortton_lit_pyre) {
-    %morttonquest = ^mortton_lit_pyre;
-}
-
 //3t wait osrs
 if (%action_delay < map_clock) {
     mes("You attempt to light the funeral pyre.");
@@ -184,6 +193,9 @@ if(~validate_shade_and_log_type(loc_type, %mortton_current_shade) = false) {
     clearqueue(clear_pyre_loc);
     return;
 }
+if(%morttonquest < ^mortton_lit_pyre) {
+    %morttonquest = ^mortton_lit_pyre;
+}
 spotanim_map(temple_pyre_fire, ~get_pyre_coord(loc_coord, loc_angle), 0, 30);
 sound_synth(fire_lit, 0, 0);
 stat_advance(firemaking, struct_param($funeral_pyre_struct, pyre_fm_experience));
@@ -203,7 +215,7 @@ sound_synth(smokepuff, 0, 0);
 ~give_shade_rewards(%mortton_current_shade, $pillar_coord);
 %mortton_current_shade = null;
 loc_findallzone($coord);
-if(loc_findnext = true) {
+while(loc_findnext = true) {
     if(loc_coord = $coord) {
         loc_change(temple_pyre, 1);
     }

--- a/scripts/minigames/game_mortton/scripts/mortton_pyre.rs2
+++ b/scripts/minigames/game_mortton/scripts/mortton_pyre.rs2
@@ -102,7 +102,7 @@ if(oc_category(last_useitem) = category_2049) {
 
 [label,add_remains_to_funeral_pyre](obj $remains)
 if(getqueue(funeral_pyre_reward) > 0) {
-        mes("You've already set fire to a funeral pyre.");
+        mes("You've already set fire to a funeral pyre."); // todo: different mes? 
         return;
 }
 if(%pyre_loc = 0) {
@@ -127,7 +127,7 @@ mes("You place the shade's remains on the logs.");
 
 [oplocu,_category_2052]
 if(getqueue(funeral_pyre_reward) > 0) {
-        mes("You've already set fire to a funeral pyre."); // todo: different mes? 
+        mes("You've already set fire to a funeral pyre.");
         return;
 }
 


### PR DESCRIPTION
- Now always removes current pyre after burning
- Some mes' weren't correct
- Moved quest progression to successful pyre light instead of just attempt