### PR TITLE
fix: Allow combat with Troll Spectators, instead of Dad! (254+)

### DIFF
--- a/scripts/quests/quest_troll/scripts/troll_spectator.rs2
+++ b/scripts/quests/quest_troll/scripts/troll_spectator.rs2
@@ -14,9 +14,9 @@ if(~troll_spectator_can_attack = false) {
 
 [proc,troll_spectator_can_attack]()(boolean)
 npc_huntall(coord, 24, 0);
-while (npc_findnext = true) {
-    if(npc_type = troll_champion) {
-        if((npc_getmode = opplayer2 | npc_getmode = applayer2) & %npc_aggressive_player = uid) {
+while (.npc_findnext = true) {
+    if(.npc_type = troll_champion) {
+        if((.npc_getmode = opplayer2 | .npc_getmode = applayer2) & .%npc_aggressive_player = uid) {
             mes("I'm already under attack"); // no period
             return (false);
         }


### PR DESCRIPTION
pleae
Stop killing Dad!

Previously, if you attacked a Troll Spectator in the Death Plateau arena, your character would enter combat with Dad instead.

**For 254+**