### PR TITLE
feat: added castlewars manual

### DIFF
--- a/scripts/general/scripts/book.rs2
+++ b/scripts/general/scripts/book.rs2
@@ -24,6 +24,7 @@ switch_obj (%open_book) {
     case horror_diary1 : @book_flip_page(^book_direction_backward, 0, 13, horror_diary1);
     case horror_diary2 : @book_flip_page(^book_direction_backward, 0, 13, horror_diary2);
     case horror_diary3 : @book_flip_page(^book_direction_backward, 0, 10, horror_diary3);
+    case castlewars_manual : @book_flip_page(^book_direction_backward, 0, 9, castlewars_manual);
 }
 p_delay(0);
 
@@ -50,6 +51,7 @@ switch_obj (%open_book) {
     case horror_diary1 : @book_flip_page(^book_direction_forward, 0, 13, horror_diary1);
     case horror_diary2 : @book_flip_page(^book_direction_forward, 0, 13, horror_diary2);
     case horror_diary3 : @book_flip_page(^book_direction_forward, 0, 10, horror_diary3);
+    case castlewars_manual : @book_flip_page(^book_direction_forward, 0, 9, castlewars_manual);
 }
 p_delay(0);
 

--- a/scripts/minigames/game_castlewars/scripts/castlewars_manual.rs2
+++ b/scripts/minigames/game_castlewars/scripts/castlewars_manual.rs2
@@ -1,0 +1,22 @@
+[opheld1,castlewars_manual]
+%book_page = 0;
+%open_book = castlewars_manual;
+@open_castlewars_manual;
+
+[label,open_castlewars_manual]
+@book_flip_page(0, 0, 9, castlewars_manual);
+
+[proc,castlewars_manual]
+switch_int (%book_page) {
+    case 0 : ~book("Castle Wars Manual", "Objective:|The aim is to get into your opponents castle and take their team standard. Then bring that back and capture it on your teams standard.");
+    case 1 : ~book_obj("Castle Wars Manual", book:page_left_model_3, castlewars_toolkit, 200, "||||Toolkit:|This useful item allows you to repair broken doors and catapults. Simply use it on the item to be repaired, or have one in your inventory when you select the option, and you'll rebuild it!");
+    case 2 : ~book_obj("Castle Wars Manual", book:page_left_model_2, castlewars_bandages, 200, "||||Bandages:|These can be used to heal some health and restore some of your running energy. You can also use them to heal fellow players.");
+    case 3 : ~book_obj("Castle Wars Manual", book:page_left_model_4, castlewars_explosives_potion, 200, "|||||Explosive Potion:|A simple but effective item, use it to blow up your opponents catapult and barricades! It can also be used to clear the tunnels under the arena for a sneak attack into your opponents castle. Don't forget to collapse the tunnels into your own castle though!");
+    case 4 : ~book_obj("Castle Wars Manual", book:page_left_model_4, castlewars_barricade, 200, "|||||Barricade:|Use these constructs to block your opponents movement and prevent them accessing your castle. Each team can only have 10 built at any time.");
+    case 5 : ~book_obj("Castle Wars Manual", book:page_left_model_3, bucket_water, 200, "||||Bucket:|Fill a bucket with water and you can use it to put out a burning catapult or barricade, but be quick or it'll be destroyed.");
+    case 6 : ~book_obj("Castle Wars Manual", book:page_left_model_3, tinderbox, 200, "||||Tinderbox:|Logs aren't all that's flammable, use a tinderbox to set light to your opponents catapult and barricades.");
+    case 7 : ~book_obj("Castle Wars Manual", book:page_left_model_3, bronze_pickaxe, 200, "|||||Pickaxe:|Use a pickaxe to mine your way through the tunnels under the arena for a sneak attack into your opponents castle. Don't forget to collapse the tunnels into your own castle though!");
+    case 8 : ~book_obj("Castle Wars Manual", book:page_left_model_3, castlewars_catapult, 200, "||||Catapult:|Use this war machine to launch rocks at your opponents. Just give it rough coordinates and let the rock fly, just be careful not to hit your team with it!");
+    case 9 : ~book_obj("Castle Wars Manual", book:page_left_model_4, castlewars_catapult_rock, 200, "|||||Rock:|Used as ammo for the catapult, and not much else. Brings new meaning to the phrase 'flies like a rock'.");
+}
+


### PR DESCRIPTION
huge thanks to @Indio3's guidance overall and work in #712, ended a lot of the learning curve headache with the book interfaces and components and made this task really simple.

historical accuracy is a bit "educated guess" with this one, but he and I decided to leave one page spread for each entry in the book. we couldn't find any screenshots or videos of the actual castlewars manual dating back to the end of 04 - beginning of 05 time period. we do however have a source for the text itself located below (thanks @thesuddensilent!):

https://discord.com/channels/953326730632904844/1126857544523063367/1533302966013132901

<img width="608" height="1090" alt="image" src="https://github.com/user-attachments/assets/2d537e47-b921-4ad1-96df-b3397da13c0b" />

the 04-05 book interfaces combined with text + object models just doesn't seem possible to line up with whats in OSRS, and Indio confirmed with rsprox that OSRS is using an `indexed_book` interface separate from the old book or inter_167 interfaces, most likely to achieve the layout below:

https://oldschool.runescape.wiki/w/Castlewars_manual#Gallery

same layout attempted in 04:

<img width="503" height="322" alt="image" src="https://github.com/user-attachments/assets/f5357d54-8475-4e2d-9b52-8976432255f4" />