### PR TITLE
fix: open correct defence skill guide page

### DIFF
--- a/scripts/player/scripts/skill_guide.rs2
+++ b/scripts/player/scripts/skill_guide.rs2
@@ -1,7 +1,7 @@
 [if_button,stats:attack] @skill_guide(attack, 0);
 [if_button,stats:hitpoints] @skill_guide(attack, 0);
 [if_button,stats:strength] @skill_guide(attack, 0);
-[if_button,stats:defence] @skill_guide(attack, 0);
+[if_button,stats:defence] @skill_guide(attack, 1);
 [if_button,stats:mining] @skill_guide(mining, 0);
 [if_button,stats:agility] @skill_guide(agility, 0);
 [if_button,stats:smithing] @skill_guide(smithing, 0);


### PR DESCRIPTION
based on the work and conversations below:
- https://github.com/LostCityRS/Content/pull/737
- https://github.com/LostCityRS/Engine-TS/issues/122
- https://discord.com/channels/953326730632904844/1545434790625284208

previously in #737 skill_guide.dbrow was updated to add a base parameter for the defence skill guide, but the following line needed to be changed to put it to use:

`[if_button,stats:defence] @skill_guide(attack, 0);`

to 

`[if_button,stats:defence] @skill_guide(attack, 1);`

where 1 is the 2nd page in the combat skill guide (defence)

```
[skill_guide_combat]
table=skill_guide_ops
data=lookup,attack
data=op,Attack,skill_guide_combat_attack
data=op,Defence,skill_guide_combat_defence
```

after this change the defence skill guide now correctly shows (where it was previously showing the attack skill guide shown in screenshots in the discussions linked above), and the engine can now properly apply black and red text based on what's unlocked individually by the attack and defence skills:

<img width="761" height="501" alt="image" src="https://github.com/user-attachments/assets/f7a4b834-8577-4af1-a984-f67ae0e91e11" />