### PR TITLE
fix: stop characters logging in & teleporting to Castle Wars inadvertently

### DIFF
--- a/scripts/minigames/game_castlewars/scripts/castlewars.rs2
+++ b/scripts/minigames/game_castlewars/scripts/castlewars.rs2
@@ -264,6 +264,7 @@ if (~in_castlewars_waitingroom(coord) = true) {
 if (inzone(0_37_148_0_0, 0_37_148_63_63, $coord) = true) {
     return(true);
 }
+return(false);
 
 [proc,in_castlewars_waitingroom](coord $coord)(boolean)
 if (inzone(0_37_148_0_0, 0_37_148_25_25, $coord) = true | inzone(0_37_148_40_40, 0_37_148_63_63, $coord) = true) {


### PR DESCRIPTION
Prior to this fix, sometimes when you login your character was teleported into a Castle Wars waiting room.
This prevents that.