### PR TITLE
fix: Skill Guide 'splitbark boots' to 'splitbark greaves'

### DIFF
--- a/scripts/player/configs/skill_guide.dbrow
+++ b/scripts/player/configs/skill_guide.dbrow
@@ -140,9 +140,9 @@ data=inv,skill_guide_magic_armour
 data=unlock,20,Wizard boots.
 data=unlock,40,Splitbark helm\n     (with defence 40).
 data=unlock,40,Splitbark body\n     (with defence 40).
-data=unlock,40,Splitbark legs\n     with defence 40).
+data=unlock,40,Splitbark legs\n     (with defence 40).
 data=unlock,40,Splitbark gauntlets\n     (with defence 40).
-data=unlock,40,Splitbark boots\n     (with defence 40).
+data=unlock,40,Splitbark greaves\n     (with defence 40).
 
 // ----
 


### PR DESCRIPTION
Renamed Splitbark boots to Splitbark greaves as per new source.

Also added missing open parenthesis to the Splitbark legs entry in the skill guide.

Sources:
<img width="1897" height="702" alt="image" src="https://github.com/user-attachments/assets/80632c82-87a2-4e2c-9c2c-b62bc474f94b" />
<img width="524" height="91" alt="image" src="https://github.com/user-attachments/assets/57f6ffcf-7124-4295-9f14-3c05e036a31c" />
https://discord.com/channels/953326730632904844/1126857544523063367/1529974033901289555

After change: 
<img width="188" height="113" alt="image" src="https://github.com/user-attachments/assets/1e5a70bd-198d-4298-8e95-885be5a83068" />
