### PR TITLE
fix: prevent polearms being brought into various areas (274+)

### DIFF
--- a/scripts/areas/area_mage_arena/scripts/mage_arena.rs2
+++ b/scripts/areas/area_mage_arena/scripts/mage_arena.rs2
@@ -116,6 +116,7 @@ if ((inv_totalcat(inv, armour_hands) > 0 | inv_totalcat(worn, armour_hands) > 0)
     | (inv_totalcat(inv, weapon_scythe) > 0 | inv_totalcat(worn, weapon_scythe) > 0) 
     | (inv_totalcat(inv, weapon_bow) > 0 | inv_totalcat(worn, weapon_bow) > 0)
     | (inv_totalcat(inv, weapon_claws) > 0 | inv_totalcat(worn, weapon_claws) > 0)
+    | (inv_totalcat(inv, weapon_polearm) > 0 | inv_totalcat(worn, weapon_polearm) > 0)
     | (inv_totalcat(inv, arrows) > 0 | inv_totalcat(worn, arrows) > 0)
     | (inv_totalcat(inv, unstrung_bow) > 0)
     | (inv_total(inv, headless_arrow) > 0) // headless arrows

--- a/scripts/areas/area_port_sarim/scripts/monk_of_entrana.rs2
+++ b/scripts/areas/area_port_sarim/scripts/monk_of_entrana.rs2
@@ -46,6 +46,7 @@ if ((inv_totalcat(inv, armour_hands) > 0 | inv_totalcat(worn, armour_hands) > 0)
     | (inv_totalcat(inv, weapon_scythe) > 0 | inv_totalcat(worn, weapon_scythe) > 0) 
     | (inv_totalcat(inv, weapon_bow) > 0 | inv_totalcat(worn, weapon_bow) > 0)
     | (inv_totalcat(inv, weapon_claws) > 0 | inv_totalcat(worn, weapon_claws) > 0)
+    | (inv_totalcat(inv, weapon_polearm) > 0 | inv_totalcat(worn, weapon_polearm) > 0)
     | (inv_totalcat(inv, cannon_parts) > 0)) {
     return(true);
 }

--- a/scripts/quests/quest_viking/scripts/viking_thorvald.rs2
+++ b/scripts/quests/quest_viking/scripts/viking_thorvald.rs2
@@ -454,6 +454,8 @@ if ((inv_totalcat(inv, armour_hands) > 0 | inv_totalcat(worn, armour_hands) > 0)
     | (inv_totalcat(inv, weapon_thrown) > 0 | inv_totalcat(worn, weapon_thrown) > 0) 
     | (inv_totalcat(inv, weapon_scythe) > 0 | inv_totalcat(worn, weapon_scythe) > 0) 
     | (inv_totalcat(inv, weapon_bow) > 0 | inv_totalcat(worn, weapon_bow) > 0) 
+    | (inv_totalcat(inv, weapon_claws) > 0 | inv_totalcat(worn, weapon_claws) > 0) 
+    | (inv_totalcat(inv, weapon_polearm) > 0 | inv_totalcat(worn, weapon_polearm) > 0)
     | (inv_totalcat(inv, arrows) > 0 | inv_totalcat(worn, arrows) > 0)
     | (inv_totalcat(worn, flowers) > 0) // doesn't check worn
     | (inv_totalcat(inv, category_149) > 0) // runes

--- a/scripts/quests/quest_waterfall/scripts/quest_waterfall.rs2
+++ b/scripts/quests/quest_waterfall/scripts/quest_waterfall.rs2
@@ -63,6 +63,8 @@ if ((inv_totalcat(inv, armour_hands) > 0 | inv_totalcat(worn, armour_hands) > 0)
     | (inv_totalcat(inv, weapon_thrown) > 0 | inv_totalcat(worn, weapon_thrown) > 0) 
     | (inv_totalcat(inv, weapon_scythe) > 0 | inv_totalcat(worn, weapon_scythe) > 0) 
     | (inv_totalcat(inv, weapon_bow) > 0 | inv_totalcat(worn, weapon_bow) > 0) 
+    | (inv_totalcat(inv, weapon_claws) > 0 | inv_totalcat(worn, weapon_claws) > 0) 
+    | (inv_totalcat(inv, weapon_polearm) > 0 | inv_totalcat(worn, weapon_polearm) > 0)
     | (inv_totalcat(inv, arrows) > 0 | inv_totalcat(worn, arrows) > 0)
     | (inv_totalcat(worn, flowers) > 0) // doesn't check worn
     | (inv_totalcat(inv, category_149) > 0) // runes


### PR DESCRIPTION
For 274+

Add polearm weapon category checks to Mage Arena, Entrana, Glarial's Tomb & Koschei (Fremennik Trials).