### PR TITLE
fix: run unequip effects when switching items

### DIFF
--- a/scripts/interface_bank/scripts/bank.rs2
+++ b/scripts/interface_bank/scripts/bank.rs2
@@ -101,7 +101,7 @@ if ($deposit > 0) {
     session_log(^log_moderator, "Deposited <oc_debugname($obj)> x<tostring($deposit)> into bank");
     inv_moveitem_uncert($inv, bank, $obj, $deposit);
     if($inv = worn) {
-        ~unequip_effect($obj);
+        ~unequip_effect($obj, ^true);
     }
 }
 return(true);

--- a/scripts/player/scripts/equip.rs2
+++ b/scripts/player/scripts/equip.rs2
@@ -75,17 +75,17 @@ if (p_finduid(uid) = true) {
         return;
     }
     inv_moveitem(worn, inv, $obj, sub($count, $overflow));
-    ~unequip_effect($obj);
+    ~unequip_effect($obj, ^true);
 }
 
-[proc,unequip_effect](obj $obj)
+[proc,unequip_effect](obj $obj, int $update_all)
 if($obj = elemental_shield) {
     sound_synth(shield_appear, 1, 0);
 }
 if (oc_param($obj, specwep) = ^true) {
     %sa_attack = ^false;
 }
-~update_all($obj);
+if($update_all = ^true) ~update_all($obj);
 
 // used for duel arena, no weapon/no armour
 [proc,try_unequip](int $slot)
@@ -364,13 +364,16 @@ if (~unequip_conflicts_space($equip_obj) = false) { // check if enough space
     return(false);
 }
 
+def_obj $previous_equip = inv_getobj(worn, $worn_slot);
 inv_movetoslot(inv, worn, $inv_slot, $worn_slot); // equip item! this performs a swap
+
 if (inv_getobj(inv, $inv_slot) ! null) {
     // presumably, they added this as an easy way for stackable objs to stack in the inv (instead of directly swapping)
     // seems like in late 2006 they removed this line of code and it produced this bug: https://youtu.be/EYXp7GMFWEw, https://youtu.be/DwzDt3yw6k4
     inv_movefromslot(inv, inv, $inv_slot); // moves item to the first available slot in the inv...
 }
 ~unequip_conflicts($equip_obj);
+~unequip_effect($previous_equip, ^false);
 
 return(true);
 

--- a/scripts/player/scripts/equip.rs2
+++ b/scripts/player/scripts/equip.rs2
@@ -79,7 +79,7 @@ if (p_finduid(uid) = true) {
 }
 
 [proc,unequip_effect](obj $obj, int $update_all)
-if($obj = elemental_shield) {
+if($obj = elemental_shield & inv_getobj(worn, ^wearpos_lhand) = null) {
     sound_synth(shield_appear, 1, 0);
 }
 if (oc_param($obj, specwep) = ^true) {
@@ -364,6 +364,7 @@ if (~unequip_conflicts_space($equip_obj) = false) { // check if enough space
     return(false);
 }
 
+def_obj $previous_equip = inv_getobj(worn, $worn_slot);
 inv_movetoslot(inv, worn, $inv_slot, $worn_slot); // equip item! this performs a swap
 
 if (inv_getobj(inv, $inv_slot) ! null) {
@@ -372,6 +373,7 @@ if (inv_getobj(inv, $inv_slot) ! null) {
     inv_movefromslot(inv, inv, $inv_slot); // moves item to the first available slot in the inv...
 }
 ~unequip_conflicts($equip_obj);
+if($previous_equip ! null) ~unequip_effect($previous_equip, ^false);
 
 return(true);
 
@@ -409,10 +411,11 @@ while ($i < inv_size(worn)) {
     def_obj $worn_obj = inv_getobj(worn, $i);
     def_int $worn_num = inv_getnum(worn, $i);
     if ($worn_obj ! null & ~wearpos_conflicts($equip_obj, $worn_obj) = true) {
-        ~unequip_effect($worn_obj, ^false);
         if ($worn_obj ! $equip_obj) { // skip the obj we just equipped
             inv_moveitem(worn, inv, $worn_obj, $worn_num);
         }
+        // run unequip effects on the conflicted obj
+        ~unequip_effect($worn_obj, ^false);
     }
     $i = add($i, 1);
 }

--- a/scripts/player/scripts/equip.rs2
+++ b/scripts/player/scripts/equip.rs2
@@ -364,7 +364,6 @@ if (~unequip_conflicts_space($equip_obj) = false) { // check if enough space
     return(false);
 }
 
-def_obj $previous_equip = inv_getobj(worn, $worn_slot);
 inv_movetoslot(inv, worn, $inv_slot, $worn_slot); // equip item! this performs a swap
 
 if (inv_getobj(inv, $inv_slot) ! null) {
@@ -373,7 +372,6 @@ if (inv_getobj(inv, $inv_slot) ! null) {
     inv_movefromslot(inv, inv, $inv_slot); // moves item to the first available slot in the inv...
 }
 ~unequip_conflicts($equip_obj);
-~unequip_effect($previous_equip, ^false);
 
 return(true);
 
@@ -411,9 +409,7 @@ while ($i < inv_size(worn)) {
     def_obj $worn_obj = inv_getobj(worn, $i);
     def_int $worn_num = inv_getnum(worn, $i);
     if ($worn_obj ! null & ~wearpos_conflicts($equip_obj, $worn_obj) = true) {
-        if (oc_param($worn_obj, specwep) = ^true) {
-            %sa_attack = ^false;
-        }
+        ~unequip_effect($worn_obj, ^false);
         if ($worn_obj ! $equip_obj) { // skip the obj we just equipped
             inv_moveitem(worn, inv, $worn_obj, $worn_num);
         }

--- a/scripts/player/scripts/equip.rs2
+++ b/scripts/player/scripts/equip.rs2
@@ -413,9 +413,9 @@ while ($i < inv_size(worn)) {
     if ($worn_obj ! null & ~wearpos_conflicts($equip_obj, $worn_obj) = true) {
         if ($worn_obj ! $equip_obj) { // skip the obj we just equipped
             inv_moveitem(worn, inv, $worn_obj, $worn_num);
+            // run unequip effects on the conflicted obj
+            ~unequip_effect($worn_obj, ^false);
         }
-        // run unequip effects on the conflicted obj
-        ~unequip_effect($worn_obj, ^false);
     }
     $i = add($i, 1);
 }


### PR DESCRIPTION
for 225+ (although not needed before 244 anyways)

currently unequip effects when unequiped through a switch (like the elemental shield sound, or switching with a greegree on)