### PR TITLE
fix: add missing base parameter on combat skillguide dbrows

### DIFF
--- a/scripts/player/configs/skill_guide.dbrow
+++ b/scripts/player/configs/skill_guide.dbrow
@@ -6,6 +6,7 @@ data=op,Defence,skill_guide_combat_defence
 
 [skill_guide_combat_attack]
 table=skill_guides
+data=base,attack
 data=name,Combat - Attack
 data=advancement,Able to wield:
 data=inv,skill_guide_combat_weapons
@@ -21,6 +22,7 @@ data=unlock,60,Members: Dragon.
 
 [skill_guide_combat_defence]
 table=skill_guides
+data=base,defence
 data=name,Combat - Defence
 data=advancement,Able to wear:
 data=inv,skill_guide_combat_armours


### PR DESCRIPTION
274+
Fixes missing "base" parameter from skill_guide.dbrow
Reported by Art_Will on discord: https://discord.com/channels/953326730632904844/1538926163458531438