### PR TITLE
fix: Strikeout Nature Spirit quest req. on In Search of the Myreque quest journal

### DIFF
--- a/scripts/quests/quest_routequest/scripts/routequest_journal.rs2
+++ b/scripts/quests/quest_routequest/scripts/routequest_journal.rs2
@@ -16,7 +16,11 @@ if(%routequest = ^routequest_complete) {
 if(%routequest = ^routequest_not_started) {
     $text = "@dbl@I can start this quest by talking to a @dre@stranger@dbl@ in the '@dre@Hair|@dre@ of the Dog Inn@dbl@' located in the town of @dre@Canifis@dbl@ in the land of|@dre@Morytania@dbl@.";
     $text = append($text, "||@dbl@I need to complete the following quest:-"); // not a typo, source 2009 GoingCrazy201 video.
-    $text = append($text, "|@dre@Nature Spirit");
+    if (%druidspirit < ^druidspirit_complete) { // https://youtu.be/pNz0_8VjqPc?si=FNBsiGfffAnyVwu1&t=5
+        $text = append($text, "|@dre@Nature Spirit");
+    } else {
+        $text = append($text, "|@str@Nature Spirit");
+    }
     $text = append($text, "|@dbl@I also need to be able to defeat a level 97 foe.");
 } else {
     $text = "@str@I talked to a stranger called Vanstrom Klause in the 'Hair of|@str@the Dog Inn' located in the town of Canifis.";


### PR DESCRIPTION
Strike out the quest requirement if Nature Spirit is completed - previously it would still show up as a red quest requirement for In Search of the Myreque.

**Before:**
<img width="527" height="347" alt="image" src="https://github.com/user-attachments/assets/a3418ddd-535b-4134-bcdf-ef64d14432ab" />


**After:**
<img width="524" height="346" alt="image" src="https://github.com/user-attachments/assets/ff26f6ef-b45c-4d51-be95-9d5fb5ad4236" />

**Source used:** https://youtu.be/pNz0_8VjqPc?si=FNBsiGfffAnyVwu1&t=5