### PR TITLE
fix: Runecraft levelups (254+)

### DIFF
--- a/scripts/levelup/scripts/levelup_unlocks_runecrafting.rs2
+++ b/scripts/levelup/scripts/levelup_unlocks_runecrafting.rs2
@@ -5,6 +5,7 @@ switch_int(stat_base(runecraft)) {
     case 5 : ~objbox(waterrune,"You can now craft @dbl@Water Runes.", 250, 0, 0);
     case 9 : ~objbox(earthrune,"You can now craft @dbl@Earth Runes.", 250, 0, 0);
     // case 11 : ~objbox(airrune,"You can now receive 2 @dbl@Air Runes@bla@.", 250, 0, 0);
+    // case 13 : ~objbox(mudrune,"Members can now craft @dbl@Mud Runes.", 250, 0, 0); // https://i.imgur.com/CBgQATk.png (after pure ess)
     case 14 : ~objbox(firerune,"You can now craft @dbl@Fire Runes.", 250, 0, 0);
     // case 19 : ~objbox(waterrune,"You can now receive 2 @dbl@Water Runes@bla@.", 250, 0, 0);
     case 20 : ~objbox(bodyrune,"You can now craft @dbl@Body Runes.", 250, 0, 0);
@@ -13,33 +14,36 @@ switch_int(stat_base(runecraft)) {
     case 27 : ~objbox(cosmicrune,"Members can now craft @dbl@Cosmic Runes.", 250, 0, 0);
     // case 28 : ~objbox(mindrune,"You can now receive 3 @dbl@Mind Runes@bla@.", 250, 0, 0);
     // case 33 : ~objbox(airrune,"You can now receive 4 @dbl@Air Runes@bla@.", 250, 0, 0);
-    case 35 : ~objbox(chaosrune,"Members can now craft @dbl@Chaos Runes.", 250, 0, 0); 
+    case 35 : ~objbox(chaosrune,"Members can now craft @dbl@Chaos Runes.", 250, 0, 0); // https://i.imgur.com/ZebP7RG.png
     // case 38 : ~objbox(waterrune,"You can now receive 3 @dbl@Water Runes@bla@.", 250, 0, 0);
     // case 42 : ~objbox(mindrune,"You can now receive 4 @dbl@Mind Runes@bla@.", 250, 0, 0);
-    case 44 : ~objbox(naturerune,"Members can now craft @dbl@Nature Runes.", 250, 0, 0); // imgur.com/bz6j0wl (Changed to Members by at least jan05)
+    case 44 : ~objbox(naturerune,"Members can now craft @dbl@Nature Runes.", 250, 0, 0); // https://i.imgur.com/RpbOz9j.png (april 2nd 2004) / https://i.imgur.com/e0187NG.png (september 2004) Likely changed to members with Law Altar
     // case 46 : ~objbox(bodyrune,"You can now receive 2 @dbl@Body Runes@bla@.", 250, 0, 0);
     // case 52 : ~objbox(earthrune,"You can now receive 3 @dbl@Earth Runes@bla@.", 250, 0, 0);
     // https://oldschool.runescape.wiki/w/Law_Altar
     // 08/24/2004
-    case 54 : ~objbox(lawrune,"Members can now craft @dbl@Law Runes@bla@.", 250, 0, 0); // https://i.imgur.com/It2qwnY.png (jan 05)
+    case 54 : ~objbox(lawrune,"Members can now craft @dbl@Law Runes@bla@.", 250, 0, 0); // https://i.imgur.com/XeXDXB6.png (october 2004) Likely changed to members with Law Altar
     // case 55 : ~objbox(airrune,"You can now receive 4 @dbl@Air Runes@bla@.", 250, 0, 0);
     // case 56 : ~objbox(mindrune,"You can now receive 5 @dbl@Mind Runes@bla@.", 250, 0, 0);
     // case 57 : ~objbox(waterrune,"You can now receive 4 @dbl@Water Runes@bla@.", 250, 0, 0);
-    // case 59 : ~objbox(cosmicrune,"You can now receive 2 @dbl@Cosmic Runes@bla@.", 250, 0, 0);
+    // case 59 : ~objbox(cosmicrune,"Members can now receive 2 @dbl@Cosmic Runes@bla@.", 250, 0, 0); // https://i.imgur.com/9LbSVlN.png (after pure ess)
     // https://oldschool.runescape.wiki/w/Death_Altar
     // 10/17/2005
-    // case 65 : ~objbox(deathrune,"You can now craft @dbl@Death Runes@bla@.", 250, 0, 0);
+    // case 65 : ~objbox(deathrune,"Members can now craft @dbl@Death Runes.", 250, 0, 0); // https://i.imgur.com/JpAkzun.png (after pure ess)
     // case 66 : ~objbox(airrune,"You can now receive 7 @dbl@Air Runes@bla@.", 250, 0, 0);
     // case 70 : ~doubleobjbox(mindrune,firerune,"You can now receive 6 @dbl@Mind Runes@bla@|and you can now receive 3 @dbl@Fire Runes@bla@.");
-    // case 74 : ~objbox(chaosrune,"You can now receive 2 @dbl@Chaos Runes@bla@.", 250, 0, 0);
+    // case 74 : ~objbox(chaosrune,"Members can now receive 2 @dbl@Chaos Runes@bla@.", 250, 0, 0); // https://i.imgur.com/fd1utjc.png (after pure ess)
     // case 76 : ~objbox(waterrune,"You can now receive 5 @dbl@Water Runes@bla@.", 250, 0, 0);
+    // case 77 : ~objbox(bloodrune,"Members can now craft @dbl@Blood Runes.", 250, 0 ,0); https://i.imgur.com/AlIK0HI.png / https://i.imgur.com/VLDpViC.png (after pure ess)
     // case 77 : ~objbox(airrune,"You can now receive 8 @dbl@Air Runes@bla@.", 250, 0, 0);
     // case 78 : ~objbox(earthrune,"You can now receive 4 @dbl@Earth Runes@bla@.", 250, 0, 0);
     // case 84 : ~objbox(mindrune,"You can now receive 7 @dbl@Mind Runes@bla@.", 250, 0, 0);
     // case 88 : ~objbox(airrune,"You can now receive 9 @dbl@Air Runes@bla@.", 250, 0, 0);
-    // case 91 : ~objbox(naturerune,"You can now receive 2 @dbl@Nature Runes@bla@.", 250, 0, 0);
+    // https://i.imgur.com/LVWemoU.png (november 2005 N0valyfe blog) / https://i.imgur.com/Bw0aABK.png / https://i.imgur.com/PAyrJrX.png
+    // case 90 : ~objbox(soulrune,"Members can now craft @dbl@Soul Runes.", 250, 0, 0);
+    // case 91 : ~objbox(naturerune,"Members can now receive 2 @dbl@Nature Runes@bla@.", 250, 0, 0);
     // case 92 : ~objbox(bodyrune,"You can now receive 3 @dbl@Body Runes@bla@.", 250, 0, 0);
-    // case 95 : ~doubleobjbox(waterrune,lawrune,"You can now receive 6 @dbl@Water Runes@bla@|and you can now receive 2 @dbl@Law Runes@bla@.");
+    // case 95 : ~doubleobjbox(waterrune,lawrune,"You can now receive 6 @dbl@Water Runes@bla@|and members can now receive 2 @dbl@Law Runes@bla@.");
     // case 98 : ~objbox(mindrune,"You can now receive 8 @dbl@Mind Runes@bla@.", 250, 0, 0);
     // case 99 : ~objbox(airrune,"You can now receive 10 @dbl@Air Runes@bla@.", 250, 0, 0);
 }


### PR DESCRIPTION
254+

* Changed members runes messages based on september/october 2004 sources
* Added additional sources and corrected future levelup messages in code

<img width="1022" height="739" alt="image" src="https://github.com/user-attachments/assets/0429a9b6-40fe-4094-8949-b049d9648064" />
<img width="775" height="587" alt="image" src="https://github.com/user-attachments/assets/fe20a58e-9968-4ca3-8f0f-e62dbe8f29c9" />
<img width="646" height="496" alt="image" src="https://github.com/user-attachments/assets/bea94e9a-2813-49b7-a36e-4adc888c804f" />
<img width="1020" height="487" alt="image" src="https://github.com/user-attachments/assets/12982e38-2033-4bad-903b-bdc62caebbe6" />
<img width="502" height="239" alt="image" src="https://github.com/user-attachments/assets/7e677a21-584a-4bf5-89ac-3df853fb0442" />
<img width="785" height="569" alt="image" src="https://github.com/user-attachments/assets/ddda02ad-89b7-4e09-ac14-3c1754a596af" />
<img width="618" height="403" alt="image" src="https://github.com/user-attachments/assets/ce045915-2714-4b35-93e4-0a856c5ba73e" />
<img width="1033" height="675" alt="image" src="https://github.com/user-attachments/assets/d1c85320-1bb2-4d23-ba63-3155c3cf120d" />



