### PR TITLE
fix: fixes to dummy scripts (225+)

### DIFF
--- a/scripts/areas/area_combat_training/scripts/combat_training_camp.rs2
+++ b/scripts/areas/area_combat_training/scripts/combat_training_camp.rs2
@@ -43,21 +43,20 @@ if(%biohazard < ^biohazard_complete) {
 ~open_and_close_double_door2(~check_axis(coord, loc_coord, loc_angle), $side, grate_open);
 
 [oploc1,biohazarddummy] // Combat training camp dummy
-if (%damagestyle = ^style_ranged_accurate | %damagestyle = ^style_ranged_longrange | %damagestyle = ^style_ranged_rapid) {
+if (%damagetype = ^ranged_style | ~player_autocast_enabled = true) {
     mes("You can't use ranged attacks on the dummy.");
     return;
 }
-if (%biodummy < 6) {
-    %biodummy = add(%biodummy, 1);
-    stat_advance(attack, 500);
-} else {
+if(%biodummy > 5) {
     mes("There's no more to learn from hitting this dummy.");
     return;
 }
+%biodummy = add(%biodummy, 1);
+stat_advance(attack, 500);
 anim(%com_attackanim, 0);
 sound_synth(%com_attacksound, 1, 0);
 mes("You hit the dummy.");
-p_delay(3);
+p_delay(2);
 
 [opnpc2,lathastrainingogre]
 if (~player_in_combat_check = false) {

--- a/scripts/areas/area_varrock/scripts/attack_dummy.rs2
+++ b/scripts/areas/area_varrock/scripts/attack_dummy.rs2
@@ -1,15 +1,14 @@
 [oploc2,sworddummy]
-if (%damagestyle = ^style_ranged_accurate | %damagestyle = ^style_ranged_longrange | %damagestyle = ^style_ranged_rapid) {
+if (%damagetype = ^ranged_style | ~player_autocast_enabled = true) {
     mes("You can't use ranged attacks on the dummy.");
     return;
 }
+mes("You swing at the dummy...");
+if (stat_base(attack) > 7) {
+    mes("There is nothing more you can learn from hitting a dummy.");
+    return;
+}
+mes("You hit the dummy. <tostring(map_clock)>");
 anim(%com_attackanim, 0);
 sound_synth(%com_attacksound, 1, 0);
-mes("You hit the dummy.");
-p_delay(0);
-if (stat_base(attack) < 8) {
-    stat_advance(attack, 50);
-} else {
-    mes("There is nothing more you can learn from hitting a dummy.");
-}
-p_delay(0);
+p_delay(4);

--- a/scripts/areas/area_varrock/scripts/attack_dummy.rs2
+++ b/scripts/areas/area_varrock/scripts/attack_dummy.rs2
@@ -8,7 +8,7 @@ if (stat_base(attack) > 7) {
     mes("There is nothing more you can learn from hitting a dummy.");
     return;
 }
-mes("You hit the dummy. <tostring(map_clock)>");
+mes("You hit the dummy.");
 anim(%com_attackanim, 0);
 sound_synth(%com_attacksound, 1, 0);
 p_delay(4);


### PR DESCRIPTION
- correct messages for sworddummy (https://www.youtube.com/watch?v=aRyH1k9Z71w same as osrs)
- correct checks: can't attack dummy while on autocast, check attack level before animations/delay
- fix delay on dummies: biohazard dummy should have a 3t delay at end instead of 4t, sworddummy should have a 5t delay at end instead of 1t between messages