### PR TITLE
chore: add a few missing synths

### DIFF
--- a/scripts/_unpack/225/all.npc
+++ b/scripts/_unpack/225/all.npc
@@ -1349,6 +1349,7 @@ param=defend_anim,hell_block
 param=death_anim,hell_death
 param=attack_sound,growl6
 param=defend_sound,growl5
+param=death_sound,growl3
 huntmode=cowardly
 huntrange=2
 // osrs stats and Vislvl match 1:1

--- a/scripts/quests/quest_arena/configs/quest_arena.npc
+++ b/scripts/quests/quest_arena/configs/quest_arena.npc
@@ -491,6 +491,7 @@ param=defend_anim,hell_block
 param=death_anim,hell_death
 param=attack_sound,growl6
 param=defend_sound,growl5
+param=death_sound,growl3
 huntmode=aggressive_melee
 huntrange=2
 // osrs stats and Vislvl match 1:1

--- a/scripts/quests/quest_upass/scripts/upass_grid.rs2
+++ b/scripts/quests/quest_upass/scripts/upass_grid.rs2
@@ -6,32 +6,40 @@ loc_change(upass_lever_down, 15);
 p_delay(1);
 mes("The portcullis opens.");
 if(loc_find(0_38_151_33_10, portcullis_upass) = true) {
-    loc_anim(portcullisopen); // sound portcullis_open
+    loc_anim(portcullisopen);
+    sound_synth(portcullis_open, 1, 0);
 }
 if(loc_find(0_38_151_33_12, portcullis_upass) = true) {
-    loc_anim(portcullisopen); // sound portcullis_open
+    loc_anim(portcullisopen);
+    sound_synth(portcullis_open, 1, 0);
 }
 if(loc_find(0_38_151_33_14, portcullis_upass) = true) {
-    loc_anim(portcullisopen); // sound portcullis_open
+    loc_anim(portcullisopen);
+    sound_synth(portcullis_open, 1, 0);
 }
 if(loc_find(0_38_151_33_16, portcullis_upass) = true) {
-    loc_anim(portcullisopen); // sound portcullis_open
+    loc_anim(portcullisopen);
+    sound_synth(portcullis_open, 1, 0);
 }
 ~forcemove(movecoord(coord, 0, 0, 2));
 ~forcemove(movecoord(coord, -2, 0, 1));
 ~forcemove(movecoord(coord, 0, 0, 1));
 mes("The portcullis closes.");
 if(loc_find(0_38_151_33_10, portcullis_upass) = true) {
-    loc_anim(portcullisclose); // sound portcullis_open
+    loc_anim(portcullisclose);
+    sound_synth(portcullis_close, 1, 0);
 }
 if(loc_find(0_38_151_33_12, portcullis_upass) = true) {
-    loc_anim(portcullisclose); // sound portcullis_open
+    loc_anim(portcullisclose);
+    sound_synth(portcullis_close, 1, 0);
 }
 if(loc_find(0_38_151_33_14, portcullis_upass) = true) {
-    loc_anim(portcullisclose); // sound portcullis_open
+    loc_anim(portcullisclose);
+    sound_synth(portcullis_close, 1, 0);
 }
 if(loc_find(0_38_151_33_16, portcullis_upass) = true) {
-    loc_anim(portcullisclose); // sound portcullis_open
+    loc_anim(portcullisclose);
+    sound_synth(portcullis_close, 1, 0);
 }
 
 // generates a 5-digit value from 1-5


### PR DESCRIPTION
Adds a few missing sounds:
* Hellhound had no death_sound defined, set to `growl3` but unconfirmed if this was the actual, osrs uses `dog_death`.
* Upass porticullis open/close sound (yes it plays x4 to make sure the player goes deaf)