### PR TITLE
fix: elemental workshop box_2 sets needle_found bit not leather_found

### DIFF
--- a/scripts/quests/quest_elemental_workshop/scripts/quest_elemental_workshop.rs2
+++ b/scripts/quests/quest_elemental_workshop/scripts/quest_elemental_workshop.rs2
@@ -57,7 +57,7 @@ if(inv_total(inv, needle) > 0 | testbit(%elemental_workshop_bits, ^elemental_wor
 }
 inv_add(inv, needle, 1);
 mes("You find a needle.");
-%elemental_workshop_bits = setbit(%elemental_workshop_bits, ^elemental_workshop_leather_found);
+%elemental_workshop_bits = setbit(%elemental_workshop_bits, ^elemental_workshop_needle_found);
 
 [oploc1,elemental_workshop_box_4]
 if(inv_total(inv, leather) > 0 | testbit(%elemental_workshop_bits, ^elemental_workshop_leather_found) = ^true) {


### PR DESCRIPTION
When picking up the needle from `box_2`, the wrong bit was being set (`elemental_workshop_leather_found` instead of `elemental_workshop_needle_found`). This caused `box_4` to always say "It's empty." because the leather_found check was already true.\n\nPresent since the original quest commit (1643671ea), survived the box reshuffle in 5cee44f04.

This affects revision 244+
