### PR TITLE
fix: Hickton dialogue, Slimey eel msg, Shilo cart msg, Big Net msg, Lobster msg

### DIFF
--- a/scripts/areas/area_catherby/scripts/hickton.rs2
+++ b/scripts/areas/area_catherby/scripts/hickton.rs2
@@ -1,8 +1,8 @@
 [opnpc1,hickton]
 ~chatnpc("<p,neutral>Welcome to Hickton's Archery Store.|Do you want to see my wares?");
-def_int $option = ~p_choice2("Yes, please.", 1, "No, I prefer to bash things close up.", 2);
+def_int $option = ~p_choice2("Yes please.", 1, "No, I prefer to bash things close up.", 2); // https://youtu.be/aZIVR-1dAzg?si=X41w_H8N2vfQg8sB&t=108
 if($option = 1) {
-    ~chatplayer("<p,neutral>Yes, please.");
+    ~chatplayer("<p,neutral>Yes please.");
     ~openshop_activenpc;
 } else if($option = 2) {
     ~chatplayer("<p,neutral>No, I prefer to bash things close up.");

--- a/scripts/levelup/scripts/levelup_unlocks_fishing.rs2
+++ b/scripts/levelup/scripts/levelup_unlocks_fishing.rs2
@@ -8,7 +8,7 @@ switch_int(stat_base(fishing)) {
     case 20 : ~doubleobjbox(raw_trout,fly_fishing_rod,"You can now try fly fishing for @dbl@Trout.", 200);
     case 23 : ~doubleobjbox(raw_cod,net,"Members can now try fishing for @dbl@Cod with a large net.", 200);
     case 25 : ~doubleobjbox(raw_pike,fishing_rod,"You can now try fishing for @dbl@Pike.", 200);
-    case 28 : ~doubleobjbox(mort_slimey_eel,fishing_rod,"Members can now try fishing for @dbl@slimey eels.", 200);
+    case 28 : ~doubleobjbox(mort_slimey_eel,fishing_rod,"Members can now try fishing for @dbl@slimey eel.", 200); // https://www.youtube.com/watch?t=678&v=thHuATlGYag
     case 30 : ~doubleobjbox(raw_salmon,fly_fishing_rod,"You can now try fly fishing for @dbl@Salmon.", 200);
     case 35 : ~doubleobjbox(raw_tuna,harpoon,"You can now try harpooning @dbl@Tuna.", 200);
     case 40 : ~doubleobjbox(raw_lobster,lobster_pot,"You can now try to catch @dbl@Lobsters.", 200);

--- a/scripts/quests/quest_zombiequeen/scripts/quest_zombiequeen.rs2
+++ b/scripts/quests/quest_zombiequeen/scripts/quest_zombiequeen.rs2
@@ -3,7 +3,9 @@
 
 [oploc2,shilo_brokencart]
 if(coordx(coord) <= coordx(loc_coord)) {
+    mes("You climb up onto the cart."); // https://youtu.be/mxX7rB1PnEM?si=XKr8CZwpZT0GPPUu&t=47 
     mes("You nimbly jump from one side of the cart...");
+    p_delay(1);
     mes("...to the other and climb down again.");
     p_telejump(movecoord(loc_coord, 3, 0, 1));
     return;
@@ -16,8 +18,8 @@ if(npc_find(coord, mosol_rei, 8, 0) = true) {
 ~mesbox("It looks as if you can climb across the cart. Would you like to try?");
 switch_int(~p_choice2("Yes, I am very nimble and agile!", 1, "No, I am happy where I am thanks!", 2)) {
     case 1 :
-        mes("You nimbly jump from one side of the cart...");
-        mes("...to the other and climb down again.");
+        mes("You search the cart."); // https://i.imgur.com/ZCWLdBC.png
+        mes("You attempt to climb up onto the cart...");
         p_telejump(movecoord(loc_coord, -1, 0, 1));
     case 2 :
         if_close;

--- a/scripts/skill_fishing/configs/fishing_equipment.struct
+++ b/scripts/skill_fishing/configs/fishing_equipment.struct
@@ -7,7 +7,8 @@ param=fish_equipment_failmessage,You need a net to catch these fish.
 param=fish_wrong_spot_message,There is nothing suitable for catching with a net here.
 
 [fish_equipment_big_net]
-param=fish_equipment_failmessage,You need a big net to catch these fish.
+// https://youtu.be/RDx7HdaJkMo?si=Bs4xjx468SMP6LDV&t=341
+param=fish_equipment_failmessage,You need a Big Net to catch these fish. 
 param=fish_wrong_spot_message,There is nothing suitable for catching with a net here.
 
 [fish_equipment_fishing_rod]

--- a/scripts/skill_fishing/scripts/fishing_spots/rarefish.rs2
+++ b/scripts/skill_fishing/scripts/fishing_spots/rarefish.rs2
@@ -33,7 +33,7 @@ if (~check_fish_equipment(lobster_pot) = false) {
 // check if inv is full
 if (inv_freespace(inv) < 1) {
     anim(null, 0);
-    ~mesbox("You can't carry any more lobsters.");
+    ~mesbox("You can't carry any more Lobsters."); // https://www.youtube.com/watch?t=436&v=RDx7HdaJkMo
     return;
 }
 if (%action_delay < map_clock) {
@@ -69,7 +69,7 @@ if (~check_fish_equipment(lobster_pot) = false) {
 // check if inv is full again
 if (inv_freespace(inv) < 1) {
     anim(null, 0);
-    ~mesbox("You can't carry any more lobsters.");
+    ~mesbox("You can't carry any more Lobsters."); // https://www.youtube.com/watch?t=436&v=RDx7HdaJkMo
     return;
 }
 if (%action_delay < map_clock) {


### PR DESCRIPTION
<img width="1153" height="746" alt="image" src="https://github.com/user-attachments/assets/4abbf7e9-8d9f-4aed-9099-dfb718a3825b" />
225+

* Changed Hickton dialogue based on 2006 source
<img width="1130" height="742" alt="image" src="https://github.com/user-attachments/assets/7a758ae2-d5cf-4ddd-bd27-d282a34f1dee" />
274+ 

* Changed 28 fishing message based on 2007 source
<img width="992" height="745" alt="image" src="https://github.com/user-attachments/assets/5ee467be-c41e-4e95-8db1-ef3238f6d0fa" />
<img width="597" height="393" alt="image" src="https://github.com/user-attachments/assets/5c01de9a-69dc-45cd-ae7c-233331292704" />

225+

* Changed Shilo cart (south-east entrance) messages (going in & going out) based on 2007 sources
* Added correct delay in Shilo cart message
<img width="992" height="746" alt="image" src="https://github.com/user-attachments/assets/e6a0a16d-07f6-4842-bb4c-0c08bba04db4" />
225+

* Changed Big Net message based on 2006 source
<img width="996" height="743" alt="image" src="https://github.com/user-attachments/assets/bdaa12fc-29d7-4e7d-b7e5-4a14981d9ad0" />
225+

* Changed Lobster message based on 2006 source 


