### PR TITLE
chore: split axe checker logic from printing message

### DIFF
--- a/scripts/skill_woodcutting/scripts/woodcut.rs2
+++ b/scripts/skill_woodcutting/scripts/woodcut.rs2
@@ -141,10 +141,9 @@ if (stat_random(woodcutting, $tree_chance_low, $tree_chance_high) = true) {
 }
 p_oploc(3);
 
-// check if player has axe and level, ifso return best axe
-[proc,woodcutting_axe_checker](boolean $print_mes)(namedobj)
+[proc,axe_checker]()(namedobj)
 def_int $level = stat(woodcutting);
-def_obj $obj1 = inv_getobj(worn, ^wearpos_rhand);
+def_obj $weapon = inv_getobj(worn, ^wearpos_rhand);
 // no wc req in 2004, this is also the case in rsc. Heres a guide from 2004 that says so :
 // https://web.archive.org/web/20040622013913/http://runehq.com/viewguidedb.php?id=00330
 // if (($obj1 = rune_axe | inv_total(inv, rune_axe) > 0) & $level > 40) {
@@ -168,34 +167,39 @@ def_obj $obj1 = inv_getobj(worn, ^wearpos_rhand);
 // if (($obj1 = bronze_axe | inv_total(inv, bronze_axe) > 0) & $level > 0) {
 //     return (bronze_axe);
 // }
-if (($obj1 = rune_axe | inv_total(inv, rune_axe) > 0)) {
+if (($weapon = rune_axe | inv_total(inv, rune_axe) > 0)) {
     return (rune_axe);
 }
-if (($obj1 = adamant_axe | inv_total(inv, adamant_axe) > 0)) {
+if (($weapon = adamant_axe | inv_total(inv, adamant_axe) > 0)) {
     return (adamant_axe);
 }
-if (($obj1 = mithril_axe | inv_total(inv, mithril_axe) > 0)) {
+if (($weapon = mithril_axe | inv_total(inv, mithril_axe) > 0)) {
     return (mithril_axe);
 }
-if (($obj1 = black_axe | inv_total(inv, black_axe) > 0)) {
+if (($weapon = black_axe | inv_total(inv, black_axe) > 0)) {
     return (black_axe);
 }
-if (($obj1 = steel_axe | inv_total(inv, steel_axe) > 0)) {
+if (($weapon = steel_axe | inv_total(inv, steel_axe) > 0)) {
     return (steel_axe);
 }
-if (($obj1 = iron_axe | inv_total(inv, iron_axe) > 0)) {
+if (($weapon = iron_axe | inv_total(inv, iron_axe) > 0)) {
     return (iron_axe);
 }
-if (($obj1 = bronze_axe | inv_total(inv, bronze_axe) > 0)) {
+if (($weapon = bronze_axe | inv_total(inv, bronze_axe) > 0)) {
     return (bronze_axe);
 }
+return (null);
+
+// check if player has axe and level, ifso return best axe
+[proc,woodcutting_axe_checker](boolean $print_mes)(namedobj)
+def_namedobj $axe = ~axe_checker;
 // mes("You need an axe to chop down this tree."); // this message was added in 2005 when they fixed axe wc reqs
 // https://imgur.com/Cj7w6y9
 // https://imgur.com/fnmlJ7R
-if ($print_mes = true) {
+if ($axe = null & $print_mes = true) {
     mes("You do not have an axe which you have the level to use.");
 }
-return(null);
+return($axe);
 
 [proc,woodcutting_successchance](dbrow $data, obj $axe)(int, int)
 def_int $count = calc(db_getfieldcount($data, woodcutting_trees:successchance) - 1);


### PR DESCRIPTION
Splits the axe checker logic into a proc that returns the best axe and another that checks for axe & possibly prints a "no axe available" message.