### PR TITLE
fix: Shades of Mort'ton Temple Building Fixes

### DIFF
--- a/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
+++ b/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
@@ -45,17 +45,17 @@ p_oploc(3);
 
 %action_delay = calc(map_clock + 4);
 
+def_int $crafting_bonus = 0;
 def_int $low_roll = 130;
 def_int $high_roll = 210;
-def_int $crafting_boost = 0;
 
 // flamtaer hammer gives +40 invisible boost:
 // https://x.com/JagexAsh/status/1297181159726735360
 if(inv_total(inv,flamtaer_hammer) > 0) {
-    $crafting_boost = 40;
+    $crafting_bonus = 40;
     // add (high - low) * 40 / 98
-    $low_roll = add($low_roll, divide(multiply(sub($high_roll, $low_roll), $crafting_boost), 98));
-    $high_roll = add($high_roll, divide(multiply(sub($high_roll, $low_roll), $crafting_boost), 98));
+    $low_roll = add($low_roll, divide(multiply(sub($high_roll, $low_roll), $crafting_bonus), 98));
+    $high_roll = add($high_roll, divide(multiply(sub($high_roll, $low_roll), $crafting_bonus), 98));
 }
 
 // this success rate is estimated based on observed data from osrs
@@ -104,7 +104,7 @@ if(%temple_repaired_p = 100) {
 }
 
 // resource contribution is a random value from 7 to (level+2)/2
-def_int $resource_amount = ~random_range(7,divide(add(add(stat(crafting), $crafting_boost), 2), 2));
+def_int $resource_amount = ~random_range(7,divide(add(add(stat(crafting), $crafting_bonus), 2), 2));
 
 if(gettimer(sanctity_drain) = ^false) {
     settimer(sanctity_drain, 100);

--- a/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
+++ b/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
@@ -45,20 +45,24 @@ p_oploc(3);
 
 %action_delay = calc(map_clock + 4);
 
-def_int $crafting_bonus = 0;
+def_int $low_roll = 130;
+def_int $high_roll = 210;
+def_int $crafting_boost = 0;
+
+// flamtaer hammer gives +40 invisible boost:
+// https://x.com/JagexAsh/status/1297181159726735360
 if(inv_total(inv,flamtaer_hammer) > 0) {
-    $crafting_bonus = 40; //https://x.com/JagexAsh/status/1297181159726735360
+    $crafting_boost = 40;
+    // add (high - low) * 40 / 98
+    $low_roll = add($low_roll, divide(multiply(sub($high_roll, $low_roll), $crafting_boost), 98));
+    $high_roll = add($high_roll, divide(multiply(sub($high_roll, $low_roll), $crafting_boost), 98));
 }
-def_int $effective_crafting_lvl = add(stat_base(crafting),$crafting_bonus);
 
 // this success rate is estimated based on observed data from osrs
 // samples were taken at low-20s, low-70s, 99, and 139 (99 with +40 flamtaer boost)
-// results: 95/161 at low-20s, 129/161 at low-70s, 131/161 at 99, 138/161 at 139
-// most likely the success rate caps at 99 and the difference is just variance.
-// larger samples could be taken to fine-tune the accuracy
-// TODO: min($effective_crafting_lvl, 99) can be removed when the engine command is
-// updated to cap success at 99
-if (stat_random(min($effective_crafting_lvl, 99), 130, 210) = false) {
+// results: 95/161 at low-20s, 129/161 at low-70s, 131/161 at 99, 138/161 at 139.
+// TODO: larger samples should be taken to fine-tune the accuracy
+if (stat_random(crafting, $low_roll, $high_roll) = false) {
     anim(human_pickuptable, 0);
     p_oploc(3);
     // TODO: should execution stop here, or should we simply set resource_amount to 0 if this roll fails?
@@ -100,7 +104,7 @@ if(%temple_repaired_p = 100) {
 }
 
 // resource contribution is a random value from 7 to (level+2)/2
-def_int $resource_amount = ~random_range(7,divide(add($effective_crafting_lvl, 2), 2));
+def_int $resource_amount = ~random_range(7,divide(add(add(stat(crafting), $crafting_boost), 2), 2));
 
 if(gettimer(sanctity_drain) = ^false) {
     settimer(sanctity_drain, 100);

--- a/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
+++ b/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
@@ -49,7 +49,7 @@ def_int $crafting_bonus = 0;
 if(inv_total(inv,flamtaer_hammer) > 0) {
     $crafting_bonus = 40; //https://x.com/JagexAsh/status/1297181159726735360
 }
-def_int effective_crafting_lvl = add(stat_base(crafting),$crafting_bonus);
+def_int $effective_crafting_lvl = add(stat_base(crafting),$crafting_bonus);
 
 // this success rate is estimated based on observed data from osrs
 // samples were taken at low-20s, low-70s, 99, and 139 (99 with +40 flamtaer boost)

--- a/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
+++ b/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
@@ -63,13 +63,6 @@ if(inv_total(inv,flamtaer_hammer) > 0) {
 def_int $low_roll = add(130, divide(multiply(sub(210, 130), $crafting_bonus), 98));
 def_int $high_roll = add(210, divide(multiply(sub(210, 130), $crafting_bonus), 98));
 
-if (stat_random(crafting, $low_roll, $high_roll) = false) {
-    anim(human_pickuptable, 0);
-    p_oploc(3);
-    // TODO: should execution stop here, or should we simply set resource_amount to 0 if this roll fails?
-    return;
-}
-
 if ((inv_total(inv,woodplank) > 0 & inv_total(inv,swamppaste) > 4 & inv_total(inv,limestonebrick) > 0) & %temple_resources < 15000) {
     ~add_temple_resources;
 }
@@ -105,7 +98,11 @@ if(%temple_repaired_p = 100) {
 }
 
 // resource contribution is a random value from 7 to (level+2)/2
-def_int $resource_amount = ~random_range(7,divide(add(add(stat(crafting), $crafting_bonus), 2), 2));
+// if you fail a crafting level roll, you contribute 0 and get 0 xp
+def_int $resource_amount = 0;
+if (stat_random(crafting, $low_roll, $high_roll) = true) {
+    $resource_amount = ~random_range(7,divide(add(add(stat(crafting), $crafting_bonus), 2), 2));
+}
 
 if(gettimer(sanctity_drain) = ^false) {
     settimer(sanctity_drain, 100);

--- a/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
+++ b/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
@@ -60,8 +60,8 @@ if(inv_total(inv,flamtaer_hammer) > 0) {
 
 // to apply the boost, add ((high - low) * crafting_bonus / 98) to low/high rolls
 // if crafting_bonus is 0, values remain 130,210
-def_int $low_roll = add(130, divide(multiply(sub($high_roll, $low_roll), $crafting_bonus), 98));
-def_int $high_roll = add(210, divide(multiply(sub($high_roll, $low_roll), $crafting_bonus), 98));
+def_int $low_roll = add(130, divide(multiply(sub(210, 130), $crafting_bonus), 98));
+def_int $high_roll = add(210, divide(multiply(sub(210, 130), $crafting_bonus), 98));
 
 if (stat_random(crafting, $low_roll, $high_roll) = false) {
     anim(human_pickuptable, 0);

--- a/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
+++ b/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
@@ -45,23 +45,24 @@ p_oploc(3);
 
 %action_delay = calc(map_clock + 4);
 
-def_int $crafting_bonus = 0;
-def_int $low_roll = 130;
-def_int $high_roll = 210;
-
 // flamtaer hammer gives +40 invisible boost:
 // https://x.com/JagexAsh/status/1297181159726735360
+def_int $crafting_bonus = 0;
 if(inv_total(inv,flamtaer_hammer) > 0) {
     $crafting_bonus = 40;
-    // add (high - low) * 40 / 98
-    $low_roll = add($low_roll, divide(multiply(sub($high_roll, $low_roll), $crafting_bonus), 98));
-    $high_roll = add($high_roll, divide(multiply(sub($high_roll, $low_roll), $crafting_bonus), 98));
 }
 
+// base success rates of 130, 210
 // this success rate is estimated based on observed data from osrs
 // samples were taken at low-20s, low-70s, 99, and 139 (99 with +40 flamtaer boost)
 // results: 95/161 at low-20s, 129/161 at low-70s, 131/161 at 99, 138/161 at 139.
 // TODO: larger samples should be taken to fine-tune the accuracy
+
+// to apply the boost, add ((high - low) * crafting_bonus / 98) to low/high rolls
+// if crafting_bonus is 0, values remain 130,210
+def_int $low_roll = add(130, divide(multiply(sub($high_roll, $low_roll), $crafting_bonus), 98));
+def_int $high_roll = add(210, divide(multiply(sub($high_roll, $low_roll), $crafting_bonus), 98));
+
 if (stat_random(crafting, $low_roll, $high_roll) = false) {
     anim(human_pickuptable, 0);
     p_oploc(3);

--- a/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
+++ b/scripts/minigames/game_mortton/scripts/flamtaer_temple.rs2
@@ -43,18 +43,26 @@ p_oploc(3);
 
 [label,try_build_temple]
 
-%action_delay = calc(map_clock + 3);
+%action_delay = calc(map_clock + 4);
 
 def_int $crafting_bonus = 0;
 if(inv_total(inv,flamtaer_hammer) > 0) {
-    //Todo: Use invis boost in stat_randoms
     $crafting_bonus = 40; //https://x.com/JagexAsh/status/1297181159726735360
 }
+def_int effective_crafting_lvl = add(stat_base(crafting),$crafting_bonus);
 
-//Todo: Actual (best guess) roll. Seemed like a 40% chance of succeeding at 20 crafting 80% at 120+?
-if (stat_random(crafting, 85, 175) = false) {
+// this success rate is estimated based on observed data from osrs
+// samples were taken at low-20s, low-70s, 99, and 139 (99 with +40 flamtaer boost)
+// results: 95/161 at low-20s, 129/161 at low-70s, 131/161 at 99, 138/161 at 139
+// most likely the success rate caps at 99 and the difference is just variance.
+// larger samples could be taken to fine-tune the accuracy
+// TODO: min($effective_crafting_lvl, 99) can be removed when the engine command is
+// updated to cap success at 99
+if (stat_random(min($effective_crafting_lvl, 99), 130, 210) = false) {
     anim(human_pickuptable, 0);
     p_oploc(3);
+    // TODO: should execution stop here, or should we simply set resource_amount to 0 if this roll fails?
+    return;
 }
 
 if ((inv_total(inv,woodplank) > 0 & inv_total(inv,swamppaste) > 4 & inv_total(inv,limestonebrick) > 0) & %temple_resources < 15000) {
@@ -91,31 +99,8 @@ if(%temple_repaired_p = 100) {
     }
 }
 
-def_int $resource_amount = ~random_range(7,9); //minimum
-//todo: update roll odds
-//Not sure if it has different rolls for different levels and if it falls into lower band 
-//or if your level just decides how many resources
-//Find exact level breakpoint? Never received 60+ with 97 crafting
-if (add(stat_base(crafting),$crafting_bonus) > 98) {
-    if (stat_random(crafting, 5, 65) = true) {
-        //70 is max resources spent
-        //todo: Find (guess) minimum for this band?
-        $resource_amount = ~random_range(60,70);
-    }
-}
-//todo: update roll odds
-//Find exact level breakpoint? Seems to be 50
-if ($resource_amount < 10 & add(stat_base(crafting),$crafting_bonus) > 49) {
-    if (stat_random(crafting, 5, 65) = true) {
-        //todo: Find (guess) minimum + maximum for this band?
-        $resource_amount = ~random_range(35,59);
-    }
-}
-//todo: update roll odds
-if ($resource_amount < 10 & stat_random(crafting, 5, 65) = true) {
-    //todo: Find (guess) minimum + maximum for this band?
-    $resource_amount = ~random_range(10,35);
-}
+// resource contribution is a random value from 7 to (level+2)/2
+def_int $resource_amount = ~random_range(7,divide(add($effective_crafting_lvl, 2), 2));
 
 if(gettimer(sanctity_drain) = ^false) {
     settimer(sanctity_drain, 100);
@@ -133,7 +118,8 @@ if(%temple_sanctity_p < 100) {
 }
 
 //1 exp per 2 resources spent
-stat_advance(crafting, divide(multiply($resource_amount,10),2));
+// xp given is always integer. I tested on rs3, which will show decimals in xp drops
+stat_advance(crafting, multiply(divide($resource_amount, 2), 10));
 
 def_int $current_wall_state = loc_param(temple_wall_level);
 //todo: Find better breakpoints


### PR DESCRIPTION
- Repair action goes from 3t to 4t. It's 4t in both RS3 and OSRS.
- All crafting rolls use the Flamtaer hammer's +40 crafting boost, which matches RS3 and OSRS.
- Success rate of repair action improved based on data gathered from OSRS. The code here was also missing a return, so you could never actually fail the roll and get 0 xp.
- Simplified the resource contribution and xp reward code. Based on observations from RS3/OSRS, the lowest xp drop you can get is always 3, and the highest is (craftinglvl+2)/4, capping at 35 at 99 with flamtaer hammer (effective lvl 139). You can get any amount of xp between the minimum and maximum. Resource contribution is 2x xp, so maximum resource contribution becomes (craftinglvl+2)/2.
- xp awarded is always integer, so I adjusted the formula to multiply by 10 after dividing resource contribution by 2.
- TODO: Shades should be interrupting wall building, requiring the player to click on the wall again. This happens very frequently when solo on RS3/OSRS, and much less frequently with a group. I recall very clearly from rs2 days that it was impossible to build the temple solo, and that is still true in RS3/OSRS. I do not know how to write that code lol