### PR TITLE
fix: Dragon spear spec: add a third knockback fallback tile

### DIFF
--- a/scripts/skill_combat/scripts/player/specs/scripts/pvm_dragon_spear.rs2
+++ b/scripts/skill_combat/scripts/player/specs/scripts/pvm_dragon_spear.rs2
@@ -36,21 +36,33 @@ switch_int ($dir) {
         $end_coord = movecoord($target_coord, -1, 0, -1);
         if (lineofwalk($target_coord, $end_coord) = false) {
             $end_coord = movecoord($target_coord, -1, 0, 0);
+            if (lineofwalk($target_coord, $end_coord) = false) {
+                $end_coord = movecoord($target_coord, -1, 0, 1);
+            }
         }
     case ^exact_east : 
         $end_coord = movecoord($target_coord, 1, 0, 1);
         if (lineofwalk($target_coord, $end_coord) = false) {
             $end_coord = movecoord($target_coord, 1, 0, 0);
+            if (lineofwalk($target_coord, $end_coord) = false) {
+                $end_coord = movecoord($target_coord, 1, 0, -1);
+            }
         }
     case ^exact_north : 
         $end_coord = movecoord($target_coord, -1, 0, 1);
         if (lineofwalk($target_coord, $end_coord) = false) {
             $end_coord = movecoord($target_coord, 0, 0, 1);
+            if (lineofwalk($target_coord, $end_coord) = false) {
+                $end_coord = movecoord($target_coord, 1, 0, 1);
+            }
         }
     case ^exact_south : 
         $end_coord = movecoord($target_coord, 1, 0, -1);
         if (lineofwalk($target_coord, $end_coord) = false) {
             $end_coord = movecoord($target_coord, 0, 0, -1);
+            if (lineofwalk($target_coord, $end_coord) = false) {
+                $end_coord = movecoord($target_coord, -1, 0, -1);
+            }
         }
 }
 if (lineofwalk($target_coord, $end_coord) = true) {


### PR DESCRIPTION
Previously each direction tried only the leading diagonal then the straight tile; if both were blocked, the knockback was dropped. Fall back to the trailing diagonal as a third option before giving up (e.g. pushed east: north-east -> east -> south-east).

(should apply to all revisions)

Example from osrs:

https://github.com/user-attachments/assets/b8fd1ef4-a151-41dc-870f-e0a9dc92f112

