### PR TITLE
fix: Harpoon fishing spot requirement text

### DIFF
--- a/scripts/skill_fishing/scripts/fishing_spots/memberfish.rs2
+++ b/scripts/skill_fishing/scripts/fishing_spots/memberfish.rs2
@@ -9,7 +9,7 @@
 // check level 
 if (stat(fishing) < 76) {
     anim(null, 0);
-    ~mesbox("You need at least 76 Fishing to harpoon these fish.");
+    ~mesbox("You need at least 76 Fishing to Harpoon these fish.");
     return;
 }
 // check if they have fishing equipment
@@ -46,7 +46,7 @@ if (afk_event = ^true & npc_param(is_whirlpool) = ^false) {
 // check level 
 if (stat(fishing) < 76) {
     anim(null, 0);
-    ~mesbox("You need at least 76 Fishing to harpoon these fish.");
+    ~mesbox("You need at least 76 Fishing to Harpoon these fish.");
     return;
 }
 // check if they have fishing equipment

--- a/scripts/skill_fishing/scripts/fishing_spots/memberfish.rs2
+++ b/scripts/skill_fishing/scripts/fishing_spots/memberfish.rs2
@@ -9,6 +9,7 @@
 // check level 
 if (stat(fishing) < 76) {
     anim(null, 0);
+    // https://web.archive.org/web/*/http://runescape.salmoneus.net/cities/images/atollfish2.png
     ~mesbox("You need at least 76 Fishing to Harpoon these fish.");
     return;
 }
@@ -46,6 +47,7 @@ if (afk_event = ^true & npc_param(is_whirlpool) = ^false) {
 // check level 
 if (stat(fishing) < 76) {
     anim(null, 0);
+    // https://web.archive.org/web/*/http://runescape.salmoneus.net/cities/images/atollfish2.png
     ~mesbox("You need at least 76 Fishing to Harpoon these fish.");
     return;
 }

--- a/scripts/skill_fishing/scripts/fishing_spots/rarefish.rs2
+++ b/scripts/skill_fishing/scripts/fishing_spots/rarefish.rs2
@@ -85,6 +85,7 @@ p_opnpc(4);
 // check level for tuna
 if (stat(fishing) < 35) {
     anim(null, 0);
+    // https://web.archive.org/web/*/http://runescape.salmoneus.net/cities/images/atollfish2.png
     ~mesbox("You need at least 35 Fishing to Harpoon these fish.");
     return;
 }
@@ -123,6 +124,7 @@ if (afk_event = ^true & npc_param(is_whirlpool) = ^false) {
 // check level for tuna
 if (stat(fishing) < 35) {
     anim(null, 0);
+    // https://web.archive.org/web/*/http://runescape.salmoneus.net/cities/images/atollfish2.png
     ~mesbox("You need at least 35 Fishing to Harpoon these fish.");
     return;
 }

--- a/scripts/skill_fishing/scripts/fishing_spots/rarefish.rs2
+++ b/scripts/skill_fishing/scripts/fishing_spots/rarefish.rs2
@@ -85,7 +85,7 @@ p_opnpc(4);
 // check level for tuna
 if (stat(fishing) < 35) {
     anim(null, 0);
-    ~mesbox("You need at least 35 Fishing to harpoon these fish.");
+    ~mesbox("You need at least 35 Fishing to Harpoon these fish.");
     return;
 }
 // check if they have fishing equipment
@@ -123,7 +123,7 @@ if (afk_event = ^true & npc_param(is_whirlpool) = ^false) {
 // check level for tuna
 if (stat(fishing) < 35) {
     anim(null, 0);
-    ~mesbox("You need at least 35 Fishing to harpoon these fish.");
+    ~mesbox("You need at least 35 Fishing to Harpoon these fish.");
     return;
 }
 // check if they have fishing equipment


### PR DESCRIPTION
Title cases the word "Harpoon" in level requirement messages per source below.

Source: 
https://web.archive.org/web/*/http://runescape.salmoneus.net/cities/images/atollfish2.png
<img width="493" height="112" alt="image" src="https://github.com/user-attachments/assets/ba91b15d-f231-45b6-9db1-6370c79afa7e" />
