### PR TITLE
chore: level unlock message fixes

### DIFF
--- a/scripts/levelup/scripts/levelup_unlocks_cooking.rs2
+++ b/scripts/levelup/scripts/levelup_unlocks_cooking.rs2
@@ -2,16 +2,16 @@
 //Cooking level up unlock messages
 switch_int(stat_base(cooking)) {
     case 5 : ~objbox(herring,"You can now cook @dbl@Herring@bla@.", 250, 0, 0);
-    case 10 : ~doubleobjbox(mackerel,redberry_pie,"You can now cook @dbl@Redberry Pies@bla@. Members can cook|@dbl@Mackerel@bla@.", 200);
+    case 10 : ~doubleobjbox(mackerel,half_redberry_pie,"You can now cook @dbl@Redberry Pies@bla@. Members can cook|@dbl@Mackerel@bla@.", 200);
     case 12 : ~objbox(snail_corpse_cooked1,"Members can now cook @dbl@thin snail@bla@.", 250, 0, 0);
     case 15 : ~objbox(trout,"You can now cook @dbl@Trout@bla@.", 250, 0, 0);
     case 17 : ~objbox(snail_corpse_cooked2,"Members can now cook @dbl@lean snail@bla@.", 250, 0, 0);
     case 18 : ~objbox(cod,"Members can now cook @dbl@Cod@bla@.", 250, 0, 0);
-    case 20 : ~doubleobjbox(pike,meat_pie,"You can now cook @dbl@Meat Pies@bla@ and @dbl@Pike@bla@.", 200);
+    case 20 : ~doubleobjbox(pike,half_meat_pie,"You can now cook @dbl@Meat Pies@bla@ and @dbl@Pike@bla@.", 200);
     case 22 : ~objbox(snail_corpse_cooked3,"Members can now cook @dbl@fat snail@bla@.", 250, 0, 0);
     case 25 : ~doubleobjbox(salmon,stew,"You can now cook @dbl@Stews@bla@ and @dbl@Salmon@bla@.", 200);
     case 28 : ~objbox(mort_slimey_eel_cooked,"Members can now cook @dbl@slimey eels@bla@.", 250, 0, 0);
-    case 30 : ~doubleobjbox(tuna,apple_pie,"You can now cook @dbl@Apple Pies@bla@ and @dbl@Tuna@bla@.", 200);
+    case 30 : ~doubleobjbox(tuna,half_apple_pie,"You can now cook @dbl@Apple Pies@bla@ and @dbl@Tuna@bla@.", 200);
     case 32 : ~objbox(chefs_hat,"You are now qualified to enter the prestigious @dbl@Chefs'|Guild@bla@.", 250, 0, 0);
     case 35 : ~doubleobjbox(plain_pizza,jug_wine,"You can now cook @dbl@Pizzas@bla@ and @dbl@Wine@bla@.", 200);
     case 40 : ~doubleobjbox(lobster,cake,"You can now cook @dbl@Cakes@bla@ and @dbl@Lobsters@bla@.", 200);

--- a/scripts/levelup/scripts/levelup_unlocks_cooking.rs2
+++ b/scripts/levelup/scripts/levelup_unlocks_cooking.rs2
@@ -2,16 +2,16 @@
 //Cooking level up unlock messages
 switch_int(stat_base(cooking)) {
     case 5 : ~objbox(herring,"You can now cook @dbl@Herring@bla@.", 250, 0, 0);
-    case 10 : ~doubleobjbox(mackerel,half_redberry_pie,"You can now cook @dbl@Redberry Pies@bla@. Members can cook|@dbl@Mackerel@bla@.", 200);
+    case 10 : ~doubleobjbox(mackerel,half_a_redberry_pie,"You can now cook @dbl@Redberry Pies@bla@. Members can cook|@dbl@Mackerel@bla@.", 200);
     case 12 : ~objbox(snail_corpse_cooked1,"Members can now cook @dbl@thin snail@bla@.", 250, 0, 0);
     case 15 : ~objbox(trout,"You can now cook @dbl@Trout@bla@.", 250, 0, 0);
     case 17 : ~objbox(snail_corpse_cooked2,"Members can now cook @dbl@lean snail@bla@.", 250, 0, 0);
     case 18 : ~objbox(cod,"Members can now cook @dbl@Cod@bla@.", 250, 0, 0);
-    case 20 : ~doubleobjbox(pike,half_meat_pie,"You can now cook @dbl@Meat Pies@bla@ and @dbl@Pike@bla@.", 200);
+    case 20 : ~doubleobjbox(pike,half_a_meat_pie,"You can now cook @dbl@Meat Pies@bla@ and @dbl@Pike@bla@.", 200);
     case 22 : ~objbox(snail_corpse_cooked3,"Members can now cook @dbl@fat snail@bla@.", 250, 0, 0);
     case 25 : ~doubleobjbox(salmon,stew,"You can now cook @dbl@Stews@bla@ and @dbl@Salmon@bla@.", 200);
     case 28 : ~objbox(mort_slimey_eel_cooked,"Members can now cook @dbl@slimey eels@bla@.", 250, 0, 0);
-    case 30 : ~doubleobjbox(tuna,half_apple_pie,"You can now cook @dbl@Apple Pies@bla@ and @dbl@Tuna@bla@.", 200);
+    case 30 : ~doubleobjbox(tuna,half_an_apple_pie,"You can now cook @dbl@Apple Pies@bla@ and @dbl@Tuna@bla@.", 200);
     case 32 : ~objbox(chefs_hat,"You are now qualified to enter the prestigious @dbl@Chefs'|Guild@bla@.", 250, 0, 0);
     case 35 : ~doubleobjbox(plain_pizza,jug_wine,"You can now cook @dbl@Pizzas@bla@ and @dbl@Wine@bla@.", 200);
     case 40 : ~doubleobjbox(lobster,cake,"You can now cook @dbl@Cakes@bla@ and @dbl@Lobsters@bla@.", 200);

--- a/scripts/levelup/scripts/levelup_unlocks_fletching.rs2
+++ b/scripts/levelup/scripts/levelup_unlocks_fletching.rs2
@@ -5,19 +5,24 @@ switch_int(stat_base(fletching)) {
     case 10 : ~objbox(longbow,"You can now make @dbl@Longbows.", 250, 0, 0);
     case 15 : ~objbox(iron_arrow_5,"You can now make @dbl@Iron Arrows.", 250, 0, 0);
     case 20 : ~objbox(oak_shortbow,"You can now make @dbl@Oak Shortbows.", 250, 0, 0);
+    case 22 : ~objbox(iron_dart,"You can now make @dbl@Iron Darts.", 250, 0, 0);
     case 25 : 
         ~objbox(oak_longbow,"You can now make @dbl@Oak Longbows.", 250, 0, 0);
         ~mesbox("@dbl@~ This is one of the requirements of the @dre@FREMENNIK TRIALS@dbl@. @dbl@~");
     case 30 : ~objbox(steel_arrow_5,"You can now make @dbl@Steel Arrows.", 250, 0, 0);
     case 35 : ~objbox(willow_shortbow,"You can now make @dbl@Willow Shortbows.", 250, 0, 0);
+    case 37 : ~objbox(steel_dart,"You can now make @dbl@Steel Darts.", 250, 0, 0);
     case 40 : ~objbox(willow_longbow,"You can now make @dbl@Willow Longbows.", 250, 0, 0);
     case 45 : ~objbox(mithril_arrow_5,"You can now make @dbl@Mithril Arrows.", 250, 0, 0);
     case 50 : ~objbox(maple_shortbow,"You can now make @dbl@Maple Shortbows.", 250, 0, 0);
+    case 52 : ~objbox(mithril_dart,"You can now make @dbl@Mithril Darts.", 250, 0, 0);
     case 55 : ~objbox(maple_longbow,"You can now make @dbl@Maple Longbows.", 250, 0, 0);
     case 60 : ~objbox(adamant_arrow_5,"You can now make @dbl@Adamant Arrows.", 250, 0, 0);
     case 65 : ~objbox(yew_shortbow,"You can now make @dbl@Yew Shortbows.", 250, 0, 0);
+    case 67 : ~objbox(adamant_dart,"You can now make @dbl@Adamant Darts.", 250, 0, 0);
     case 70 : ~objbox(yew_longbow,"You can now make @dbl@Yew Longbows.", 250, 0, 0); //imgur.com/3Er8U3m
     case 75 : ~objbox(rune_arrow_5,"You can now make @dbl@Rune Arrows.", 250, 0, 0);
     case 80 : ~objbox(magic_shortbow,"You can now make @dbl@Magic Shortbows.", 250, 0, 0);
+    case 81 : ~objbox(rune_dart,"You can now make @dbl@Rune Darts.", 250, 0, 0);
     case 85 : ~objbox(magic_longbow,"You can now make @dbl@Magic Longbows.", 250, 0, 0);
 }

--- a/scripts/levelup/scripts/levelup_unlocks_herblore.rs2
+++ b/scripts/levelup/scripts/levelup_unlocks_herblore.rs2
@@ -29,5 +29,5 @@ switch_int(stat_base(herblore)) {
     case 72 : ~objbox(3doserangerspotion,"You can now make @dbl@Ranging Potions@bla@.", 250, 0, ^objbox_height);
     case 75 : ~objbox(torstol,"You can now identify @dbl@Torstol@bla@.", 250, 0, 0);
     case 76 : ~objbox(3dose1magic,"You can now make @dbl@Magic Potions@bla@.", 250, 0, ^objbox_height);
-    case 78 : ~objbox(3dosepotionofzamorak,"You can now make @dbl@Zamorak Brews@bla@.", 250, 0, ^objbox_height);
+    case 78 : ~objbox(3dosepotionofzamorak,"You can now make @dbl@Zamorak Potions@bla@.", 250, 0, ^objbox_height);
 }

--- a/scripts/levelup/scripts/levelup_unlocks_smithing.rs2
+++ b/scripts/levelup/scripts/levelup_unlocks_smithing.rs2
@@ -12,6 +12,7 @@ switch_int(stat_base(smithing)) {
     case 10 : ~objbox(bronze_battleaxe,"You can now make @dbl@Bronze Battle Axes.", 250, 0, 0);
     case 11 : ~objbox(bronze_chainbody,"You can now make @dbl@Bronze Chainmail Bodies.", 250, 0, 0);
     case 12 : ~objbox(bronze_kiteshield,"You can now make @dbl@Bronze Kite Shields.", 250, 0, 0);
+    case 13 : ~objbox(bronze_claws,"You can now make @dbl@Bronze claws.", 250, 0, 0);
     case 14 : ~objbox(bronze_2h_sword,"You can now make @dbl@Bronze Two Handed Swords.", 250, 0, 0);
     case 15 : ~objbox(iron_dagger,"You can now make @dbl@Iron Daggers.", 250, 0, 0);
     case 16 : ~doubleobjbox(bronze_platelegs,iron_axe,"You can now make @dbl@Bronze Plate Legs@bla@, @dbl@Bronze plate|skirts@bla@ and @dbl@Iron Axes.", 200); // https://i.imgur.com/qMAZcT9.png
@@ -26,6 +27,7 @@ switch_int(stat_base(smithing)) {
     case 25 : ~objbox(iron_battleaxe,"You can now make @dbl@Iron Battleaxes.", 250, 0, 0);
     case 26 : ~objbox(iron_chainbody,"You can now make @dbl@Iron Chainmail Bodies.", 250, 0, 0);
     case 27 : ~objbox(iron_kiteshield,"You can now make @dbl@Iron Kite Shields.", 250, 0, 0);
+    case 28 : ~objbox(iron_claws,"You can now make @dbl@Iron claws.", 250, 0, 0);
     case 29 : ~objbox(iron_2h_sword,"You can now make @dbl@Iron Two Handed Swords.", 250, 0, 0);
     case 30 : ~objbox(steel_dagger,"You can now make @dbl@Steel Daggers.", 250, 0, 0);
     case 31 : ~doubleobjbox(iron_platelegs,steel_axe,"You can now make @dbl@Iron Plate Legs@bla@, @dbl@Iron plate skirts|@bla@and @dbl@Steel Axes.", 200); // https://i.imgur.com/H2sx0gZ.png
@@ -40,6 +42,7 @@ switch_int(stat_base(smithing)) {
     case 40 : ~doubleobjbox(gold_ore,steel_battleaxe,"You can now smelt @dbl@Gold Ore@bla@ and make @dbl@Steel|Battleaxes.", 200);
     case 41 : ~objbox(steel_chainbody,"You can now make @dbl@Steel Chainmail Bodies.", 250, 0, 0);
     case 42 : ~objbox(steel_kiteshield,"You can now make @dbl@Steel Kite Shields.", 250, 0, 0);
+    case 43 : ~objbox(steel_claws,"You can now make @dbl@Steel claws.", 250, 0, 0);
     case 44 : ~objbox(steel_2h_sword,"You can now make @dbl@Steel Two Handed Swords.", 250, 0, 0);
     case 46 : ~doubleobjbox(steel_platelegs,steel_plateskirt,"You can now make @dbl@Steel Plate Legs@bla@ and @dbl@Steel|plate skirts.", 200);
     case 48 : ~objbox(steel_platebody,"You can now make @dbl@Steel Plate Bodies.", 250, 0, 0);
@@ -56,6 +59,7 @@ switch_int(stat_base(smithing)) {
     case 60 : ~objbox(mithril_battleaxe,"You can now make @dbl@Mithril Battleaxes.", 250, 0, 0);
     case 61 : ~objbox(mithril_chainbody,"You can now make @dbl@Mithril Chainmail Bodies.", 250, 0, 0); //imgur.com/J7orCyb
     case 62 : ~objbox(mithril_kiteshield,"You can now make @dbl@Mithril Kite Shields.", 250, 0, 0); //imgur.com/2mwJUWO
+    case 63 : ~objbox(mithril_claws,"You can now make @dbl@Mithril claws.", 250, 0, 0);
     case 64 : ~objbox(mithril_2h_sword,"You can now make @dbl@Mithril Two Handed Swords.", 250, 0, 0); //imgur.com/qMcRqiu
     case 66 : ~doubleobjbox(mithril_platelegs,mithril_plateskirt,"You can now make @dbl@Mithril Plate Legs@bla@ and @dbl@Mithril|plate skirts.", 200); // https://i.imgur.com/UjfgamE.png
     case 68 : ~objbox(mithril_platebody,"You can now make @dbl@Mithril Plate Bodies.", 250, 0, 0);
@@ -72,6 +76,7 @@ switch_int(stat_base(smithing)) {
     case 80 : ~objbox(adamant_battleaxe,"You can now make @dbl@Adamant Battleaxes.", 250, 0, 0);
     case 81 : ~objbox(adamant_chainbody,"You can now make @dbl@Adamant Chainmail Bodies.", 250, 0, 0);
     case 82 : ~objbox(adamant_kiteshield,"You can now make @dbl@Adamant Kite Shields.", 250, 0, 0);
+    case 83 : ~objbox(adamant_claws,"You can now make @dbl@Adamant claws.", 250, 0, 0);
     case 84 : ~objbox(adamant_2h_sword,"You can now make @dbl@Adamant Two Handed Swords.", 250, 0, 0);
     case 85 : ~objbox(rune_dagger,"You can now make @dbl@Rune Daggers.", 250, 0, 0);
     case 86 : ~doubleobjbox(adamant_platelegs,adamant_plateskirt,"You can now make @dbl@Adamant Plate Legs@bla@, @dbl@Adamant|plate skirts@bla@ and @dbl@Rune Axes.", 200);
@@ -86,5 +91,6 @@ switch_int(stat_base(smithing)) {
     case 95 : ~objbox(rune_battleaxe,"You can now make @dbl@Rune Battleaxes.", 250, 0, 0);
     case 96 : ~objbox(rune_chainbody,"You can now make @dbl@Rune Chainmail Bodies.", 250, 0, 0);
     case 97 : ~objbox(rune_kiteshield,"You can now make @dbl@Rune Kite Shields.", 250, 0, 0);
+    case 98 : ~objbox(rune_claws,"You can now make @dbl@Rune claws.", 250, 0, 0);
     case 99 : ~doubleobjbox(rune_2h_sword,rune_platebody,"You can now make @dbl@Rune Two Handed Swords@bla@, @dbl@Plate|Legs@bla@, @dbl@plate skirts@bla@, and @dbl@Plate Bodies.", 200); // https://i.imgur.com/ooGMh4g.png
 }


### PR DESCRIPTION
*bronze- rune claws added to unlock messages.
*Fixed incorrect objbox displayed in pies unlock messages. 
*iron - rune darts added to unlock messages.
*Zamorak brew name changed in zamorak potion unlock messages. because the item name was renamed on 24 October 2005.