### PR TITLE
fix: elvarg respawn rate

### DIFF
--- a/scripts/quests/quest_dragon/configs/quest_dragon.npc
+++ b/scripts/quests/quest_dragon/configs/quest_dragon.npc
@@ -10,7 +10,7 @@ recol1s=15855
 recol1d=4484
 model1=model_2853_npc
 model2=model_2854_npc
-respawnrate=100
+respawnrate=15
 // https://web.archive.org/web/20051201225926/http://runehq.com/RHQMonsterView.php?id=100
 // https://web.archive.org/web/20060828154137/http://www.trillionareguild.com/runescape/beastiary1.php
 hitpoints=120


### PR DESCRIPTION
For 225+

Elvarg respawns after about 4.3 seconds (7 ticks). Which is `respawnrate=9`
- from https://youtu.be/ucaYfz3ihWs&t=229

https://github.com/user-attachments/assets/0c733e98-af57-49f5-b147-e93083553038

Other examples:
- https://youtu.be/kCMB4I_aJJM&t=335
- https://youtu.be/6ZU7EIZcU4o&t=142
- https://youtu.be/zmYEl97Smxs&t=223
- https://youtu.be/juRWRm7hrGM&t=205
- https://youtu.be/LJvL-T55ujc&t=226
- https://youtu.be/bU8sQbojKH4&t=284
- https://youtu.be/o63Ck1AGPr4&t=207