### PR TITLE
fix: accurate logic for dying with pets/followers

### DIFF
--- a/scripts/player/scripts/death.rs2
+++ b/scripts/player/scripts/death.rs2
@@ -32,7 +32,10 @@ if (findhero = true) {
 p_teleport(map_findsquare(0_50_50_21_18, 0, 2, ^map_findsquare_lineofwalk));
 buildappearance(worn);
 ~prayer_deactivate_all;
-~follower_death;
+if (npc_finduid(%follower_uid) = true) {
+    ~remove_follower;
+    npc_add(npc_coord, npc_type, 50);
+}
 anim(null, 0);
 p_stopaction;
 
@@ -72,11 +75,12 @@ while ($i < $size) {
         if (oc_category($currentitem) = armour_godcape) {
             mes(oc_param($currentitem, lose_cape_message));
         }
-        if($currentitem = ikov_bootsoflightnessworn) { // can make a namedobj param for this later with barrows
-            inv_setslot(inv, oc_wearpos(ikov_bootsoflightnessworn), ikov_bootsoflightness, 1);
-        }
         if (oc_param($currentitem, destroy_drop) = ^true | oc_param($currentitem, destroy_death) = ^true) {
             inv_delslot(inv, $i);
+        }
+        if(oc_param($currentitem, follower_id) ! null) {
+            ~remove_follower_inv($currentitem, $i);
+            npc_add(coord, oc_param($currentitem, follower_id), 50);
         }
     }
     $i = calc($i + 1);
@@ -90,7 +94,7 @@ while ($i < $size) {
         if (oc_category($currentitem) = armour_godcape) {
             mes(oc_param($currentitem, lose_cape_message));
         }
-        if($currentitem = ikov_bootsoflightnessworn) {
+        if($currentitem = ikov_bootsoflightnessworn) { // can make a namedobj param for this later with barrows
             inv_setslot(worn, oc_wearpos(ikov_bootsoflightnessworn), ikov_bootsoflightness, 1);
         }
         if (oc_param($currentitem, destroy_drop) = ^true | oc_param($currentitem, destroy_death) = ^true) {
@@ -132,14 +136,14 @@ while ($i < $size) {
     if (inv_getnum(inv, $i) > 0) {
         $currentitem = inv_getobj(inv, $i);
         if (oc_param($currentitem, destroy_drop) = ^true | oc_param($currentitem, destroy_death) = ^true) {
-            if (oc_category(inv_getobj(inv, $i)) = armour_godcape) {
-                mes(oc_param(inv_getobj(inv, $i), lose_cape_message));
+            if (oc_category($currentitem) = armour_godcape) {
+                mes(oc_param($currentitem, lose_cape_message));
             }
             inv_delslot(inv, $i);
+        } else if(oc_param($currentitem, follower_id) ! null) {
+            ~remove_follower_inv($currentitem, $i);
+            npc_add(coord, oc_param($currentitem, follower_id), 50);
         } else {
-            if($currentitem = ikov_bootsoflightnessworn) {
-                inv_setslot(inv, oc_wearpos(ikov_bootsoflightnessworn), ikov_bootsoflightness, 1);
-            }
             both_dropslot(inv, coord, $i, ^lootdrop_duration);
         }
     }

--- a/scripts/quests/quest_fluffs/configs/quest_fluffs.obj
+++ b/scripts/quests/quest_fluffs/configs/quest_fluffs.obj
@@ -80,7 +80,6 @@ weight=750g
 category=kitten
 param=follower_id,kittenpet1
 tradeable=no
-param=destroy_drop,^true
 
 [kittenobject_light]
 name=Pet kitten
@@ -105,7 +104,6 @@ weight=750g
 category=kitten
 param=follower_id,kittenpet_light
 tradeable=no
-param=destroy_drop,^true
 
 [kittenobject_brown]
 name=Pet kitten
@@ -128,7 +126,6 @@ weight=750g
 category=kitten
 param=follower_id,kittenpet_brown
 tradeable=no
-param=destroy_drop,^true
 
 [kittenobject_black]
 name=Pet kitten
@@ -151,7 +148,6 @@ weight=750g
 category=kitten
 param=follower_id,kittenpet_black
 tradeable=no
-param=destroy_drop,^true
 
 [kittenobject_browngrey]
 name=Pet kitten
@@ -174,7 +170,6 @@ weight=750g
 category=kitten
 param=follower_id,kittenpet_browngrey
 tradeable=no
-param=destroy_drop,^true
 
 [kittenobject_bluegrey]
 name=Pet kitten
@@ -197,7 +192,6 @@ weight=750g
 category=kitten
 param=follower_id,kittenpet_bluegrey
 tradeable=no
-param=destroy_drop,^true
 
 [growncatobject]
 name=Pet cat
@@ -214,7 +208,6 @@ weight=1500g
 category=cat
 param=follower_id,growncat
 tradeable=no
-param=destroy_drop,^true
 
 [growncatobject_light]
 name=Pet cat
@@ -239,7 +232,6 @@ weight=1500g
 category=cat
 param=follower_id,growncat_light
 tradeable=no
-param=destroy_drop,^true
 
 [growncatobject_brown]
 name=Pet cat
@@ -262,7 +254,6 @@ weight=1500g
 category=cat
 param=follower_id,growncat_brown
 tradeable=no
-param=destroy_drop,^true
 
 [growncatobject_black]
 name=Pet cat
@@ -285,7 +276,6 @@ weight=1500g
 category=cat
 param=follower_id,growncat_black
 tradeable=no
-param=destroy_drop,^true
 
 [growncatobject_browngrey]
 name=Pet cat
@@ -308,7 +298,6 @@ weight=1500g
 category=cat
 param=follower_id,growncat_browngrey
 tradeable=no
-param=destroy_drop,^true
 
 [growncatobject_bluegrey]
 name=Pet cat
@@ -331,7 +320,6 @@ weight=1500g
 category=cat
 param=follower_id,growncat_bluegrey
 tradeable=no
-param=destroy_drop,^true
 
 [overgrowncatobject]
 name=Pet cat
@@ -348,7 +336,6 @@ weight=2500g
 category=overgrown
 param=follower_id,overgrowncat
 tradeable=no
-param=destroy_drop,^true
 
 [overgrowncatobject_light]
 name=Pet cat
@@ -373,7 +360,6 @@ weight=2500g
 category=overgrown
 param=follower_id,overgrowncat_light
 tradeable=no
-param=destroy_drop,^true
 
 [overgrowncatobject_brown]
 name=Pet cat
@@ -396,7 +382,6 @@ weight=2500g
 category=overgrown
 param=follower_id,overgrowncat_brown
 tradeable=no
-param=destroy_drop,^true
 
 [overgrowncatobject_black]
 name=Pet cat
@@ -419,7 +404,6 @@ weight=2500g
 category=overgrown
 param=follower_id,overgrowncat_black
 tradeable=no
-param=destroy_drop,^true
 
 [overgrowncatobject_browngrey]
 name=Pet cat
@@ -442,7 +426,6 @@ weight=2500g
 category=overgrown
 param=follower_id,overgrowncat_browngrey
 tradeable=no
-param=destroy_drop,^true
 
 [overgrowncatobject_bluegrey]
 name=Pet cat
@@ -465,4 +448,3 @@ weight=2500g
 category=overgrown
 param=follower_id,overgrowncat_bluegrey
 tradeable=no
-param=destroy_drop,^true

--- a/scripts/quests/quest_fluffs/scripts/pet.rs2
+++ b/scripts/quests/quest_fluffs/scripts/pet.rs2
@@ -5,7 +5,6 @@ if (finduid(%npc_attacking_uid) = true) {
     }
     return;
 }
-npc_del;
 
 [timer,petcat_growth]
 if (%follower_uid = null) {
@@ -253,11 +252,18 @@ settimer(petcat_growth, 150);
 
 [proc,follower_death]
 if (npc_finduid(%follower_uid) = true) {
-    %follower_uid = null;
-    %follower_obj = null;
-    %cat_growth = 0;
-    npc_del;
+    ~remove_follower;
 }
+
+[proc,remove_follower]
+%follower_uid = null;
+%follower_obj = null;
+if(npc_category = petcat) %cat_growth = 0; // cat specific
+npc_del;
+
+[proc,remove_follower_inv](obj $obj, int $slot)
+if(oc_category($obj) = kitten | oc_category($obj) = cat | oc_category($obj) = overgrown) %cat_growth = 0; // cat specific
+inv_delslot(inv, $slot);
 
 [proc,follower_logout]
 if (npc_finduid(%follower_uid) = true) {


### PR DESCRIPTION
for 225+
- on player death, if a pet is lost (either not protected in inventory, or as a follower), it will now spawn the npc to wander for 50t before despawning rather than just deleting it (following npcs are deleted and added again, this matches osrs)
- don't check for the worn variant of boots of lightness in the inv loops for death (likewise pets wont need to be checked in worn)
- remove destroy_drop param from cats