### PR TITLE
fix: Apply ring of wealth nothing-removal to the mega rare table

### DIFF
--- a/scripts/drop tables/scripts/shared_droptables.rs2
+++ b/scripts/drop tables/scripts/shared_droptables.rs2
@@ -123,7 +123,14 @@ if ($random < 3) {
 
 // Name unconfirmed
 [proc,megararetable]()(namedobj, int)
-def_int $random = random(128);
+def_int $random = 0;
+
+if (inv_total(worn, ring_of_wealth) > 0 & map_members = ^true) {
+    $random = random(15);
+} else {
+    $random = random(128);
+}
+
 def_namedobj $drop = null;
 if ($random < 8) { $drop = rune_spear; }
 else if ($random < 12) { $drop = dragonshield_a; }


### PR DESCRIPTION
`~randomjewel` already strips the empty slots from the gem drop table — it compresses `random(128)` to `random(65)` when a ring of wealth is worn — but `~megararetable` still rolls the full 128 with 113 empty slots, so a ring wearer who reaches it gets nothing 88.3% of the time.

This compresses the roll to `random(15)`, the first boundary past the last populated branch, mirroring the gem table's existing 65 cutoff. With the ring equipped the `$drop = null` fall-through becomes unreachable and the table always yields.

```
[proc,megararetable]()(namedobj, int)
def_int $random = 0;

if (inv_total(worn, ring_of_wealth) > 0 & map_members = ^true) {
    $random = random(15);
} else {
    $random = random(128);
}
```

### Within the table

| drop | no ROW | with ROW |
|---|---|---|
| `rune_spear` | 8/128 (6.25%) | 8/15 (53.3%) |
| `dragonshield_a` | 4/128 (3.13%) | 4/15 (26.7%) |
| `dragon_spear` | 3/128 (2.34%) | 3/15 (20.0%) |
| nothing | 113/128 (88.3%) | — |

### Compounding with the gem table

The mega rare branch (`$random < 62`) still sits inside the ring's `random(65)` window, so on that path the ring now applies at both levels:

| path | no ROW | with ROW | factor |
|---|---|---|---|
| `~randomjewel` | 0.049% | 0.82% | ~16.8× |
| `~ultrarare_getitem` | 0.73% | 6.25% | ~8.5× |

Both factors match the documented behaviour:

> Wearing this ring completely removes the chance to receive "nothing" as a result of accessing the rare drop table and gem drop table. [...] The ring of wealth approximately doubles the chance of receiving a regular item from the gem drop table by removing the 63 empty slots out of the 128 entries in the drop table. It also removes all 113 empty slots out of the 128 entries in the mega rare drop table, increasing the chance of obtaining a mega-rare item by a factor of approximately 16.8 from the gem drop table, and by a factor of 8.5 from the rare drop table.

— [Ring of wealth § Rare drop enhancement](https://oldschool.runescape.wiki/w/Ring_of_wealth#Rare_drop_enhancement)

Further reference on the ring's interaction with the rare drop tables: https://twitter.com/JagexAsh/status/434304022632079361

### Notes for review

- The `map_members` check is redundant — every call site into `~megararetable` is already behind a members gate — but it is kept so the condition reads identically to the one in `~randomjewel`.
- **Not compile-verified.** The script has not been built or run against the engine; it has only been checked for consistency with the surrounding dialect. A compile and an in-game sanity check are worth doing before merge.
- The Mod Ash link is included as supporting reference only and its contents were not re-read while writing this description; the numbers above are derived from the code and cross-checked against the wiki text quoted.
