### PR TITLE
fix rock crab drop table, add edible seaweed

### DIFF
--- a/scripts/quests/quest_viking/scripts/horror_rockcrab.rs2
+++ b/scripts/quests/quest_viking/scripts/horror_rockcrab.rs2
@@ -26,7 +26,7 @@ else if ($random < 11) obj_add(npc_coord, iron_pickaxe, 1, ^lootdrop_duration);
 else if ($random < 15) obj_add(npc_coord, seaweed, 1, ^lootdrop_duration);
 else if ($random < 19) obj_add(npc_coord, seaweed, 2, ^lootdrop_duration);
 else if ($random < 21) obj_add(npc_coord, seaweed, 5, ^lootdrop_duration);
-else if ($random < 23) obj_add(npc_coord, seaweed, 2, ^lootdrop_duration);
+else if ($random < 23) obj_add(npc_coord, edible_seaweed, 2, ^lootdrop_duration);
 else if ($random < 35) obj_add(npc_coord, oystershell, 2, ^lootdrop_duration);
 else if ($random < 44) obj_add(npc_coord, oystershell, 1, ^lootdrop_duration);
 else if ($random < 47) obj_add(npc_coord, oysterempty, 1, ^lootdrop_duration);


### PR DESCRIPTION
the lost city rock crab drop table listed seaweed(2) twice, instead of seaweed(2) and edible seaweed (2)

source: https://web.archive.org/web/20041110235527/http://www.runehq.com/cache/viewMonster283.htm dated nov 10, 2004