### PR TITLE
fix: Herblore potion messages

### DIFF
--- a/scripts/skill_herblore/configs/brewing/brew_potion.struct
+++ b/scripts/skill_herblore/configs/brewing/brew_potion.struct
@@ -253,7 +253,7 @@ param=brew_potion_ingredient,red_spiders_eggs
 param=brew_potion_solvent,snapdragonvial
 param=brew_potion_exp,1425
 param=brew_potion_level,63
-// https://www.youtube.com/watch?v=mJiNVCot3dQ
+// https://i.imgur.com/tKXYMFa.png
 param=brew_potion_message,You mix the eggs into your potion.
 param=brew_potion_mixture,3dose2restore
 

--- a/scripts/skill_herblore/configs/brewing/brew_potion.struct
+++ b/scripts/skill_herblore/configs/brewing/brew_potion.struct
@@ -101,7 +101,8 @@ param=brew_potion_ingredient,red_spiders_eggs
 param=brew_potion_solvent,harralandervial
 param=brew_potion_level,22
 param=brew_potion_exp,625
-param=brew_potion_message,You mix the red spiders' eggs into your potion.
+// https://www.youtube.com/watch?v=mJiNVCot3dQ
+param=brew_potion_message,You mix the eggs into your potion.
 param=brew_potion_mixture,3dosestatrestore
 
 [3dose1strength]
@@ -141,7 +142,8 @@ param=brew_potion_ingredient,unicorn_horn_dust
 param=brew_potion_solvent,marrentillvial
 param=brew_potion_level,5
 param=brew_potion_exp,375
-param=brew_potion_message,You mix the unicorn horn dust into your potion.
+// https://www.youtube.com/watch?v=_Q4g187iU5I&t=1394s
+param=brew_potion_message,You mix the unicorn horn into your potion.
 param=brew_potion_mixture,3doseantipoison
 
 [3dose2antipoison]
@@ -149,7 +151,8 @@ param=brew_potion_ingredient,unicorn_horn_dust
 param=brew_potion_solvent,iritvial
 param=brew_potion_level,48
 param=brew_potion_exp,1063
-param=brew_potion_message,You mix the unicorn horn dust into your potion.
+// https://www.youtube.com/watch?v=_Q4g187iU5I&t=1394s
+param=brew_potion_message,You mix the unicorn horn into your potion.
 param=brew_potion_mixture,3dose2antipoison
 
 [3dose1defense]
@@ -189,7 +192,8 @@ param=brew_potion_ingredient,wine_of_zamorak
 param=brew_potion_solvent,dwarfweedvial
 param=brew_potion_level,72
 param=brew_potion_exp,1625
-param=brew_potion_message,You mix the wine of zamorak into your potion.
+// https://i.imgur.com/fmSVVIw.png
+param=brew_potion_message,You mix the wine into your potion.
 param=brew_potion_mixture,3doserangerspotion
 
 [3dosepotionofzamorak]


### PR DESCRIPTION
225+
* Changed Restore potion herblore message based on source
* Changed Antipoison herblore message based on source
* Changed Superantipoison herblore message based on source
* Changed Ranging potion herblore message based on source

254+
* Changed source to match the right potion

<img width="1025" height="798" alt="image" src="https://github.com/user-attachments/assets/6de430e0-b0b2-4f81-86de-66a86a2d4712" />
<img width="1330" height="752" alt="image" src="https://github.com/user-attachments/assets/d31b7ce7-4796-46f3-9dfb-e2367741013f" />
<img width="1097" height="813" alt="image" src="https://github.com/user-attachments/assets/ff874bae-45f6-4f46-bbc0-8aa23aa4c0d9" />
<img width="1095" height="814" alt="image" src="https://github.com/user-attachments/assets/ab166844-242e-4fa0-95f9-5ba352c8643f" />



