### PR TITLE
fix: more precise kq worker spawn mechanics

### DIFF
--- a/scripts/areas/area_kalphite/scripts/kalphite_queen.rs2
+++ b/scripts/areas/area_kalphite/scripts/kalphite_queen.rs2
@@ -1,7 +1,4 @@
 [ai_queue1,kalphite_queen]
-if (random(^kalphite_worker_spawn_rate) = 0 & npc_stat(hitpoints) < 175) { // doesnt spawn until boss is under 175 ish hp https://youtu.be/ZHaxxMq3nVI?list=PLn23LiLYLb1YiomJ3wnXokdbgjE7-Lgt5&t=87
-    ~kalphite_worker_spawn;
-}
 ~npc_default_retaliate_ap;
 
 [ai_opplayer2,kalphite_queen] npc_setmode(applayer2);
@@ -26,6 +23,12 @@ switch_int($random) {
     case 1 : ~kalphite_queen_ranged_attack;
     case 2 : ~kalphite_melee_attack;
 }
+
+[ai_queue2,kalphite_queen]
+if (random(^kalphite_worker_spawn_rate) = 0) {
+    ~kalphite_worker_spawn;
+}
+~npc_default_damage(last_int);
 
 // #1 https://youtu.be/KTVznh5-S44?t=222
 // #2 https://youtu.be/AeMRG94A5KY?t=290
@@ -149,9 +152,6 @@ while (huntnext = true & $i < 5) { // up to 5? https://youtu.be/ZHaxxMq3nVI?list
 }
 
 [ai_queue1,kalphite_flyingqueen]
-if (random(^kalphite_worker_spawn_rate) = 0) {
-    ~kalphite_worker_spawn;
-}
 ~npc_default_retaliate_ap;
 
 [ai_applayer2,kalphite_flyingqueen]
@@ -176,6 +176,12 @@ switch_int($random) {
 }
 
 [ai_opplayer2,kalphite_flyingqueen] npc_setmode(applayer2);
+
+[ai_queue2,kalphite_flyingqueen]
+if (random(^kalphite_worker_spawn_rate) = 0) {
+    ~kalphite_worker_spawn;
+}
+~npc_default_damage(last_int);
 
 [proc,kalphite_flyingqueen_melee_attack]
 anim(%com_defendanim, 0);

--- a/scripts/areas/area_kalphite/scripts/kalphite_worker_spawn.rs2
+++ b/scripts/areas/area_kalphite/scripts/kalphite_worker_spawn.rs2
@@ -2,11 +2,10 @@
 [proc,kalphite_worker_spawn]
 // todo: refactor to loc_findall? Does this command even exist?
 def_coord $coord;
-def_coord $npc_coord = movecoord(npc_coord, 2, 0, 2);
 def_int $i = 0;
 while ($i < enum_getoutputcount(cocoon_coords)) {
     $coord = enum(int, coord, cocoon_coords, $i);
-    if (distance($npc_coord, $coord) <= 10 & loc_find($coord, kalphite_egg) = true) {
+    if (distance(npc_coord, $coord) < 10 & loc_find($coord, kalphite_egg) = true) {
         loc_anim(kalphite_egg_open);
         // close anim doesnt seem to be used?
         .npc_add(loc_coord, kalphite_worker_chamber, 500); // seems to be 5 min?


### PR DESCRIPTION
For 254+

- Our video source for the hp < 175 check was wrong. I think this was just bad rng and not a lot of people attacking KQ yet. Screenshot from [April 2006](https://youtu.be/qjk3TSwpZBg?list=PLn23LiLYLb1YiomJ3wnXokdbgjE7-Lgt5&t=11)

<img width="730" height="480" alt="VS--YouTube-runescapekq-0’11”" src="https://github.com/user-attachments/assets/1d34ef11-00fa-442d-9475-11ad3710d6eb" />

- KQ should check for worker spawn locs within 9 tiles of it's southwest tile (osrs)
- Splashing shouldnt cause workers to spawn, this means its damage queue, not retal queue (osrs)