### PR TITLE
fix: update gender checks and damage constants in various scripts

### DIFF
--- a/scripts/areas/area_burthorpe/scripts/death_cook.rs2
+++ b/scripts/areas/area_burthorpe/scripts/death_cook.rs2
@@ -1,6 +1,6 @@
 [opnpc1,death_cook]
 // confirm mesanims, current are based off osrs + guessed for female
-if(gender() = 0) {
+if(gender() = ^gender_male) {
     ~chatplayer("<p,quiz>What's cooking, good looking?");
     ~chatnpc("<p,neutral>The stew for the servant's main meal.");
     ~chatplayer("<p,confused>Um...er...see you later.");

--- a/scripts/player/scripts/damage.rs2
+++ b/scripts/player/scripts/damage.rs2
@@ -4,10 +4,10 @@ if (stat(hitpoints) = 0) {
 }
 if_close;
 if ($amount > 0) {
-    damage(uid, 1, $amount);
+    damage(uid, ^hitmark_damage, $amount);
     ~human_hit_sound;
 } else {
-    damage(uid, 0, 0);
+    damage(uid, ^hitmark_block, 0);
 }
 
 if (stat(hitpoints) = 0){
@@ -23,7 +23,7 @@ if (stat(hitpoints) = 0){
 [proc,human_hit_sound]
 def_int $rand;
 def_synth $sound;
-if (gender() = 0) {
+if (gender() = ^gender_male) {
         $rand = random(3);
         switch_int($rand) {
             case 0 : $sound = human_hit2;

--- a/scripts/skill_agility/scripts/agility.rs2
+++ b/scripts/skill_agility/scripts/agility.rs2
@@ -106,8 +106,8 @@ sound_synth(stumble_loop, 10, 0);
 facesquare($fall_face);
 p_delay(1);
 p_telejump($fail_coord);
-damage(uid, 1, $damage);
-if (gender() = 0) {
+damage(uid, ^hitmark_damage, $damage);
+if (gender() = ^gender_male) {
     sound_synth(human_hit2, 1, 20);
 } else {
     sound_synth(female_hit2, 1, 20);

--- a/scripts/skill_combat/scripts/poison.rs2
+++ b/scripts/skill_combat/scripts/poison.rs2
@@ -38,7 +38,7 @@ def_synth $sound;
 def_int $rand;
 // not sure if this damage is supposed to be queued or not
 damage(uid, ^hitmark_poison, $damage);
-if (gender() = 0) {
+if (gender() = ^gender_male) {
     $rand = random(3);
     switch_int($rand) {
         case 0 : $sound = human_hit2;


### PR DESCRIPTION
replace magic numbers where `gender()` and `damage()` are used to instead use constants