### PR TITLE
fix: Aemad dialogue, Bakers dialogue, Silk merchant dialogue, Mage Arena ladder, Locked gate msg

### DIFF
--- a/scripts/areas/area_ardougne_east/scripts/aemad.rs2
+++ b/scripts/areas/area_ardougne_east/scripts/aemad.rs2
@@ -2,7 +2,8 @@
 [opnpc1,kortan] @aemad_talk;
 
 [label,aemad_talk]
-~chatnpc("<p,happy>Hello there. You've come to the right place if you're looking for adventurer's equipment.");
+// https://web.archive.org/web/20071012102441im_/http://runescape.salmoneus.net/cities/images/aemadshop.gif
+~chatnpc("<p,happy>Hello you look like a bold adventurer. You've come to|the right place for adventurer's equipment.");
 def_int $option = ~p_choice2("Oh that sounds interesting.", 1, "No, I've come to the wrong place.", 2);
 if($option = 1) {
     ~chatplayer("<p,neutral>Oh that sounds interesting.");

--- a/scripts/areas/area_ardougne_east/scripts/baker.rs2
+++ b/scripts/areas/area_ardougne_east/scripts/baker.rs2
@@ -2,7 +2,8 @@
 if (getqueue(stolen_from_stall_baker) > 0) {
     @stall_owner_alert_guards;
 }
-def_string $line = text_gender("<p,happy>Good day Sir. Would you like some nice freshly baked bread?", "<p,happy>Good day Madame. Would you like some nice freshly baked bread?");
+// https://web.archive.org/web/20070328202303im_/http://runescape.salmoneus.net/cities/images/ardybakershop.gif
+def_string $line = text_gender("<p,happy>Good day Monsieur. Would you like ze nice freshly|baked bread? Or perhaps a nice piece of cake?", "<p,happy>Good day Madame. Would you like ze nice freshly|baked bread? Or perhaps a nice piece of cake?");
 ~chatnpc($line);
 def_int $option = ~p_choice2("Let's see what you have.", 1, "No thank you.", 2);
 

--- a/scripts/areas/area_ardougne_east/scripts/silk_merchant.rs2
+++ b/scripts/areas/area_ardougne_east/scripts/silk_merchant.rs2
@@ -47,7 +47,8 @@ if(inv_total(inv, silk) > 0) {
         ~chatnpc("<p,angry>Don't be ridiculous! That is far too much. You insult me with that price.");
     }
 } else {
-    ~chatnpc("<p,happy>I buy silk. If you ever want to|sell any silk, bring it here.");
+    // https://web.archive.org/web/20071012103142im_/http://runescape.salmoneus.net/cities/images/ardysilkseller.gif
+    ~chatnpc("<p,happy>I buy silk. If you get any silk to sell bring it here.");
 }
 
 [proc,silk_merchant_sell_silk](int $price)

--- a/scripts/areas/area_mage_arena/scripts/mage_arena.rs2
+++ b/scripts/areas/area_mage_arena/scripts/mage_arena.rs2
@@ -9,6 +9,7 @@ mes("You climb down the ladder.");
 [oploc1,magearena_ladder_from_cellar]
 p_arrivedelay;
 ~climb_ladder(movecoord(coord, 549, 0, -756), true);
+mes("You climb up the ladder."); // https://web.archive.org/web/20040829183021if_/http://www.iownjoo.com:80/freeimghost/ajay/rs2thedevilscry1.jpg
 
 
 [oploc1,magearena_waterportal1] @jump_in_sparkling_pool(^sparkling_pool_chamber_coord);

--- a/scripts/general_use/scripts/locked_gates.rs2
+++ b/scripts/general_use/scripts/locked_gates.rs2
@@ -1,5 +1,4 @@
 [oploc1,_locked_gate]
 p_arrivedelay;
+// https://www.youtube.com/watch?t=79&v=xQTlmBWIITk
 mes("You try to open the gate...");
-p_delay(2);
-mes("The gate is locked securely, it won't open!");

--- a/scripts/levelup/scripts/levelup_unlocks_smithing.rs2
+++ b/scripts/levelup/scripts/levelup_unlocks_smithing.rs2
@@ -50,7 +50,7 @@ switch_int(stat_base(smithing)) {
     case 51 : ~objbox(mithril_axe,"You can now make @dbl@Mithril Axes.", 250, 0, 0);
     case 52 : ~objbox(mithril_mace,"You can now make @dbl@Mithril Maces.", 250, 0, divide(^objbox_height, 2));
     case 53 : ~objbox(mithril_med_helm,"You can now make @dbl@Mithril Medium Helms.", 250, 0, divide(^objbox_height, 2));
-    case 54 : ~doubleobjbox(mithril_sword,mithril_dart,"You can now make @dbl@Mithril Short Swords@bla@ and members|can make @dbl@Mithril Dart Tips.", 200);
+    case 54 : ~doubleobjbox(mithril_sword,mithril_dart_tip,"You can now make @dbl@Mithril Short Swords@bla@ and members|can make @dbl@Mithril Dart Tips.", 200);
     case 55 : ~doubleobjbox(mithril_scimitar,mithril_arrowheads,"You can now make @dbl@Mithril Scimitars@bla@ and members|can make @dbl@Mithril Arrow Heads.", 200);
     case 56 : ~objbox(mithril_longsword,"You can now make @dbl@Mithril Long Swords.", 250, 0, 0);
     case 57 : ~doubleobjbox(mithril_full_helm,mithril_knife,"You can now make @dbl@Mithril Full Helms@bla@ and members|can make @dbl@Mithril Throwing Knives.", 200);


### PR DESCRIPTION
225+

* Changed Aemad dialogue based on source
* Changed the Bakers in Ardougne back to French based on sources
* Changed Silk merchant dialogue based on source
* Added Mage Arena "climb up" ladder message based on 2004 source
* Changed locked gate message based on 2006 source
* Fixed typo in 54 smithing levelup screen

<img width="477" height="92" alt="image" src="https://github.com/user-attachments/assets/fd0d24f3-54c8-4677-8d87-a38bc2bf5ee6" />
<img width="469" height="89" alt="image" src="https://github.com/user-attachments/assets/9c202e56-fa74-4a43-80ff-3b129a2feade" />
<img width="488" height="141" alt="image" src="https://github.com/user-attachments/assets/8326e34a-3923-48d5-bfa8-b02f469688de" />
<img width="465" height="88" alt="image" src="https://github.com/user-attachments/assets/2d78ac75-699a-48f8-8686-e4a10f5f44c0" />
<img width="785" height="525" alt="image" src="https://github.com/user-attachments/assets/6b1f2027-5d8c-46c9-9c6a-555dde73d37e" />
<img width="1060" height="695" alt="image" src="https://github.com/user-attachments/assets/83bd475c-cdd8-494c-b40b-13db608a1cc5" />
