### PR TITLE
fix: chestlocked script, remove chocolate dust being used for chocolate cakes

### DIFF
--- a/scripts/general_use/scripts/chests.rs2
+++ b/scripts/general_use/scripts/chests.rs2
@@ -75,3 +75,12 @@ sound_synth(chest_close, 1, 0);
 p_delay(0);
 // Temp note: dur does not need updated
 loc_change($other_chest, 300);
+
+// https://youtu.be/TlsGPU8-BDo?si=Zxzd_cgUI76xplMp&t=337 (none of these seem to be placed in osrs anymore)
+[oploc1,chestlocked]
+mes("The chest is locked.");
+sound_synth(locked, 1, 0);
+
+[oploc1,chestlockedgold]
+mes("The chest is locked.");
+sound_synth(locked, 1, 0);

--- a/scripts/quests/quest_itexam/scripts/area_digsite.rs2
+++ b/scripts/quests/quest_itexam/scripts/area_digsite.rs2
@@ -775,6 +775,7 @@ p_teleport(0_52_152_40_39);
 
 [oploc1,digchestclosed]
 mes("The chest is locked.");
+sound_synth(locked, 1, 0);
 
 [oplocu,digchestclosed]
 if (last_useitem = digchestkey) {

--- a/scripts/skill_cooking/scripts/cooking_inv/scripts/cakes/cakes.rs2
+++ b/scripts/skill_cooking/scripts/cooking_inv/scripts/cakes/cakes.rs2
@@ -42,7 +42,6 @@ switch_int(oc_param(last_useitem, gnome_cooking_type)) {
     case ^gnome_bowl, ^gnome_batta, ^gnome_crunchies : @finish_gnome_food(last_useitem, last_item);
 }
 switch_obj (last_useitem) {
-    case cake : @make_chocolate_cake(last_slot);
     case bucket_milk : @make_chocolate_milk(last_slot);
     case harralandervial : ~attempt_brew_potion(last_useslot, last_slot);
     case default : ~displaymessage(^dm_default);
@@ -54,9 +53,10 @@ switch_obj (last_useitem) {
     case default : ~attempt_brew_potion(last_useslot, last_slot);
 }
 
+// using chocolate dust to make cakes seem to be added with this update (18 Apr 2005): https://oldschool.runescape.wiki/w/Update:Desert_Treasure
 [opheldu,cake]
 switch_obj (last_useitem) {
-    case chocolate_bar, chocolate_dust : @make_chocolate_cake(last_useslot);
+    case chocolate_bar : @make_chocolate_cake(last_useslot);
     case default : ~displaymessage(^dm_default);
 }
 


### PR DESCRIPTION
for 225+
- added missing scripts for `chestlocked` and `chestlockedgold`
- removed the ability to use chocolate dust to make chocolate cakes (matching RSC), looks to have been added with https://oldschool.runescape.wiki/w/Update:Desert_Treasure instead