### PR TITLE
fix: Boardgames fixes and misc.

### DIFF
--- a/scripts/minigames/game_gamesroom/boardgames_draughts/scripts/boardgames_draughts.rs2
+++ b/scripts/minigames/game_gamesroom/boardgames_draughts/scripts/boardgames_draughts.rs2
@@ -429,17 +429,17 @@ inv_delslot(boardgames_boardinv, $mid_slot);
 
 ~move_draughts_piece($start_slot, $target_slot);
 
-if (divide($target_slot, 8) = 0 & $king = false) {
-    ~make_draughts_king($target_slot);
-    $king = true;
-}
-
 if (~draughts_check_forced_captures_one_piece($target_slot, $king) = true) {
     %boardgames_draughts_musttake = 1;
     %boardgames_draughts_moveagain = 1;
     %boardgames_draughts_lastpiece = $target_slot;
     
     ~make_draughts_move_for_opponent($start_slot, $target_slot, $king);
+
+    if (divide($target_slot, 8) = 0 & $king = false) {
+        ~make_draughts_king($target_slot);
+        $king = true;
+    }
 
     ~draughts_find_and_force_move;
     return (true);
@@ -448,6 +448,12 @@ if (~draughts_check_forced_captures_one_piece($target_slot, $king) = true) {
     %boardgames_draughts_moveagain = 0;
     
     ~make_draughts_move_for_opponent($start_slot, $target_slot, $king);
+    
+    if (divide($target_slot, 8) = 0 & $king = false) {
+        ~make_draughts_king($target_slot);
+        $king = true;
+    }
+    
     return (true);
 }
 
@@ -896,16 +902,59 @@ if (.finduid(%duel2accept) = false) {
 .if_setanim(boardgames_draughts:runeflash, null);
 .if_setanim(boardgames_draughts:runeflash, runeflash_off);
 .if_close;
-.queue*(draughts_game_end_results, 0)($rank_change, $p1_rank, $p2_rank);
+if (.p_finduid(%duel2accept) = false) {
+    return;
+}
+.p_teleport(movecoord(^draughts_room_tele_coord, ~random_range(-3, 3), .%boardgames_challengeroom, ~random_range(-3, 3)));
+.anim(null, 0);
+~.setup_draughts_view($p1_rank, $p2_rank);
+if (.%boardgames_closemode = ^boardgames_draw) {
+    ~.music_jingle("boardgames draw");
+    .if_settext(boardgames_draughts_view:winner, "It's a draw!");
+    if (.%boardgames_closereason = ^draughts_timeout) {
+        .if_settext(boardgames_draughts_view:status1, "Nothing happened for 40 moves.");
+    } else {
+        .if_settext(boardgames_draughts_view:status1, "A draw was agreed.");
+    }
+    .if_settext(boardgames_draughts_view:status2, "");
+} else if (.%boardgames_closemode = ^boardgames_win) {
+    ~.music_jingle("boardgames victory");
+    .if_settext(boardgames_draughts_view:winner, "You win!");
+    if (.%boardgames_closereason = ^draughts_normal_end) {
+        .if_settext(boardgames_draughts_view:status1, "Player took all pieces!");
+    } else {
+        .if_settext(boardgames_draughts_view:status1, "Player resigned.");
+    }
+
+    if(.%boardgames_rankedgame = 1 & .%boardgames_numturns > 3) {
+        .if_settext(boardgames_draughts_view:status2, "Rank change: +<tostring($rank_change)>");
+    } else {
+        .if_settext(boardgames_draughts_view:status2, "");
+    }
+} else if (.%boardgames_closemode = ^boardgames_loss) {
+    ~.music_jingle("boardgames defeat");
+    .if_settext(boardgames_draughts_view:winner, "You lose!");
+    if (.%boardgames_closereason = ^draughts_normal_end) {
+        .if_settext(boardgames_draughts_view:status1, "Player took all pieces!");
+    } else {
+        .if_settext(boardgames_draughts_view:status1, "Player resigned.");
+    }
+
+    if(.%boardgames_rankedgame = 1 & .%boardgames_numturns > 3) {
+        .if_settext(boardgames_draughts_view:status2, "Rank change: -<tostring($rank_change)>");
+    } else {
+        .if_settext(boardgames_draughts_view:status2, "");
+    }
+}
 
 [proc,draughts_game_end](int $rank_change, int $p1_rank, int $p2_rank)
 %boardgames_viewing = 1;
 if_setanim(boardgames_draughts:runeflash, null);
 if_setanim(boardgames_draughts:runeflash, runeflash_off);
 if_close;
-queue*(draughts_game_end_results, 0)($rank_change, $p1_rank, $p2_rank);
-
-[queue,draughts_game_end_results](int $rank_change, int $p1_rank, int $p2_rank)
+if(p_finduid(uid) = false) {
+    return;
+}
 p_teleport(movecoord(^draughts_room_tele_coord, ~random_range(-3, 3), %boardgames_challengeroom, ~random_range(-3, 3)));
 anim(null, 0);
 ~setup_draughts_view($p1_rank, $p2_rank);

--- a/scripts/minigames/game_gamesroom/boardgames_runelink/scripts/boardgames_runelink.rs2
+++ b/scripts/minigames/game_gamesroom/boardgames_runelink/scripts/boardgames_runelink.rs2
@@ -568,9 +568,9 @@ def_int $rank_change = ~calculate_rank_change($p2_rank, $p1_rank);
 if_setanim(boardgames_runelink:runeflash, null);
 if_setanim(boardgames_runelink:runeflash, runeflash_off);
 if_close;
-queue*(runelink_game_end_results, 0)($rank_change, $p1_rank, $p2_rank);
-
-[queue,runelink_game_end_results](int $rank_change, int $p1_rank, int $p2_rank)
+if(p_finduid(uid) = false) {
+    return;
+}
 p_teleport(movecoord(^runelink_room_tele_coord, ~random_range(-3, 3), %boardgames_challengeroom, ~random_range(-3, 3)));
 anim(null, 0);
 ~setup_runelink_view($p1_rank, $p2_rank);
@@ -626,7 +626,48 @@ if (.finduid(%duel2accept) = false) {
 if (.p_finduid(.uid) = false) {
     return;
 }
-.queue*(runelink_game_end_results, 0)($rank_change, $p1_rank, $p2_rank);
+.p_teleport(movecoord(^runelink_room_tele_coord, ~random_range(-3, 3), .%boardgames_challengeroom, ~random_range(-3, 3)));
+.anim(null, 0);
+~.setup_runelink_view($p1_rank, $p2_rank);
+
+if (.%boardgames_closemode = ^boardgames_draw) {
+    ~.music_jingle("boardgames draw");
+    .if_settext(boardgames_runelink_view:winner, "It's a draw!");
+    if (.%boardgames_closereason = ^runelink_fullboard_draw) {
+        .if_settext(boardgames_runelink_view:status1, "All columns where full.");
+    } else {
+        .if_settext(boardgames_runelink_view:status1, "A draw was agreed.");
+    }
+    .if_settext(boardgames_runelink_view:status2, "");
+} else if (.%boardgames_closemode = ^boardgames_win) {
+    ~.music_jingle("boardgames victory");
+    .if_settext(boardgames_runelink_view:winner, "You win!");
+    if (.%boardgames_closereason = ^runelink_connect_win) {
+        .if_settext(boardgames_runelink_view:status1, "Player got four in a row!");
+    } else {
+        .if_settext(boardgames_runelink_view:status1, "Player resigned.");
+    }
+
+    if(.%boardgames_rankedgame = 1 & add(.inv_totalcat(boardgames_boardinv, boardgames_piece), .inv_totalcat(boardgames_boardinv, draughts_king)) > 3) {
+        .if_settext(boardgames_runelink_view:status2, "Rank change: +<tostring($rank_change)>");
+    } else {
+        .if_settext(boardgames_runelink_view:status2, "");
+    }
+} else if (.%boardgames_closemode = ^boardgames_loss) {
+    ~.music_jingle("boardgames defeat");
+    .if_settext(boardgames_runelink_view:winner, "You lose!");
+    if (.%boardgames_closereason = ^runelink_connect_win) {
+        .if_settext(boardgames_runelink_view:status1, "Player got four in a row!");
+    } else {
+        .if_settext(boardgames_runelink_view:status1, "Player resigned.");
+    }
+
+    if(.%boardgames_rankedgame = 1 & add(.inv_totalcat(boardgames_boardinv, boardgames_piece), .inv_totalcat(boardgames_boardinv, draughts_king)) > 3) {
+        .if_settext(boardgames_runelink_view:status2, "Rank change: -<tostring($rank_change)>");
+    } else {
+        .if_settext(boardgames_runelink_view:status2, "");
+    }
+}
 
 [proc,setup_runelink_view](int $p1_rank, int $p2_rank)
 if (.finduid(%duel2accept) = false) {

--- a/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
+++ b/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
@@ -324,8 +324,8 @@ if (oc_category(last_useitem) = category_110) {
     anim(human_pickuptable, 0);
     mes("You carefully sanctify the oil in the sacred flame.");
     //Todo: Guess since it is called serum 208 now
-    if(testbit(%morttonmulti, ^mortton_made_perm_serum) = ^false) {
-        %morttonmulti = setbit(%morttonmulti, ^mortton_made_perm_serum);
+    if(testbit(%morttonmulti, ^player_made_perm_serum) = ^false) {
+        %morttonmulti = setbit(%morttonmulti, ^player_made_perm_serum);
         ~objbox(oc_param($obj, next_obj_stage_temple), "You sanctify serum 207 in the sacred flame and|rename it to serum 207(p).", 200, 0, ^objbox_height);
     }
     return;

--- a/scripts/minigames/game_trail/scripts/trail_clue_drop.rs2
+++ b/scripts/minigames/game_trail/scripts/trail_clue_drop.rs2
@@ -1,5 +1,6 @@
 [proc,trail_geteasyclue]()(namedobj)
 if(~trail_hasclue_all = false) {
+    ~clear_trail_progress;
     def_namedobj $trail_clue_easy = enum(int, namedobj, trail_easy_enum, random(enum_getoutputcount(trail_easy_enum)));
     return($trail_clue_easy);
 } else {
@@ -8,6 +9,7 @@ if(~trail_hasclue_all = false) {
 
 [proc,trail_getmediumclue]()(namedobj)
 if(~trail_hasclue_all = false) {
+    ~clear_trail_progress;
     def_namedobj $trail_clue_medium = enum(int, namedobj, trail_medium_enum, random(enum_getoutputcount(trail_medium_enum)));
     return($trail_clue_medium);
 } else {
@@ -16,6 +18,7 @@ if(~trail_hasclue_all = false) {
 
 [proc,trail_gethardclue]()(namedobj)
 if(~trail_hasclue_all = false) {
+    ~clear_trail_progress;
     def_namedobj $trail_clue_hard = enum(int, namedobj, trail_hard_enum, random(enum_getoutputcount(trail_hard_enum)));
     return($trail_clue_hard);
 } else {

--- a/scripts/quests/quest_mortton/configs/quest_mortton.constant
+++ b/scripts/quests/quest_mortton/configs/quest_mortton.constant
@@ -1,17 +1,15 @@
 ^mortton_used_serum_on_ulsquire = 0
-^mortton_cured_ulsquire = 1
+^ulsquire_visible = 1
 ^mortton_used_serum_on_razmire = 2
-^mortton_cured_razmire = 3
+^razmire_visible = 3
 ^shadeattack = 4
-^mortton_used_perm_serum_on_ulsquire = 5
-^mortton_used_perm_serum_on_razmire = 6
-^mortton_made_perm_serum = 7
-^mortton_checked_table = 8
+^ulsquire_perm_serum_used = 5
+^razmire_perm_serum_used = 6
+^player_made_perm_serum = 7
+^shades_table_searched = 8
 //pyre_loc = 9-13
 //temple_resources = 14-27
-//shades_dampe_intro is the name of varbit in osrs.. they accidentally re-used the bit for this quest
-//truly a Jagex moment
-^mortton_shades_dampe_intro = 28
+^shades_ulsquire_oil_given = 28
 ^mortton_unlocked_shade_lair = 29
 ^mortton_gave_dairy_to_apothecary = 30
 ^mortton_temple_fullpool_warning = 31

--- a/scripts/quests/quest_mortton/scripts/quest_mortton.rs2
+++ b/scripts/quests/quest_mortton/scripts/quest_mortton.rs2
@@ -11,11 +11,11 @@ if (inv_freespace(inv) < 1 & ~obj_gettotal(serum_book) = 0) {
 mes("You find nothing useful here.");
 
 [oploc5,shades_experimenttable]
-if (inv_freespace(inv) < 3 & testbit(%morttonmulti, ^mortton_checked_table) = ^false) {
+if (inv_freespace(inv) < 3 & testbit(%morttonmulti, ^shades_table_searched) = ^false) {
     ~objbox(unidentified_tarromin, "You see three herbs inside, but you don't have enough|inventory space to take them.", 200, 0, divide(^objbox_height, 2));
     return;
-} else if (testbit(%morttonmulti, ^mortton_checked_table) = ^false) {
-    %morttonmulti = setbit(%morttonmulti, ^mortton_checked_table);
+} else if (testbit(%morttonmulti, ^shades_table_searched) = ^false) {
+    %morttonmulti = setbit(%morttonmulti, ^shades_table_searched);
     inv_add(inv, unidentified_tarromin, 1);
     inv_add(inv, unidentified_rogues_purse, 1);
     inv_add(inv, unidentified_tarromin, 1);

--- a/scripts/quests/quest_mortton/scripts/razmire_keelgan.rs2
+++ b/scripts/quests/quest_mortton/scripts/razmire_keelgan.rs2
@@ -1,5 +1,5 @@
 [opnpc3,razmire_keelgan]
-if (testbit(%morttonmulti, ^mortton_cured_razmire) = ^false & testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^false) {
+if (testbit(%morttonmulti, ^razmire_visible) = ^false & testbit(%morttonmulti, ^razmire_perm_serum_used) = ^false) {
     npc_changetype(razmire_keelgan_afflicted,200);
     @afflicted_talk;
 }
@@ -12,7 +12,7 @@ if(%morttonquest >= ^mortton_shades_to_razmire) {
 }
 
 [opnpc4,razmire_keelgan]
-if (testbit(%morttonmulti, ^mortton_cured_razmire) = ^false & testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^false) {
+if (testbit(%morttonmulti, ^razmire_visible) = ^false & testbit(%morttonmulti, ^razmire_perm_serum_used) = ^false) {
     npc_changetype(razmire_keelgan_afflicted,200);
     @afflicted_talk;
 }
@@ -41,18 +41,18 @@ if(oc_category(last_useitem) = category_108) {
     npc_changetype(razmire_keelgan,200);
     inv_setslot(inv, last_useslot, oc_param(last_useitem, next_obj_stage), 1);
     longqueue(razmire_reset, 200, 0, ^accelerate);
-    %morttonmulti = setbit(%morttonmulti, ^mortton_cured_razmire);
-    if (testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^true) {
+    %morttonmulti = setbit(%morttonmulti, ^razmire_visible);
+    if (testbit(%morttonmulti, ^razmire_perm_serum_used) = ^true) {
         ~chatnpc("<p,happy>You've already used the permanent serum on me, you|don't need to use that any more.");
     }
     @razmire_talk;
 } else if(oc_category(last_useitem) = category_109) {
     npc_changetype(razmire_keelgan,200);
-    if (testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^false) {
+    if (testbit(%morttonmulti, ^razmire_perm_serum_used) = ^false) {
         def_int $last_useslot = last_useslot;
         def_obj $last_useitem = last_useitem;
         ~chatnpc("<p,happy>Well done - I feel this serum is really working on me.|I think you've cracked it, my friend! I'd like to give|you something for your trouble!");
-        %morttonmulti = setbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire);
+        %morttonmulti = setbit(%morttonmulti, ^razmire_perm_serum_used);
         inv_setslot(inv, $last_useslot, oc_param($last_useitem, next_obj_stage), 1);
         def_int $count = ~random_range(180,220);
         inv_add(inv, coins, $count);
@@ -66,17 +66,17 @@ if(oc_category(last_useitem) = category_108) {
 }
 
 [queue,razmire_reset]
-%morttonmulti = clearbit(%morttonmulti, ^mortton_cured_razmire);
+%morttonmulti = clearbit(%morttonmulti, ^razmire_visible);
 
 [opnpc1,razmire_keelgan]
-if (testbit(%morttonmulti, ^mortton_cured_razmire) = ^false & testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^false) {
+if (testbit(%morttonmulti, ^razmire_visible) = ^false & testbit(%morttonmulti, ^razmire_perm_serum_used) = ^false) {
     npc_changetype(razmire_keelgan_afflicted,200);
     @afflicted_talk;
 }
 @razmire_talk;
 
 [opnpc1,razmire_keelgan_afflicted]
-if (testbit(%morttonmulti, ^mortton_cured_razmire) = ^true | testbit(%morttonmulti, ^mortton_used_perm_serum_on_razmire) = ^true) {
+if (testbit(%morttonmulti, ^razmire_visible) = ^true | testbit(%morttonmulti, ^razmire_perm_serum_used) = ^true) {
     npc_changetype(razmire_keelgan,200);
     @razmire_talk;
 }

--- a/scripts/quests/quest_mortton/scripts/ulsquire_shauncy.rs2
+++ b/scripts/quests/quest_mortton/scripts/ulsquire_shauncy.rs2
@@ -14,21 +14,21 @@ if(oc_category(last_useitem) = category_108) {
     }
     npc_changetype(ulsquire_shauncy,200);
     longqueue(ulsquire_reset, 200, 0, ^accelerate);
-    %morttonmulti = setbit(%morttonmulti, ^mortton_cured_ulsquire);
-    if (testbit(%morttonmulti, ^mortton_used_perm_serum_on_ulsquire) = ^true) {
+    %morttonmulti = setbit(%morttonmulti, ^ulsquire_visible);
+    if (testbit(%morttonmulti, ^ulsquire_perm_serum_used) = ^true) {
         ~chatnpc("<p,happy>You've already used the permanent serum on me, you|don't need to use that any more.");
     }
     @ulsquire_talk;
 } else if(oc_category(last_useitem) = category_109) {
     npc_changetype(ulsquire_shauncy,200);
-    if (testbit(%morttonmulti, ^mortton_used_perm_serum_on_ulsquire) = ^true) {
+    if (testbit(%morttonmulti, ^ulsquire_perm_serum_used) = ^true) {
         ~chatnpc("<p,happy>You've already used the permanent serum on me, you|don't need to use that any more.");
         return;
     } else {
         def_int $last_useslot = last_useslot;
         def_obj $last_useitem = last_useitem;
         ~chatnpc("<p,happy>Well done - I feel this serum is really working on me.|I think you've cracked it, my friend! I'd like to give|you something for your trouble!");
-        %morttonmulti = setbit(%morttonmulti, ^mortton_used_perm_serum_on_ulsquire);
+        %morttonmulti = setbit(%morttonmulti, ^ulsquire_perm_serum_used);
         inv_setslot(inv, $last_useslot, oc_param($last_useitem, next_obj_stage), 1);
         //Guess https://oldschool.runescape.wiki/w/Transcript:Ulsquire_Shauncy#Using_Serum_208_on_him
         def_int $count = ~random_range(180,220);
@@ -41,17 +41,17 @@ if(oc_category(last_useitem) = category_108) {
 }
 
 [queue,ulsquire_reset]
-%morttonmulti = clearbit(%morttonmulti, ^mortton_cured_ulsquire);
+%morttonmulti = clearbit(%morttonmulti, ^ulsquire_visible);
 
 [opnpc1,ulsquire_shauncy]
-if (testbit(%morttonmulti, ^mortton_cured_ulsquire) = ^false & testbit(%morttonmulti, ^mortton_used_perm_serum_on_ulsquire) = ^false) {
+if (testbit(%morttonmulti, ^ulsquire_visible) = ^false & testbit(%morttonmulti, ^ulsquire_perm_serum_used) = ^false) {
     npc_changetype(ulsquire_shauncy_afflicted,200);
     @afflicted_talk;
 }
 @ulsquire_talk;
 
 [opnpc1,ulsquire_shauncy_afflicted]
-if (testbit(%morttonmulti, ^mortton_cured_ulsquire) = ^true | testbit(%morttonmulti, ^mortton_used_perm_serum_on_ulsquire) = ^true) {
+if (testbit(%morttonmulti, ^ulsquire_visible) = ^true | testbit(%morttonmulti, ^ulsquire_perm_serum_used) = ^true) {
     npc_changetype(ulsquire_shauncy,200);
     @ulsquire_talk;
 }
@@ -128,9 +128,9 @@ if(%morttonquest < ^mortton_kill_shades) {
 [label,ulsquire_temple_built]
 ~chatplayer("<p,neutral>What should I do when the temple is built?");
 ~chatnpc("<p,neutral>I've researched this much, it seems that the temple was|dedicated to the worship of elemental flame or fire. The|sacred flame was said to be very holy and was used|somehow to sanctify oil for use in cremations.");
-if (testbit(%morttonmulti, ^mortton_shades_dampe_intro) = ^false & inv_freespace(inv) ! 0) {
+if (testbit(%morttonmulti, ^shades_ulsquire_oil_given) = ^false & inv_freespace(inv) ! 0) {
     ~chatnpc("<p,neutral>The pagans believed that sacred oil sanctified the|cremation ceremony and thus helped the deceased pass|onto the next life, and it helped the logs to burn! In|case there's any truth in the story, have this!");
-    %morttonmulti = setbit(%morttonmulti, ^mortton_shades_dampe_intro);
+    %morttonmulti = setbit(%morttonmulti, ^shades_ulsquire_oil_given);
     inv_add(inv, oliveoil3, 1);
     ~objbox(oliveoil3, "Ulsquire gives you some olive oil.", 200, 0, ^objbox_height);
     ~chatplayer("<p,neutral>Thanks!");


### PR DESCRIPTION
- Fixes draughts bug with forced promotions
- Fixes a script error that can happen with someone logging out mid board game
- Updated some constants to use rs3 varbit names
- Fixed issue with clue scroll progress not resetting from shade chests