### PR TITLE
feat: enable dag mother color change messages, crumble undead xp change

### DIFF
--- a/scripts/quests/quest_horror/scripts/horror_dagannoth.rs2
+++ b/scripts/quests/quest_horror/scripts/horror_dagannoth.rs2
@@ -119,7 +119,7 @@ if(finduid(%npc_aggressive_player) = true) {
     npc_changetype(horror_dagganoth_water, 1000);
     %aggressive_npc = npc_uid;
     npc_say("Krrrrrrk");
-    //mes("The Dagannoth changes to blue..."); https://oldschool.runescape.wiki/w/Update:More_Small_Changes, TODO: enable for 289
+    mes("The Dagannoth changes to blue...");
     // can switch mode between phase changes
     if(random(2) = 0) npc_setmode(opplayer2);
     else npc_setmode(applayer2);
@@ -137,7 +137,7 @@ if(finduid(%npc_aggressive_player) = true) {
     npc_changetype(horror_dagganoth_melee, 1000);
     %aggressive_npc = npc_uid;
     npc_say("Chkhkhkhkhk");
-    //mes("The Dagannoth changes to orange...");
+    mes("The Dagannoth changes to orange...");
     if(random(2) = 0) npc_setmode(opplayer2);
     else npc_setmode(applayer2);
     ~.sound_area(dagganoth_changes, 0, npc_coord, 10);
@@ -154,7 +154,7 @@ if(finduid(%npc_aggressive_player) = true) {
     npc_changetype(horror_dagganoth_earth, 1000);
     %aggressive_npc = npc_uid;
     npc_say("Krrrrrrssssssss");
-    //mes("The Dagannoth changes to brown...");
+    mes("The Dagannoth changes to brown...");
     if(random(2) = 0) npc_setmode(opplayer2);
     else npc_setmode(applayer2);
     ~.sound_area(dagganoth_changes, 0, npc_coord, 10);
@@ -171,7 +171,7 @@ if(finduid(%npc_aggressive_player) = true) {
     npc_changetype(horror_dagganoth_fire, 1000);
     %aggressive_npc = npc_uid;
     npc_say("Sssssrrrkkkkk");
-    //mes("The Dagannoth changes to red...");
+    mes("The Dagannoth changes to red...");
     if(random(2) = 0) npc_setmode(opplayer2);
     else npc_setmode(applayer2);
     ~.sound_area(dagganoth_changes, 0, npc_coord, 10);
@@ -188,7 +188,7 @@ if(finduid(%npc_aggressive_player) = true) {
     npc_changetype(horror_dagganoth_ranged, 1000);
     %aggressive_npc = npc_uid;
     npc_say("Krkrkrkrkrkrkrkr");
-    //mes("The Dagannoth changes to green...");
+    mes("The Dagannoth changes to green...");
     if(random(2) = 0) npc_setmode(opplayer2);
     else npc_setmode(applayer2);
     ~.sound_area(dagganoth_changes, 0, npc_coord, 10);
@@ -205,7 +205,7 @@ if(finduid(%npc_aggressive_player) = true) {
     npc_changetype(horror_dagganoth_air, 1000);
     %aggressive_npc = npc_uid;
     npc_say("Tktktktktktkt");
-    //mes("The Dagannoth changes to white...");
+    mes("The Dagannoth changes to white...");
     if(random(2) = 0) npc_setmode(opplayer2);
     else npc_setmode(applayer2);
     ~.sound_area(dagganoth_changes, 0, npc_coord, 10);

--- a/scripts/skill_combat/configs/magic/magic_combat_spells.dbrow
+++ b/scripts/skill_combat/configs/magic/magic_combat_spells.dbrow
@@ -468,7 +468,7 @@ data=spellcom,magic:crumble_undead
 data=members,false
 data=levelrequired,39
 data=runesrequired,chaosrune,1,airrune,2,earthrune,2
-data=experience,490
+data=experience,245
 data=anim,human_castcrumbleundead
 data=staffanim,human_castcrumbleundead_staff
 data=spotanim_origin,crumbleundead_casting
@@ -476,7 +476,7 @@ data=spotanim_proj,crumbleundead_travel,31,31,46,16,0,64,5
 data=spotanim_target,crumbleundead_impact,124
 data=sound_success,crumble_all
 data=continue_by_autocast,true
-data=maxhit,8
+data=maxhit,15
 
 [magic_spell_saradomin_strike]
 table=magic_spell_table

--- a/scripts/skill_combat/configs/magic/magic_combat_spells.dbrow
+++ b/scripts/skill_combat/configs/magic/magic_combat_spells.dbrow
@@ -459,9 +459,6 @@ data=stat_change,attack,-1,-10
 data=continue_by_autocast,false
 
 [magic_spell_crumble_undead]
-// damage was increased, xp was decreased in dec 2004 https://oldschool.runescape.wiki/w/Update:Various_Small_Changes.
-// fansites say it had a base xp of 49
-// only one fansite has the maxhit (8), it seems credible: https://web.archive.org/web/20050416144009/http://www.trillionareguild.com/runescape/magic.php
 table=magic_spell_table
 data=spell,^crumble_undead
 data=spellcom,magic:crumble_undead


### PR DESCRIPTION
for 289
- update crumble undead xp and max hit (https://oldschool.runescape.wiki/w/Update:Various%20Small%20Changes.)
- add dagannoth mother color change messages (https://oldschool.runescape.wiki/w/Update:More_Small_Changes)