### PR TITLE
fix: Quest completion journals

### DIFF
--- a/scripts/levelrequire/scripts/levelrequire.rs2
+++ b/scripts/levelrequire/scripts/levelrequire.rs2
@@ -156,7 +156,7 @@ return(true);
 [proc,levelrequire_zanaris_quest]()(boolean)
 if (%zanaris < ^zanaris_complete) {
     mes("You have not earned the right to wear this yet.");
-    mes("You need to complete the Lost City of Zanaris Quest."); // todo confirm for 2004
+    mes("You need to complete the Lost City Of Zanaris Quest."); // todo confirm for 2004
     return(false);
 }
 return(true);

--- a/scripts/quests/quest_arena/scripts/quest_arena.rs2
+++ b/scripts/quests/quest_arena/scripts/quest_arena.rs2
@@ -271,4 +271,4 @@ stat_advance(attack, 121750);
 stat_advance(thieving, 21750);
 session_log(^log_adventure, "Quest complete: Fight Arena");
 // todo: can't find an image of this so might need to confirm obj zoom + text breaking
-~send_quest_complete(questlist:arena, coins, 250, ^arena_questpoints, "You have completed the\\nFight Arena Quest!");
+~send_quest_complete(questlist:arena, coins, 260, ^arena_questpoints, "You have completed the\\nFight Arena Quest!");

--- a/scripts/quests/quest_blackarmgang/scripts/quest_blackarmgang.rs2
+++ b/scripts/quests/quest_blackarmgang/scripts/quest_blackarmgang.rs2
@@ -123,6 +123,6 @@ if(%phoenixgang = ^phoenixgang_joined) {
     %blackarmgang = ^blackarmgang_complete;
     session_log(^log_adventure, "Quest complete: Shield of Arrav (Black Arm Gang)");
 }
-~send_quest_complete(questlist:blackarmgang, coins, 250, ^blackarmgang_questpoints, "You have completed the\\nShield of Arrav Quest!");
+~send_quest_complete(questlist:blackarmgang, coins, 260, ^blackarmgang_questpoints, "You have completed the\\nShield of Arrav Quest!");
 inv_del(inv, arravcertificate, 1);
 inv_add(inv, coins, 600);

--- a/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
+++ b/scripts/quests/quest_blackknight/scripts/quest_blackknight.rs2
@@ -154,7 +154,7 @@ if (%spy = 1) {
 inv_add(inv, coins, 2500);
 mes("Sir Amik hands you 2500 coins.");
 session_log(^log_adventure, "Quest complete: Black Knight's Fortress");
-~send_quest_complete(questlist:fortress, coins, 250, ^blackknight_questpoints, "You have completed the\\nBlack Knights' Fortress Quest!");
+~send_quest_complete(questlist:fortress, coins, 260, ^blackknight_questpoints, "You have completed the\\nBlack Knights' Fortress Quest!");
 
 [proc,black_knights_aggro](coord $first_search_coord, coord $all_search_coord)
 if (npc_find($first_search_coord, aggressive_black_knight, 5, 0) = true) {

--- a/scripts/quests/quest_cog/scripts/quest_cog.rs2
+++ b/scripts/quests/quest_cog/scripts/quest_cog.rs2
@@ -4,7 +4,7 @@
 ~cog_update_main_quest_step(^quest_cog_complete);
 inv_add(inv, coins, 500);
 session_log(^log_adventure, "Quest complete: Clock Tower");
-~send_quest_complete(questlist:cog, coins_25, 250, ^cog_questpoints, "You have completed the\\nClock Tower Quest!");
+~send_quest_complete(questlist:cog, coins_25, 260, ^cog_questpoints, "You have completed the\\nClock Tower Quest!");
 
 [proc,cog_update_main_quest_step](int $step)()
 %cogquest = setbit_range_toint(%cogquest, $step, 0, 3);

--- a/scripts/quests/quest_dragon/scripts/quest_dragon.rs2
+++ b/scripts/quests/quest_dragon/scripts/quest_dragon.rs2
@@ -33,4 +33,4 @@ if (inzone(0_44_150_31_28, 0_44_150_47_46, coord) = true) { // only tele if in t
 stat_advance(strength, 186500);
 stat_advance(defence, 186500);
 session_log(^log_adventure, "Quest complete: Dragon Slayer");
-~send_quest_complete(questlist:dragon, rune_platebody, 250, ^dragon_questpoints, "You have completed the\\nDragon Slayer Quest!");
+~send_quest_complete(questlist:dragon, rune_platebody, 220, ^dragon_questpoints, "You have completed the\\nDragon Slayer Quest!");

--- a/scripts/quests/quest_hazeelcult/scripts/quest_hazeelcult.rs2
+++ b/scripts/quests/quest_hazeelcult/scripts/quest_hazeelcult.rs2
@@ -172,4 +172,4 @@ inv_del(inv, hazeel_scroll, 1);
 stat_advance(thieving, 15000);
 inv_add(inv, coins, 2000);
 session_log(^log_adventure, "Quest complete: Hazeel Cult");
-~send_quest_complete(questlist:hazeelcult, coins, 250, ^hazeelcult_questpoints, "You have completed the\\nHazeel Cult Quest!");
+~send_quest_complete(questlist:hazeelcult, coins, 260, ^hazeelcult_questpoints, "You have completed the\\nHazeel Cult Quest!");

--- a/scripts/quests/quest_hero/scripts/quest_hero.rs2
+++ b/scripts/quests/quest_hero/scripts/quest_hero.rs2
@@ -39,4 +39,4 @@ stat_advance(smithing, 22750);
 stat_advance(mining, 25750);
 stat_advance(herblore, 13250);
 session_log(^log_adventure, "Quest complete: Hero's Quest");
-~send_quest_complete(questlist:hero, dragon_battleaxe, 250, ^hero_questpoints, "You have completed the Hero's Quest!");
+~send_quest_complete(questlist:hero, dragon_battleaxe, 180, ^hero_questpoints, "You have completed the Hero's Quest!");

--- a/scripts/quests/quest_hero/scripts/quest_hero.rs2
+++ b/scripts/quests/quest_hero/scripts/quest_hero.rs2
@@ -39,4 +39,4 @@ stat_advance(smithing, 22750);
 stat_advance(mining, 25750);
 stat_advance(herblore, 13250);
 session_log(^log_adventure, "Quest complete: Hero's Quest");
-~send_quest_complete(questlist:hero, dragon_battleaxe, 180, ^hero_questpoints, "You have completed the Hero's Quest!");
+~send_quest_complete(questlist:hero, dragon_battleaxe, 180, ^hero_questpoints, "You have completed the Heroes Quest!"); // https://i.imgur.com/H4bp0SQ.png (august 2004)

--- a/scripts/quests/quest_legends/scripts/quest_legends.rs2
+++ b/scripts/quests/quest_legends/scripts/quest_legends.rs2
@@ -2099,4 +2099,4 @@ session_log(^log_adventure, "Quest complete: Legends Quest");
 %legendsquest = ^legends_complete;
 // todo: older ref image?
 // https://storage.googleapis.com/tannerdino/images/legendscomplt.png
-~send_quest_complete(questlist:legends, thtotempolegift, 250, ^legends_questpoints, "You have completed the\\nLegends Guild Quest!");
+~send_quest_complete(questlist:legends, thtotempolegift, 200, ^legends_questpoints, "You have completed the\\nLegends Guild Quest!");

--- a/scripts/quests/quest_mm/scripts/quest_mm.rs2
+++ b/scripts/quests/quest_mm/scripts/quest_mm.rs2
@@ -1168,7 +1168,7 @@ if_openoverlay(null);
 %mm_main = ^mm_complete;
 session_log(^log_adventure, "Quest complete: Monkey Madness");
 queue(mm_complete_dialogue, 0, 0);
-~send_quest_complete(questlist:mm, mm_monkey_in_backpack, 250, ^mm_questpoints, "You have completed the\\nMonkey Madness Quest!");
+~send_quest_complete(questlist:mm, mm_monkey_in_backpack, 250, ^mm_questpoints, "You have completed the\\n'Monkey Madness' Quest!");
 
 [proc,fade_out]
 if_setanim(castlewars_shopside:com_0, null);

--- a/scripts/quests/quest_murder/scripts/quest_murder.rs2
+++ b/scripts/quests/quest_murder/scripts/quest_murder.rs2
@@ -428,4 +428,4 @@ inv_del(bank, murderfingerprint1, ^max_32bit_int);
 stat_advance(crafting, 14060);
 inv_add(inv, coins, 2000);
 session_log(^log_adventure, "Quest complete: Murder Mystery");
-~send_quest_complete(questlist:murder, coins, 250, ^murder_questpoints, "You have completed the\\nMurder Mystery Quest!");
+~send_quest_complete(questlist:murder, coins, 260, ^murder_questpoints, "You have completed the\\nMurder Mystery Quest!");

--- a/scripts/quests/quest_prince/scripts/prince_journal.rs2
+++ b/scripts/quests/quest_prince/scripts/prince_journal.rs2
@@ -94,4 +94,4 @@ if(%princequest = ^prince_not_started) {
     $text = append($text, "@red@QUEST COMPLETE!");
 }
 
-~quest_journal("The Rescue of Prince Ali", $text);
+~quest_journal("The Rescue Of Prince Ali", $text); // https://i.imgur.com/VOYbjB6.png

--- a/scripts/quests/quest_prince/scripts/quest_prince.rs2
+++ b/scripts/quests/quest_prince/scripts/quest_prince.rs2
@@ -54,5 +54,5 @@ if(coordz(coord) > coordz(loc_coord)) {
 [queue,prince_complete]
 %princequest = ^prince_complete;
 session_log(^log_adventure, "Quest complete: Prince Ali Rescue");
-~send_quest_complete(questlist:prince, coins, 250, ^prince_questpoints, "You have completed the\\nPrince Ali Rescue Quest!");
+~send_quest_complete(questlist:prince, coins, 260, ^prince_questpoints, "You have completed the\\nPrince Ali Rescue Quest!");
 inv_add(inv, coins, 700);

--- a/scripts/quests/quest_sheep/scripts/quest_sheep.rs2
+++ b/scripts/quests/quest_sheep/scripts/quest_sheep.rs2
@@ -4,4 +4,4 @@ inv_del(inv, ball_of_wool, 1);
 inv_add(inv, coins, 60);
 stat_advance(crafting, 1500);
 session_log(^log_adventure, "Quest complete: Sheep Shearer");
-~send_quest_complete(questlist:sheep, coins, 250, ^sheep_questpoints, "You have completed the\\nSheep Shearer Quest!");
+~send_quest_complete(questlist:sheep, coins, 260, ^sheep_questpoints, "You have completed the\\nSheep Shearer Quest!");

--- a/scripts/quests/quest_sheepherder/scripts/quest_sheepherder.rs2
+++ b/scripts/quests/quest_sheepherder/scripts/quest_sheepherder.rs2
@@ -6,4 +6,4 @@
 %sheepherderquest = ^sheepherder_complete;
 inv_add(inv, coins, 3100);
 session_log(^log_adventure, "Quest complete: Sheep Herder");
-~send_quest_complete(questlist:sheepherder, coins_100, 200, ^sheepherder_questpoints, "You have completed the Sheep Herder Quest!");
+~send_quest_complete(questlist:sheepherder, coins_25, 260, ^sheepherder_questpoints, "You have completed the Sheep Herder Quest!");

--- a/scripts/quests/quest_squire/scripts/quest_squire.rs2
+++ b/scripts/quests/quest_squire/scripts/quest_squire.rs2
@@ -219,7 +219,7 @@ return(true);
 [queue,squire_complete]
 %squire = ^squire_complete;
 session_log(^log_adventure, "Quest complete: The Knight's Sword");
-~send_quest_complete(questlist:squire, faladian_sword, 250, ^squire_questpoints, "You have completed the Knight's Sword Quest!");
+~send_quest_complete(questlist:squire, faladian_sword, 260, ^squire_questpoints, "You have completed the Knight's Sword Quest!");
 stat_advance(smithing, 127250);
 
 [label,thurgo_squire_complete]

--- a/scripts/quests/quest_viking/scripts/quest_viking.rs2
+++ b/scripts/quests/quest_viking/scripts/quest_viking.rs2
@@ -145,7 +145,7 @@ stat_advance(thieving, 28124);
 %viking = ^viking_complete;
 session_log(^log_adventure, "Quest complete: The Fremennik Trials");
 queue(fremennik_name, 0, 0);
-~send_quest_complete(questlist:viking, viking_helmet, 150, ^viking_questpoints, "You have completed the\\nTrials of the Fremmenik Quest!");
+~send_quest_complete(questlist:viking, viking_helmet, 150, ^viking_questpoints, "You have completed the\\nTrials Of The Fremennik Quest!");
 
 [queue,fremennik_name]
 ~generate_viking_name;

--- a/scripts/quests/quest_zanaris/scripts/quest_zanaris.rs2
+++ b/scripts/quests/quest_zanaris/scripts/quest_zanaris.rs2
@@ -103,4 +103,4 @@ if($entering = false) {
 [queue,zanaris_quest_complete]
 %zanaris = ^zanaris_complete;
 session_log(^log_adventure, "Quest complete: Lost City");
-~send_quest_complete(questlist:zanaris, coins, 250, ^zanaris_questpoints, "You have completed the\\nLost City of Zanaris Quest!");
+~send_quest_complete(questlist:zanaris, coins, 260, ^zanaris_questpoints, "You have completed the\\nLost City Of Zanaris Quest!");


### PR DESCRIPTION
225+
* Changed completion journal objbox size of: Fight Arena, Shield Of Arrav, Clock Tower, Black Knights Fortress, Dragon Slayer, Hazeel Cult, Hero's Quest, Legends Quest, Murder Mystery, Prince Ali Rescue, Sheap Shearer, Sheep Herder, Knights Sword & Lost City
* Changed completion journal text of: Lost City & Hero's Quest
* Small change in Prince Ali Rescue journal based on source

274+
* Changed completion journal text of: Trials Of The Fremennik Quest

289+
* Changed completion journal text of: Monkey Madness

All sources used are documented here:
https://github.com/04Carsten/QuestCompletions