### PR TITLE
fix: skill icon positionings

### DIFF
--- a/scripts/player/interfaces/stats.if
+++ b/scripts/player/interfaces/stats.if
@@ -82,7 +82,7 @@ graphic=staticons,6
 [com_49]
 layer=com_0
 type=graphic
-x=128
+x=132
 y=5
 width=25
 height=25
@@ -255,7 +255,7 @@ graphic=staticons,7
 [com_52]
 layer=com_7
 type=graphic
-x=128
+x=132
 y=5
 width=25
 height=25
@@ -419,7 +419,7 @@ graphic=staticons,2
 [com_55]
 layer=com_14
 type=graphic
-x=128
+x=132
 y=5
 width=25
 height=25
@@ -592,7 +592,7 @@ graphic=staticons,9
 [com_58]
 layer=com_21
 type=graphic
-x=129
+x=132
 y=5
 width=25
 height=25
@@ -764,7 +764,7 @@ graphic=staticons,10
 [com_61]
 layer=com_28
 type=graphic
-x=129
+x=132
 y=5
 width=25
 height=25
@@ -936,7 +936,7 @@ graphic=staticons,11
 [com_64]
 layer=com_35
 type=graphic
-x=129
+x=132
 y=5
 width=25
 height=25
@@ -1111,7 +1111,7 @@ colour=0xFFFF00
 [com_54]
 type=graphic
 x=68
-y=73
+y=68
 width=25
 height=25
 graphic=staticons,8


### PR DESCRIPTION
apologies, I don't have discord, if you want to get in touch I'm Midwest_Emu on the forums :)

Fixes the positioning of the following skill icons within the skill interface:
- Herblore
- Mining
- Smithing
- Fishing
- Cooking
- Firemaking
- Woodcutting

Before:
<img width="189" height="219" alt="skills_before" src="https://github.com/user-attachments/assets/6dae5e86-ac4b-416d-91d8-e0046b399a3d" />


After:
<img width="188" height="220" alt="skills_after" src="https://github.com/user-attachments/assets/98ff0f39-83ec-466d-a999-d659bb78be6e" />

