### PR TITLE
fix: Regression caused bananas to become inedible

### DIFF
--- a/scripts/player/configs/consumption/consume_messages.dbrow
+++ b/scripts/player/configs/consumption/consume_messages.dbrow
@@ -1,3 +1,8 @@
+[banana_consume_messages]
+table=consume_messages_table
+data=consumable,banana
+data=consume_message1,You eat the banana.
+
 [cabbage_consume_messages]
 table=consume_messages_table
 data=consumable,cabbage

--- a/scripts/player/scripts/consumption/consume.rs2
+++ b/scripts/player/scripts/consumption/consume.rs2
@@ -5,6 +5,7 @@
 [opheld1,_category_59] @player_consume_item(consume_effect_stat, 2, 3);
 [opheld1,_category_86] @player_consume_item(consume_effect_stat, 2, 3);
 [opheld1,tbwt_sliced_banana] @player_consume_item(consume_effect_stat, 2, 3);
+[opheld1,banana] @player_consume_item(consume_effect_stat, 2, 3);
 [opheld1,rottenapples] ~displaymessage(^dm_default);
 [opheld1,_category_120] @player_consume_item(consume_effect_stat, 2, 3);
 [opheld1,_category_131] @player_consume_item(consume_effect_stat, 2, 3);


### PR DESCRIPTION
In revision 274 attempting to eat a banana would do nothing. In development mode the error: "No trigger for [opheld1,banana]." would present. Attempted to provide a fix based on the work already done for some other food items.